### PR TITLE
Move node dataset resolver subquery ids into a separate namespace

### DIFF
--- a/.changes/unreleased/Under the Hood-20240613-171930.yaml
+++ b/.changes/unreleased/Under the Hood-20240613-171930.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Refine subquery ID generation. This may result in changing subquery ids for rendered SQL.
+time: 2024-06-13T17:19:30.939376-07:00
+custom:
+    Author: tlento
+    Issue: "1280"

--- a/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
+++ b/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
@@ -99,6 +99,7 @@ class StaticIdPrefix(IdPrefix, Enum, metaclass=EnumMetaClassHelper):
 
     TIME_SPINE_SOURCE = "time_spine_src"
     SUB_QUERY = "subq"
+    NODE_RESOLVER_SUB_QUERY = "nr_subq"
 
     @property
     @override

--- a/metricflow/dataflow/builder/node_data_set.py
+++ b/metricflow/dataflow/builder/node_data_set.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Dict, Optional, Sequence
 
+from metricflow_semantics.dag.id_prefix import StaticIdPrefix
+from metricflow_semantics.dag.sequential_id import SequentialIdGenerator
 from metricflow_semantics.mf_logging.runtime import log_block_runtime
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
+from typing_extensions import override
 
 from metricflow.dataflow.dataflow_plan import (
     DataflowPlanNode,
@@ -93,3 +96,11 @@ class DataflowPlanNodeOutputDataSetResolver(DataflowToSqlQueryPlanConverter):
             semantic_manifest_lookup=self._semantic_manifest_lookup,
             _node_to_output_data_set=dict(self._node_to_output_data_set),
         )
+
+    @override
+    def _next_unique_table_alias(self) -> str:
+        """Return the next unique table alias to use in generating queries.
+
+        This uses a separate prefix in order to minimize subquery ID thrash.
+        """
+        return SequentialIdGenerator.create_next_id(StaticIdPrefix.NODE_RESOLVER_SUB_QUERY).str_value

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0.sql
@@ -1,116 +1,116 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS FLOAT64) / CAST(NULLIF(subq_21.visits, 0) AS FLOAT64) AS visit_buy_conversion_rate
+  subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS FLOAT64) / CAST(NULLIF(subq_17.visits, 0) AS FLOAT64) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id']
         SELECT
-          subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -145,166 +145,166 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
       visit__referrer_id
-  ) subq_9
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id']
       SELECT
-        subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of INF
         SELECT
-          subq_17.ds__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -339,96 +339,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , GENERATE_UUID() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -461,23 +461,23 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
-              (subq_13.ds__day <= subq_16.ds__day)
+              (subq_9.ds__day <= subq_12.ds__day)
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
       visit__referrer_id
-  ) subq_20
+  ) subq_16
   ON
-    subq_9.visit__referrer_id = subq_20.visit__referrer_id
+    subq_5.visit__referrer_id = subq_16.visit__referrer_id
   GROUP BY
     visit__referrer_id
-) subq_21
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_35.ds__day <= subq_38.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
-    subq_31.visit__referrer_id = subq_42.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
     visit__referrer_id
-) subq_43
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -1,121 +1,121 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS FLOAT64) / CAST(NULLIF(subq_21.visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
+  subq_17.metric_time__day
+  , subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS FLOAT64) / CAST(NULLIF(subq_17.visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day) AS metric_time__day
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.metric_time__day
-        , subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.metric_time__day
+        , subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.metric_time__day
+          , subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -150,179 +150,179 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_9
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        subq_18.metric_time__day
-        , subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.metric_time__day
+        , subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of 7 day
         SELECT
-          subq_17.ds__day
-          , subq_17.metric_time__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.metric_time__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_9.metric_time__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'metric_time__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.metric_time__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.metric_time__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -357,96 +357,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , GENERATE_UUID() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -479,33 +479,33 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
               (
-                subq_13.ds__day <= subq_16.ds__day
+                subq_9.ds__day <= subq_12.ds__day
               ) AND (
-                subq_13.ds__day > DATE_SUB(CAST(subq_16.ds__day AS DATETIME), INTERVAL 7 day)
+                subq_9.ds__day > DATE_SUB(CAST(subq_12.ds__day AS DATETIME), INTERVAL 7 day)
               )
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_20
+  ) subq_16
   ON
     (
-      subq_9.visit__referrer_id = subq_20.visit__referrer_id
+      subq_5.visit__referrer_id = subq_16.visit__referrer_id
     ) AND (
-      subq_9.metric_time__day = subq_20.metric_time__day
+      subq_5.metric_time__day = subq_16.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_21
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_35.ds__day <= subq_38.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_35.ds__day > DATE_SUB(CAST(subq_38.ds__day AS DATETIME), INTERVAL 7 day)
+            subq_27.ds__day > DATE_SUB(CAST(subq_30.ds__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
     (
-      subq_31.visit__referrer_id = subq_42.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_31.metric_time__day = subq_42.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_43
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0.sql
@@ -1,116 +1,116 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
+  subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id']
         SELECT
-          subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -145,166 +145,166 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id']
       SELECT
-        subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of INF
         SELECT
-          subq_17.ds__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -339,96 +339,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , UUID() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -461,23 +461,23 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
-              (subq_13.ds__day <= subq_16.ds__day)
+              (subq_9.ds__day <= subq_12.ds__day)
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.visit__referrer_id
+  ) subq_16
   ON
-    subq_9.visit__referrer_id = subq_20.visit__referrer_id
+    subq_5.visit__referrer_id = subq_16.visit__referrer_id
   GROUP BY
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_35.ds__day <= subq_38.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
-    subq_31.visit__referrer_id = subq_42.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -1,121 +1,121 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+  subq_17.metric_time__day
+  , subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day) AS metric_time__day
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.metric_time__day
-        , subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.metric_time__day
+        , subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.metric_time__day
+          , subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -150,179 +150,179 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        subq_18.metric_time__day
-        , subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.metric_time__day
+        , subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of 7 day
         SELECT
-          subq_17.ds__day
-          , subq_17.metric_time__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.metric_time__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_9.metric_time__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'metric_time__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.metric_time__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.metric_time__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -357,96 +357,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , UUID() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -479,33 +479,33 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
               (
-                subq_13.ds__day <= subq_16.ds__day
+                subq_9.ds__day <= subq_12.ds__day
               ) AND (
-                subq_13.ds__day > DATEADD(day, -7, subq_16.ds__day)
+                subq_9.ds__day > DATEADD(day, -7, subq_12.ds__day)
               )
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+  ) subq_16
   ON
     (
-      subq_9.visit__referrer_id = subq_20.visit__referrer_id
+      subq_5.visit__referrer_id = subq_16.visit__referrer_id
     ) AND (
-      subq_9.metric_time__day = subq_20.metric_time__day
+      subq_5.metric_time__day = subq_16.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day)
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day)
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_35.ds__day <= subq_38.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_35.ds__day > DATEADD(day, -7, subq_38.ds__day)
+            subq_27.ds__day > DATEADD(day, -7, subq_30.ds__day)
           )
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
     (
-      subq_31.visit__referrer_id = subq_42.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_31.metric_time__day = subq_42.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0.sql
@@ -1,116 +1,116 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
+  subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id']
         SELECT
-          subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -145,166 +145,166 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id']
       SELECT
-        subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of INF
         SELECT
-          subq_17.ds__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -339,96 +339,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , GEN_RANDOM_UUID() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -461,23 +461,23 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
-              (subq_13.ds__day <= subq_16.ds__day)
+              (subq_9.ds__day <= subq_12.ds__day)
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.visit__referrer_id
+  ) subq_16
   ON
-    subq_9.visit__referrer_id = subq_20.visit__referrer_id
+    subq_5.visit__referrer_id = subq_16.visit__referrer_id
   GROUP BY
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_35.ds__day <= subq_38.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
-    subq_31.visit__referrer_id = subq_42.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -1,121 +1,121 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+  subq_17.metric_time__day
+  , subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day) AS metric_time__day
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.metric_time__day
-        , subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.metric_time__day
+        , subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.metric_time__day
+          , subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -150,179 +150,179 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        subq_18.metric_time__day
-        , subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.metric_time__day
+        , subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of 7 day
         SELECT
-          subq_17.ds__day
-          , subq_17.metric_time__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.metric_time__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_9.metric_time__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'metric_time__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.metric_time__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.metric_time__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -357,96 +357,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , GEN_RANDOM_UUID() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -479,33 +479,33 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
               (
-                subq_13.ds__day <= subq_16.ds__day
+                subq_9.ds__day <= subq_12.ds__day
               ) AND (
-                subq_13.ds__day > subq_16.ds__day - INTERVAL 7 day
+                subq_9.ds__day > subq_12.ds__day - INTERVAL 7 day
               )
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+  ) subq_16
   ON
     (
-      subq_9.visit__referrer_id = subq_20.visit__referrer_id
+      subq_5.visit__referrer_id = subq_16.visit__referrer_id
     ) AND (
-      subq_9.metric_time__day = subq_20.metric_time__day
+      subq_5.metric_time__day = subq_16.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day)
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day)
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_35.ds__day <= subq_38.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_35.ds__day > subq_38.ds__day - INTERVAL 7 day
+            subq_27.ds__day > subq_30.ds__day - INTERVAL 7 day
           )
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
     (
-      subq_31.visit__referrer_id = subq_42.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_31.metric_time__day = subq_42.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0.sql
@@ -1,116 +1,116 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
+  subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id']
         SELECT
-          subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -145,166 +145,166 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id']
       SELECT
-        subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of INF
         SELECT
-          subq_17.ds__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -339,96 +339,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , GEN_RANDOM_UUID() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -461,23 +461,23 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
-              (subq_13.ds__day <= subq_16.ds__day)
+              (subq_9.ds__day <= subq_12.ds__day)
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.visit__referrer_id
+  ) subq_16
   ON
-    subq_9.visit__referrer_id = subq_20.visit__referrer_id
+    subq_5.visit__referrer_id = subq_16.visit__referrer_id
   GROUP BY
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_35.ds__day <= subq_38.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
-    subq_31.visit__referrer_id = subq_42.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -1,121 +1,121 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+  subq_17.metric_time__day
+  , subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day) AS metric_time__day
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.metric_time__day
-        , subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.metric_time__day
+        , subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.metric_time__day
+          , subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -150,179 +150,179 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        subq_18.metric_time__day
-        , subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.metric_time__day
+        , subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of 7 day
         SELECT
-          subq_17.ds__day
-          , subq_17.metric_time__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.metric_time__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_9.metric_time__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'metric_time__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.metric_time__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.metric_time__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -357,96 +357,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , GEN_RANDOM_UUID() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -479,33 +479,33 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
               (
-                subq_13.ds__day <= subq_16.ds__day
+                subq_9.ds__day <= subq_12.ds__day
               ) AND (
-                subq_13.ds__day > subq_16.ds__day - MAKE_INTERVAL(days => 7)
+                subq_9.ds__day > subq_12.ds__day - MAKE_INTERVAL(days => 7)
               )
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+  ) subq_16
   ON
     (
-      subq_9.visit__referrer_id = subq_20.visit__referrer_id
+      subq_5.visit__referrer_id = subq_16.visit__referrer_id
     ) AND (
-      subq_9.metric_time__day = subq_20.metric_time__day
+      subq_5.metric_time__day = subq_16.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day)
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day)
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_35.ds__day <= subq_38.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_35.ds__day > subq_38.ds__day - MAKE_INTERVAL(days => 7)
+            subq_27.ds__day > subq_30.ds__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
     (
-      subq_31.visit__referrer_id = subq_42.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_31.metric_time__day = subq_42.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0.sql
@@ -1,116 +1,116 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
+  subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id']
         SELECT
-          subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -145,166 +145,166 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id']
       SELECT
-        subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of INF
         SELECT
-          subq_17.ds__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -339,96 +339,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -461,23 +461,23 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
-              (subq_13.ds__day <= subq_16.ds__day)
+              (subq_9.ds__day <= subq_12.ds__day)
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.visit__referrer_id
+  ) subq_16
   ON
-    subq_9.visit__referrer_id = subq_20.visit__referrer_id
+    subq_5.visit__referrer_id = subq_16.visit__referrer_id
   GROUP BY
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_35.ds__day <= subq_38.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
-    subq_31.visit__referrer_id = subq_42.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -1,121 +1,121 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+  subq_17.metric_time__day
+  , subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day) AS metric_time__day
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.metric_time__day
-        , subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.metric_time__day
+        , subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.metric_time__day
+          , subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -150,179 +150,179 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        subq_18.metric_time__day
-        , subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.metric_time__day
+        , subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of 7 day
         SELECT
-          subq_17.ds__day
-          , subq_17.metric_time__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.metric_time__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_9.metric_time__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'metric_time__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.metric_time__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.metric_time__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -357,96 +357,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -479,33 +479,33 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
               (
-                subq_13.ds__day <= subq_16.ds__day
+                subq_9.ds__day <= subq_12.ds__day
               ) AND (
-                subq_13.ds__day > DATEADD(day, -7, subq_16.ds__day)
+                subq_9.ds__day > DATEADD(day, -7, subq_12.ds__day)
               )
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+  ) subq_16
   ON
     (
-      subq_9.visit__referrer_id = subq_20.visit__referrer_id
+      subq_5.visit__referrer_id = subq_16.visit__referrer_id
     ) AND (
-      subq_9.metric_time__day = subq_20.metric_time__day
+      subq_5.metric_time__day = subq_16.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day)
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day)
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_35.ds__day <= subq_38.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_35.ds__day > DATEADD(day, -7, subq_38.ds__day)
+            subq_27.ds__day > DATEADD(day, -7, subq_30.ds__day)
           )
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
     (
-      subq_31.visit__referrer_id = subq_42.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_31.metric_time__day = subq_42.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0.sql
@@ -1,116 +1,116 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
+  subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id']
         SELECT
-          subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -145,166 +145,166 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id']
       SELECT
-        subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of INF
         SELECT
-          subq_17.ds__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -339,96 +339,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , UUID_STRING() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -461,23 +461,23 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
-              (subq_13.ds__day <= subq_16.ds__day)
+              (subq_9.ds__day <= subq_12.ds__day)
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.visit__referrer_id
+  ) subq_16
   ON
-    subq_9.visit__referrer_id = subq_20.visit__referrer_id
+    subq_5.visit__referrer_id = subq_16.visit__referrer_id
   GROUP BY
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_35.ds__day <= subq_38.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
-    subq_31.visit__referrer_id = subq_42.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -1,121 +1,121 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+  subq_17.metric_time__day
+  , subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day) AS metric_time__day
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.metric_time__day
-        , subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.metric_time__day
+        , subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.metric_time__day
+          , subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -150,179 +150,179 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        subq_18.metric_time__day
-        , subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.metric_time__day
+        , subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of 7 day
         SELECT
-          subq_17.ds__day
-          , subq_17.metric_time__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.metric_time__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_9.metric_time__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'metric_time__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.metric_time__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.metric_time__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -357,96 +357,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , UUID_STRING() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -479,33 +479,33 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
               (
-                subq_13.ds__day <= subq_16.ds__day
+                subq_9.ds__day <= subq_12.ds__day
               ) AND (
-                subq_13.ds__day > DATEADD(day, -7, subq_16.ds__day)
+                subq_9.ds__day > DATEADD(day, -7, subq_12.ds__day)
               )
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+  ) subq_16
   ON
     (
-      subq_9.visit__referrer_id = subq_20.visit__referrer_id
+      subq_5.visit__referrer_id = subq_16.visit__referrer_id
     ) AND (
-      subq_9.metric_time__day = subq_20.metric_time__day
+      subq_5.metric_time__day = subq_16.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day)
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day)
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_35.ds__day <= subq_38.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_35.ds__day > DATEADD(day, -7, subq_38.ds__day)
+            subq_27.ds__day > DATEADD(day, -7, subq_30.ds__day)
           )
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
     (
-      subq_31.visit__referrer_id = subq_42.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_31.metric_time__day = subq_42.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0.sql
@@ -1,116 +1,116 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
+  subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id']
         SELECT
-          subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -145,166 +145,166 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id']
       SELECT
-        subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of INF
         SELECT
-          subq_17.ds__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -339,96 +339,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , uuid() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -461,23 +461,23 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
-              (subq_13.ds__day <= subq_16.ds__day)
+              (subq_9.ds__day <= subq_12.ds__day)
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.visit__referrer_id
+  ) subq_16
   ON
-    subq_9.visit__referrer_id = subq_20.visit__referrer_id
+    subq_5.visit__referrer_id = subq_16.visit__referrer_id
   GROUP BY
-    COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_35.ds__day <= subq_38.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
-    subq_31.visit__referrer_id = subq_42.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -1,121 +1,121 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.visit__referrer_id
-  , CAST(subq_21.buys AS DOUBLE) / CAST(NULLIF(subq_21.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+  subq_17.metric_time__day
+  , subq_17.visit__referrer_id
+  , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_9.visits) AS visits
-    , MAX(subq_20.buys) AS buys
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day) AS metric_time__day
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_5.visits) AS visits
+    , MAX(subq_16.buys) AS buys
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-      , SUM(subq_8.visits) AS visits
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+      , SUM(subq_4.visits) AS visits
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.metric_time__day
-        , subq_7.visit__referrer_id
-        , subq_7.visits
+        subq_3.metric_time__day
+        , subq_3.visit__referrer_id
+        , subq_3.visits
       FROM (
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.visit__referrer_id
-          , subq_6.visits
+          subq_2.metric_time__day
+          , subq_2.visit__referrer_id
+          , subq_2.visits
         FROM (
           -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
           SELECT
-            subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.visit__ds__day
-            , subq_5.visit__ds__week
-            , subq_5.visit__ds__month
-            , subq_5.visit__ds__quarter
-            , subq_5.visit__ds__year
-            , subq_5.visit__ds__extract_year
-            , subq_5.visit__ds__extract_quarter
-            , subq_5.visit__ds__extract_month
-            , subq_5.visit__ds__extract_day
-            , subq_5.visit__ds__extract_dow
-            , subq_5.visit__ds__extract_doy
-            , subq_5.metric_time__day
-            , subq_5.metric_time__week
-            , subq_5.metric_time__month
-            , subq_5.metric_time__quarter
-            , subq_5.metric_time__year
-            , subq_5.metric_time__extract_year
-            , subq_5.metric_time__extract_quarter
-            , subq_5.metric_time__extract_month
-            , subq_5.metric_time__extract_day
-            , subq_5.metric_time__extract_dow
-            , subq_5.metric_time__extract_doy
-            , subq_5.user
-            , subq_5.session
-            , subq_5.visit__user
-            , subq_5.visit__session
-            , subq_5.referrer_id
-            , subq_5.visit__referrer_id
-            , subq_5.visits
-            , subq_5.visitors
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.visit__ds__day
+            , subq_1.visit__ds__week
+            , subq_1.visit__ds__month
+            , subq_1.visit__ds__quarter
+            , subq_1.visit__ds__year
+            , subq_1.visit__ds__extract_year
+            , subq_1.visit__ds__extract_quarter
+            , subq_1.visit__ds__extract_month
+            , subq_1.visit__ds__extract_day
+            , subq_1.visit__ds__extract_dow
+            , subq_1.visit__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.session
+            , subq_1.visit__user
+            , subq_1.visit__session
+            , subq_1.referrer_id
+            , subq_1.visit__referrer_id
+            , subq_1.visits
+            , subq_1.visitors
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_4.ds__day
-              , subq_4.ds__week
-              , subq_4.ds__month
-              , subq_4.ds__quarter
-              , subq_4.ds__year
-              , subq_4.ds__extract_year
-              , subq_4.ds__extract_quarter
-              , subq_4.ds__extract_month
-              , subq_4.ds__extract_day
-              , subq_4.ds__extract_dow
-              , subq_4.ds__extract_doy
-              , subq_4.visit__ds__day
-              , subq_4.visit__ds__week
-              , subq_4.visit__ds__month
-              , subq_4.visit__ds__quarter
-              , subq_4.visit__ds__year
-              , subq_4.visit__ds__extract_year
-              , subq_4.visit__ds__extract_quarter
-              , subq_4.visit__ds__extract_month
-              , subq_4.visit__ds__extract_day
-              , subq_4.visit__ds__extract_dow
-              , subq_4.visit__ds__extract_doy
-              , subq_4.ds__day AS metric_time__day
-              , subq_4.ds__week AS metric_time__week
-              , subq_4.ds__month AS metric_time__month
-              , subq_4.ds__quarter AS metric_time__quarter
-              , subq_4.ds__year AS metric_time__year
-              , subq_4.ds__extract_year AS metric_time__extract_year
-              , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_4.ds__extract_month AS metric_time__extract_month
-              , subq_4.ds__extract_day AS metric_time__extract_day
-              , subq_4.ds__extract_dow AS metric_time__extract_dow
-              , subq_4.ds__extract_doy AS metric_time__extract_doy
-              , subq_4.user
-              , subq_4.session
-              , subq_4.visit__user
-              , subq_4.visit__session
-              , subq_4.referrer_id
-              , subq_4.visit__referrer_id
-              , subq_4.visits
-              , subq_4.visitors
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.visit__ds__day
+              , subq_0.visit__ds__week
+              , subq_0.visit__ds__month
+              , subq_0.visit__ds__quarter
+              , subq_0.visit__ds__year
+              , subq_0.visit__ds__extract_year
+              , subq_0.visit__ds__extract_quarter
+              , subq_0.visit__ds__extract_month
+              , subq_0.visit__ds__extract_day
+              , subq_0.visit__ds__extract_dow
+              , subq_0.visit__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.session
+              , subq_0.visit__user
+              , subq_0.visit__session
+              , subq_0.referrer_id
+              , subq_0.visit__referrer_id
+              , subq_0.visits
+              , subq_0.visitors
             FROM (
               -- Read Elements From Semantic Model 'visits_source'
               SELECT
@@ -150,179 +150,179 @@ FROM (
                 , visits_source_src_28000.user_id AS visit__user
                 , visits_source_src_28000.session_id AS visit__session
               FROM ***************************.fct_visits visits_source_src_28000
-            ) subq_4
-          ) subq_5
-          WHERE subq_5.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-        ) subq_6
-      ) subq_7
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+        ) subq_2
+      ) subq_3
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_8
+    ) subq_4
     GROUP BY
-      subq_8.metric_time__day
-      , subq_8.visit__referrer_id
-  ) subq_9
+      subq_4.metric_time__day
+      , subq_4.visit__referrer_id
+  ) subq_5
   FULL OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-      , SUM(subq_19.buys) AS buys
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+      , SUM(subq_15.buys) AS buys
     FROM (
       -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        subq_18.metric_time__day
-        , subq_18.visit__referrer_id
-        , subq_18.buys
+        subq_14.metric_time__day
+        , subq_14.visit__referrer_id
+        , subq_14.buys
       FROM (
         -- Find conversions for user within the range of 7 day
         SELECT
-          subq_17.ds__day
-          , subq_17.metric_time__day
-          , subq_17.user
-          , subq_17.visit__referrer_id
-          , subq_17.buys
-          , subq_17.visits
+          subq_13.ds__day
+          , subq_13.metric_time__day
+          , subq_13.user
+          , subq_13.visit__referrer_id
+          , subq_13.buys
+          , subq_13.visits
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            FIRST_VALUE(subq_13.visits) OVER (
+            FIRST_VALUE(subq_9.visits) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_9.visit__referrer_id) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , FIRST_VALUE(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_9.ds__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , FIRST_VALUE(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_9.metric_time__day) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , FIRST_VALUE(subq_13.user) OVER (
+            , FIRST_VALUE(subq_9.user) OVER (
               PARTITION BY
-                subq_16.user
-                , subq_16.ds__day
-                , subq_16.mf_internal_uuid
-              ORDER BY subq_13.ds__day DESC
+                subq_12.user
+                , subq_12.ds__day
+                , subq_12.mf_internal_uuid
+              ORDER BY subq_9.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , subq_16.mf_internal_uuid AS mf_internal_uuid
-            , subq_16.buys AS buys
+            , subq_12.mf_internal_uuid AS mf_internal_uuid
+            , subq_12.buys AS buys
           FROM (
             -- Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'metric_time__day', 'user']
             SELECT
-              subq_12.ds__day
-              , subq_12.metric_time__day
-              , subq_12.user
-              , subq_12.visit__referrer_id
-              , subq_12.visits
+              subq_8.ds__day
+              , subq_8.metric_time__day
+              , subq_8.user
+              , subq_8.visit__referrer_id
+              , subq_8.visits
             FROM (
               -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.visit__ds__day
-                , subq_11.visit__ds__week
-                , subq_11.visit__ds__month
-                , subq_11.visit__ds__quarter
-                , subq_11.visit__ds__year
-                , subq_11.visit__ds__extract_year
-                , subq_11.visit__ds__extract_quarter
-                , subq_11.visit__ds__extract_month
-                , subq_11.visit__ds__extract_day
-                , subq_11.visit__ds__extract_dow
-                , subq_11.visit__ds__extract_doy
-                , subq_11.metric_time__day
-                , subq_11.metric_time__week
-                , subq_11.metric_time__month
-                , subq_11.metric_time__quarter
-                , subq_11.metric_time__year
-                , subq_11.metric_time__extract_year
-                , subq_11.metric_time__extract_quarter
-                , subq_11.metric_time__extract_month
-                , subq_11.metric_time__extract_day
-                , subq_11.metric_time__extract_dow
-                , subq_11.metric_time__extract_doy
-                , subq_11.user
-                , subq_11.session
-                , subq_11.visit__user
-                , subq_11.visit__session
-                , subq_11.referrer_id
-                , subq_11.visit__referrer_id
-                , subq_11.visits
-                , subq_11.visitors
+                subq_7.ds__day
+                , subq_7.ds__week
+                , subq_7.ds__month
+                , subq_7.ds__quarter
+                , subq_7.ds__year
+                , subq_7.ds__extract_year
+                , subq_7.ds__extract_quarter
+                , subq_7.ds__extract_month
+                , subq_7.ds__extract_day
+                , subq_7.ds__extract_dow
+                , subq_7.ds__extract_doy
+                , subq_7.visit__ds__day
+                , subq_7.visit__ds__week
+                , subq_7.visit__ds__month
+                , subq_7.visit__ds__quarter
+                , subq_7.visit__ds__year
+                , subq_7.visit__ds__extract_year
+                , subq_7.visit__ds__extract_quarter
+                , subq_7.visit__ds__extract_month
+                , subq_7.visit__ds__extract_day
+                , subq_7.visit__ds__extract_dow
+                , subq_7.visit__ds__extract_doy
+                , subq_7.metric_time__day
+                , subq_7.metric_time__week
+                , subq_7.metric_time__month
+                , subq_7.metric_time__quarter
+                , subq_7.metric_time__year
+                , subq_7.metric_time__extract_year
+                , subq_7.metric_time__extract_quarter
+                , subq_7.metric_time__extract_month
+                , subq_7.metric_time__extract_day
+                , subq_7.metric_time__extract_dow
+                , subq_7.metric_time__extract_doy
+                , subq_7.user
+                , subq_7.session
+                , subq_7.visit__user
+                , subq_7.visit__session
+                , subq_7.referrer_id
+                , subq_7.visit__referrer_id
+                , subq_7.visits
+                , subq_7.visitors
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_10.ds__day
-                  , subq_10.ds__week
-                  , subq_10.ds__month
-                  , subq_10.ds__quarter
-                  , subq_10.ds__year
-                  , subq_10.ds__extract_year
-                  , subq_10.ds__extract_quarter
-                  , subq_10.ds__extract_month
-                  , subq_10.ds__extract_day
-                  , subq_10.ds__extract_dow
-                  , subq_10.ds__extract_doy
-                  , subq_10.visit__ds__day
-                  , subq_10.visit__ds__week
-                  , subq_10.visit__ds__month
-                  , subq_10.visit__ds__quarter
-                  , subq_10.visit__ds__year
-                  , subq_10.visit__ds__extract_year
-                  , subq_10.visit__ds__extract_quarter
-                  , subq_10.visit__ds__extract_month
-                  , subq_10.visit__ds__extract_day
-                  , subq_10.visit__ds__extract_dow
-                  , subq_10.visit__ds__extract_doy
-                  , subq_10.ds__day AS metric_time__day
-                  , subq_10.ds__week AS metric_time__week
-                  , subq_10.ds__month AS metric_time__month
-                  , subq_10.ds__quarter AS metric_time__quarter
-                  , subq_10.ds__year AS metric_time__year
-                  , subq_10.ds__extract_year AS metric_time__extract_year
-                  , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_10.ds__extract_month AS metric_time__extract_month
-                  , subq_10.ds__extract_day AS metric_time__extract_day
-                  , subq_10.ds__extract_dow AS metric_time__extract_dow
-                  , subq_10.ds__extract_doy AS metric_time__extract_doy
-                  , subq_10.user
-                  , subq_10.session
-                  , subq_10.visit__user
-                  , subq_10.visit__session
-                  , subq_10.referrer_id
-                  , subq_10.visit__referrer_id
-                  , subq_10.visits
-                  , subq_10.visitors
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.visit__ds__day
+                  , subq_6.visit__ds__week
+                  , subq_6.visit__ds__month
+                  , subq_6.visit__ds__quarter
+                  , subq_6.visit__ds__year
+                  , subq_6.visit__ds__extract_year
+                  , subq_6.visit__ds__extract_quarter
+                  , subq_6.visit__ds__extract_month
+                  , subq_6.visit__ds__extract_day
+                  , subq_6.visit__ds__extract_dow
+                  , subq_6.visit__ds__extract_doy
+                  , subq_6.ds__day AS metric_time__day
+                  , subq_6.ds__week AS metric_time__week
+                  , subq_6.ds__month AS metric_time__month
+                  , subq_6.ds__quarter AS metric_time__quarter
+                  , subq_6.ds__year AS metric_time__year
+                  , subq_6.ds__extract_year AS metric_time__extract_year
+                  , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_6.ds__extract_month AS metric_time__extract_month
+                  , subq_6.ds__extract_day AS metric_time__extract_day
+                  , subq_6.ds__extract_dow AS metric_time__extract_dow
+                  , subq_6.ds__extract_doy AS metric_time__extract_doy
+                  , subq_6.user
+                  , subq_6.session
+                  , subq_6.visit__user
+                  , subq_6.visit__session
+                  , subq_6.referrer_id
+                  , subq_6.visit__referrer_id
+                  , subq_6.visits
+                  , subq_6.visitors
                 FROM (
                   -- Read Elements From Semantic Model 'visits_source'
                   SELECT
@@ -357,96 +357,96 @@ FROM (
                     , visits_source_src_28000.user_id AS visit__user
                     , visits_source_src_28000.session_id AS visit__session
                   FROM ***************************.fct_visits visits_source_src_28000
-                ) subq_10
-              ) subq_11
-              WHERE subq_11.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-            ) subq_12
-          ) subq_13
+                ) subq_6
+              ) subq_7
+              WHERE subq_7.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+            ) subq_8
+          ) subq_9
           INNER JOIN (
             -- Add column with generated UUID
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.buy__ds__day
-              , subq_15.buy__ds__week
-              , subq_15.buy__ds__month
-              , subq_15.buy__ds__quarter
-              , subq_15.buy__ds__year
-              , subq_15.buy__ds__extract_year
-              , subq_15.buy__ds__extract_quarter
-              , subq_15.buy__ds__extract_month
-              , subq_15.buy__ds__extract_day
-              , subq_15.buy__ds__extract_dow
-              , subq_15.buy__ds__extract_doy
-              , subq_15.metric_time__day
-              , subq_15.metric_time__week
-              , subq_15.metric_time__month
-              , subq_15.metric_time__quarter
-              , subq_15.metric_time__year
-              , subq_15.metric_time__extract_year
-              , subq_15.metric_time__extract_quarter
-              , subq_15.metric_time__extract_month
-              , subq_15.metric_time__extract_day
-              , subq_15.metric_time__extract_dow
-              , subq_15.metric_time__extract_doy
-              , subq_15.user
-              , subq_15.session_id
-              , subq_15.buy__user
-              , subq_15.buy__session_id
-              , subq_15.buys
-              , subq_15.buyers
+              subq_11.ds__day
+              , subq_11.ds__week
+              , subq_11.ds__month
+              , subq_11.ds__quarter
+              , subq_11.ds__year
+              , subq_11.ds__extract_year
+              , subq_11.ds__extract_quarter
+              , subq_11.ds__extract_month
+              , subq_11.ds__extract_day
+              , subq_11.ds__extract_dow
+              , subq_11.ds__extract_doy
+              , subq_11.buy__ds__day
+              , subq_11.buy__ds__week
+              , subq_11.buy__ds__month
+              , subq_11.buy__ds__quarter
+              , subq_11.buy__ds__year
+              , subq_11.buy__ds__extract_year
+              , subq_11.buy__ds__extract_quarter
+              , subq_11.buy__ds__extract_month
+              , subq_11.buy__ds__extract_day
+              , subq_11.buy__ds__extract_dow
+              , subq_11.buy__ds__extract_doy
+              , subq_11.metric_time__day
+              , subq_11.metric_time__week
+              , subq_11.metric_time__month
+              , subq_11.metric_time__quarter
+              , subq_11.metric_time__year
+              , subq_11.metric_time__extract_year
+              , subq_11.metric_time__extract_quarter
+              , subq_11.metric_time__extract_month
+              , subq_11.metric_time__extract_day
+              , subq_11.metric_time__extract_dow
+              , subq_11.metric_time__extract_doy
+              , subq_11.user
+              , subq_11.session_id
+              , subq_11.buy__user
+              , subq_11.buy__session_id
+              , subq_11.buys
+              , subq_11.buyers
               , uuid() AS mf_internal_uuid
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_14.ds__day
-                , subq_14.ds__week
-                , subq_14.ds__month
-                , subq_14.ds__quarter
-                , subq_14.ds__year
-                , subq_14.ds__extract_year
-                , subq_14.ds__extract_quarter
-                , subq_14.ds__extract_month
-                , subq_14.ds__extract_day
-                , subq_14.ds__extract_dow
-                , subq_14.ds__extract_doy
-                , subq_14.buy__ds__day
-                , subq_14.buy__ds__week
-                , subq_14.buy__ds__month
-                , subq_14.buy__ds__quarter
-                , subq_14.buy__ds__year
-                , subq_14.buy__ds__extract_year
-                , subq_14.buy__ds__extract_quarter
-                , subq_14.buy__ds__extract_month
-                , subq_14.buy__ds__extract_day
-                , subq_14.buy__ds__extract_dow
-                , subq_14.buy__ds__extract_doy
-                , subq_14.ds__day AS metric_time__day
-                , subq_14.ds__week AS metric_time__week
-                , subq_14.ds__month AS metric_time__month
-                , subq_14.ds__quarter AS metric_time__quarter
-                , subq_14.ds__year AS metric_time__year
-                , subq_14.ds__extract_year AS metric_time__extract_year
-                , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_14.ds__extract_month AS metric_time__extract_month
-                , subq_14.ds__extract_day AS metric_time__extract_day
-                , subq_14.ds__extract_dow AS metric_time__extract_dow
-                , subq_14.ds__extract_doy AS metric_time__extract_doy
-                , subq_14.user
-                , subq_14.session_id
-                , subq_14.buy__user
-                , subq_14.buy__session_id
-                , subq_14.buys
-                , subq_14.buyers
+                subq_10.ds__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.buy__ds__day
+                , subq_10.buy__ds__week
+                , subq_10.buy__ds__month
+                , subq_10.buy__ds__quarter
+                , subq_10.buy__ds__year
+                , subq_10.buy__ds__extract_year
+                , subq_10.buy__ds__extract_quarter
+                , subq_10.buy__ds__extract_month
+                , subq_10.buy__ds__extract_day
+                , subq_10.buy__ds__extract_dow
+                , subq_10.buy__ds__extract_doy
+                , subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.ds__extract_year AS metric_time__extract_year
+                , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_10.ds__extract_month AS metric_time__extract_month
+                , subq_10.ds__extract_day AS metric_time__extract_day
+                , subq_10.ds__extract_dow AS metric_time__extract_dow
+                , subq_10.ds__extract_doy AS metric_time__extract_doy
+                , subq_10.user
+                , subq_10.session_id
+                , subq_10.buy__user
+                , subq_10.buy__session_id
+                , subq_10.buys
+                , subq_10.buyers
               FROM (
                 -- Read Elements From Semantic Model 'buys_source'
                 SELECT
@@ -479,33 +479,33 @@ FROM (
                   , buys_source_src_28000.user_id AS buy__user
                   , buys_source_src_28000.session_id AS buy__session_id
                 FROM ***************************.fct_buys buys_source_src_28000
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_10
+            ) subq_11
+          ) subq_12
           ON
             (
-              subq_13.user = subq_16.user
+              subq_9.user = subq_12.user
             ) AND (
               (
-                subq_13.ds__day <= subq_16.ds__day
+                subq_9.ds__day <= subq_12.ds__day
               ) AND (
-                subq_13.ds__day > DATE_ADD('day', -7, subq_16.ds__day)
+                subq_9.ds__day > DATE_ADD('day', -7, subq_12.ds__day)
               )
             )
-        ) subq_17
-      ) subq_18
-    ) subq_19
+        ) subq_13
+      ) subq_14
+    ) subq_15
     GROUP BY
-      subq_19.metric_time__day
-      , subq_19.visit__referrer_id
-  ) subq_20
+      subq_15.metric_time__day
+      , subq_15.visit__referrer_id
+  ) subq_16
   ON
     (
-      subq_9.visit__referrer_id = subq_20.visit__referrer_id
+      subq_5.visit__referrer_id = subq_16.visit__referrer_id
     ) AND (
-      subq_9.metric_time__day = subq_20.metric_time__day
+      subq_5.metric_time__day = subq_16.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_20.metric_time__day)
-    , COALESCE(subq_9.visit__referrer_id, subq_20.visit__referrer_id)
-) subq_21
+    COALESCE(subq_5.metric_time__day, subq_16.metric_time__day)
+    , COALESCE(subq_5.visit__referrer_id, subq_16.visit__referrer_id)
+) subq_17

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_31.visits) AS visits
-    , MAX(subq_42.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-    ) subq_29
+    ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_35.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_35.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_35.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_35.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_38.user
-            , subq_38.ds__day
-            , subq_38.mf_internal_uuid
-          ORDER BY subq_35.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_38.mf_internal_uuid AS mf_internal_uuid
-        , subq_38.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) subq_35
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_38
+      ) subq_30
       ON
         (
-          subq_35.user = subq_38.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_35.ds__day <= subq_38.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_35.ds__day > DATE_ADD('day', -7, subq_38.ds__day)
+            subq_27.ds__day > DATE_ADD('day', -7, subq_30.ds__day)
           )
         )
-    ) subq_39
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_42
+  ) subq_34
   ON
     (
-      subq_31.visit__referrer_id = subq_42.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_31.metric_time__day = subq_42.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
-    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
-) subq_43
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_month__plan0.sql
@@ -1,103 +1,103 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
-  , subq_10.bookings_monthly AS trailing_3_months_bookings
+  subq_8.metric_time__month
+  , subq_8.bookings_monthly AS trailing_3_months_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
-    , SUM(subq_9.bookings_monthly) AS bookings_monthly
+    subq_7.metric_time__month
+    , SUM(subq_7.bookings_monthly) AS bookings_monthly
   FROM (
     -- Constrain Time Range to [2020-03-05T00:00:00, 2021-01-04T00:00:00]
     SELECT
-      subq_8.metric_time__month
-      , subq_8.bookings_monthly
+      subq_6.metric_time__month
+      , subq_6.bookings_monthly
     FROM (
       -- Pass Only Elements: ['bookings_monthly', 'metric_time__month']
       SELECT
-        subq_7.metric_time__month
-        , subq_7.bookings_monthly
+        subq_5.metric_time__month
+        , subq_5.bookings_monthly
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
-          , subq_4.monthly_ds__month AS monthly_ds__month
-          , subq_4.monthly_ds__quarter AS monthly_ds__quarter
-          , subq_4.monthly_ds__year AS monthly_ds__year
-          , subq_4.monthly_ds__extract_year AS monthly_ds__extract_year
-          , subq_4.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
-          , subq_4.monthly_ds__extract_month AS monthly_ds__extract_month
-          , subq_4.booking__monthly_ds__month AS booking__monthly_ds__month
-          , subq_4.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
-          , subq_4.booking__monthly_ds__year AS booking__monthly_ds__year
-          , subq_4.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
-          , subq_4.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
-          , subq_4.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.listing AS listing
-          , subq_4.booking__listing AS booking__listing
-          , subq_4.bookings_monthly AS bookings_monthly
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.monthly_ds__month AS monthly_ds__month
+          , subq_2.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_2.monthly_ds__year AS monthly_ds__year
+          , subq_2.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_2.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_2.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_2.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_2.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_2.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_2.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_2.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_2.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.listing AS listing
+          , subq_2.booking__listing AS booking__listing
+          , subq_2.bookings_monthly AS bookings_monthly
         FROM (
           -- Time Spine
           SELECT
-            DATETIME_TRUNC(subq_6.ds, month) AS metric_time__month
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-03-05' AND '2021-01-04'
+            DATETIME_TRUNC(subq_4.ds, month) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-03-05' AND '2021-01-04'
           GROUP BY
             metric_time__month
-        ) subq_5
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-12-05T00:00:00, 2021-01-04T00:00:00]
           SELECT
-            subq_3.monthly_ds__month
-            , subq_3.monthly_ds__quarter
-            , subq_3.monthly_ds__year
-            , subq_3.monthly_ds__extract_year
-            , subq_3.monthly_ds__extract_quarter
-            , subq_3.monthly_ds__extract_month
-            , subq_3.booking__monthly_ds__month
-            , subq_3.booking__monthly_ds__quarter
-            , subq_3.booking__monthly_ds__year
-            , subq_3.booking__monthly_ds__extract_year
-            , subq_3.booking__monthly_ds__extract_quarter
-            , subq_3.booking__monthly_ds__extract_month
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.listing
-            , subq_3.booking__listing
-            , subq_3.bookings_monthly
+            subq_1.monthly_ds__month
+            , subq_1.monthly_ds__quarter
+            , subq_1.monthly_ds__year
+            , subq_1.monthly_ds__extract_year
+            , subq_1.monthly_ds__extract_quarter
+            , subq_1.monthly_ds__extract_month
+            , subq_1.booking__monthly_ds__month
+            , subq_1.booking__monthly_ds__quarter
+            , subq_1.booking__monthly_ds__year
+            , subq_1.booking__monthly_ds__extract_year
+            , subq_1.booking__monthly_ds__extract_quarter
+            , subq_1.booking__monthly_ds__extract_month
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.listing
+            , subq_1.booking__listing
+            , subq_1.bookings_monthly
           FROM (
             -- Metric Time Dimension 'monthly_ds'
             SELECT
-              subq_2.monthly_ds__month
-              , subq_2.monthly_ds__quarter
-              , subq_2.monthly_ds__year
-              , subq_2.monthly_ds__extract_year
-              , subq_2.monthly_ds__extract_quarter
-              , subq_2.monthly_ds__extract_month
-              , subq_2.booking__monthly_ds__month
-              , subq_2.booking__monthly_ds__quarter
-              , subq_2.booking__monthly_ds__year
-              , subq_2.booking__monthly_ds__extract_year
-              , subq_2.booking__monthly_ds__extract_quarter
-              , subq_2.booking__monthly_ds__extract_month
-              , subq_2.monthly_ds__month AS metric_time__month
-              , subq_2.monthly_ds__quarter AS metric_time__quarter
-              , subq_2.monthly_ds__year AS metric_time__year
-              , subq_2.monthly_ds__extract_year AS metric_time__extract_year
-              , subq_2.monthly_ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.monthly_ds__extract_month AS metric_time__extract_month
-              , subq_2.listing
-              , subq_2.booking__listing
-              , subq_2.bookings_monthly
+              subq_0.monthly_ds__month
+              , subq_0.monthly_ds__quarter
+              , subq_0.monthly_ds__year
+              , subq_0.monthly_ds__extract_year
+              , subq_0.monthly_ds__extract_quarter
+              , subq_0.monthly_ds__extract_month
+              , subq_0.booking__monthly_ds__month
+              , subq_0.booking__monthly_ds__quarter
+              , subq_0.booking__monthly_ds__year
+              , subq_0.booking__monthly_ds__extract_year
+              , subq_0.booking__monthly_ds__extract_quarter
+              , subq_0.booking__monthly_ds__extract_month
+              , subq_0.monthly_ds__month AS metric_time__month
+              , subq_0.monthly_ds__quarter AS metric_time__quarter
+              , subq_0.monthly_ds__year AS metric_time__year
+              , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+              , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+              , subq_0.listing
+              , subq_0.booking__listing
+              , subq_0.bookings_monthly
             FROM (
               -- Read Elements From Semantic Model 'bookings_monthly_source'
               SELECT
@@ -117,20 +117,20 @@ FROM (
                 , bookings_monthly_source_src_16000.listing_id AS listing
                 , bookings_monthly_source_src_16000.listing_id AS booking__listing
               FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__month <= subq_5.metric_time__month
+            subq_2.metric_time__month <= subq_3.metric_time__month
           ) AND (
-            subq_4.metric_time__month > DATE_SUB(CAST(subq_5.metric_time__month AS DATETIME), INTERVAL 3 month)
+            subq_2.metric_time__month > DATE_SUB(CAST(subq_3.metric_time__month AS DATETIME), INTERVAL 3 month)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+  ) subq_7
   GROUP BY
     metric_time__month
-) subq_10
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__month AS metric_time__month
-  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATETIME_TRUNC(ds, month) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     metric_time__month
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATETIME_TRUNC(ds, month) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__month <= subq_16.metric_time__month
+    subq_11.metric_time__month <= subq_12.metric_time__month
   ) AND (
-    subq_15.metric_time__month > DATE_SUB(CAST(subq_16.metric_time__month AS DATETIME), INTERVAL 3 month)
+    subq_11.metric_time__month > DATE_SUB(CAST(subq_12.metric_time__month AS DATETIME), INTERVAL 3 month)
   )
-WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_12.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
   metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS revenue_all_time
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,16 +170,16 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
         ON
-          (subq_4.metric_time__day <= subq_5.metric_time__day)
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+          (subq_2.metric_time__day <= subq_3.metric_time__day)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
     metric_time__day
-) subq_10
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS revenue_all_time
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATETIME_TRUNC(created_at, day) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
-  (subq_15.metric_time__day <= subq_16.metric_time__day)
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_11.metric_time__day <= subq_12.metric_time__day)
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-11-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,20 +170,20 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__day <= subq_5.metric_time__day
+            subq_2.metric_time__day <= subq_3.metric_time__day
           ) AND (
-            subq_4.metric_time__day > DATE_SUB(CAST(subq_5.metric_time__day AS DATETIME), INTERVAL 2 month)
+            subq_2.metric_time__day > DATE_SUB(CAST(subq_3.metric_time__day AS DATETIME), INTERVAL 2 month)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
     metric_time__day
-) subq_10
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATETIME_TRUNC(created_at, day) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__day <= subq_16.metric_time__day
+    subq_11.metric_time__day <= subq_12.metric_time__day
   ) AND (
-    subq_15.metric_time__day > DATE_SUB(CAST(subq_16.metric_time__day AS DATETIME), INTERVAL 2 month)
+    subq_11.metric_time__day > DATE_SUB(CAST(subq_12.metric_time__day AS DATETIME), INTERVAL 2 month)
   )
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_month__plan0.sql
@@ -1,103 +1,103 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
-  , subq_10.bookings_monthly AS trailing_3_months_bookings
+  subq_8.metric_time__month
+  , subq_8.bookings_monthly AS trailing_3_months_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
-    , SUM(subq_9.bookings_monthly) AS bookings_monthly
+    subq_7.metric_time__month
+    , SUM(subq_7.bookings_monthly) AS bookings_monthly
   FROM (
     -- Constrain Time Range to [2020-03-05T00:00:00, 2021-01-04T00:00:00]
     SELECT
-      subq_8.metric_time__month
-      , subq_8.bookings_monthly
+      subq_6.metric_time__month
+      , subq_6.bookings_monthly
     FROM (
       -- Pass Only Elements: ['bookings_monthly', 'metric_time__month']
       SELECT
-        subq_7.metric_time__month
-        , subq_7.bookings_monthly
+        subq_5.metric_time__month
+        , subq_5.bookings_monthly
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
-          , subq_4.monthly_ds__month AS monthly_ds__month
-          , subq_4.monthly_ds__quarter AS monthly_ds__quarter
-          , subq_4.monthly_ds__year AS monthly_ds__year
-          , subq_4.monthly_ds__extract_year AS monthly_ds__extract_year
-          , subq_4.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
-          , subq_4.monthly_ds__extract_month AS monthly_ds__extract_month
-          , subq_4.booking__monthly_ds__month AS booking__monthly_ds__month
-          , subq_4.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
-          , subq_4.booking__monthly_ds__year AS booking__monthly_ds__year
-          , subq_4.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
-          , subq_4.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
-          , subq_4.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.listing AS listing
-          , subq_4.booking__listing AS booking__listing
-          , subq_4.bookings_monthly AS bookings_monthly
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.monthly_ds__month AS monthly_ds__month
+          , subq_2.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_2.monthly_ds__year AS monthly_ds__year
+          , subq_2.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_2.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_2.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_2.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_2.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_2.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_2.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_2.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_2.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.listing AS listing
+          , subq_2.booking__listing AS booking__listing
+          , subq_2.bookings_monthly AS bookings_monthly
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-03-05' AND '2021-01-04'
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-03-05' AND '2021-01-04'
           GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
-        ) subq_5
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-12-05T00:00:00, 2021-01-04T00:00:00]
           SELECT
-            subq_3.monthly_ds__month
-            , subq_3.monthly_ds__quarter
-            , subq_3.monthly_ds__year
-            , subq_3.monthly_ds__extract_year
-            , subq_3.monthly_ds__extract_quarter
-            , subq_3.monthly_ds__extract_month
-            , subq_3.booking__monthly_ds__month
-            , subq_3.booking__monthly_ds__quarter
-            , subq_3.booking__monthly_ds__year
-            , subq_3.booking__monthly_ds__extract_year
-            , subq_3.booking__monthly_ds__extract_quarter
-            , subq_3.booking__monthly_ds__extract_month
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.listing
-            , subq_3.booking__listing
-            , subq_3.bookings_monthly
+            subq_1.monthly_ds__month
+            , subq_1.monthly_ds__quarter
+            , subq_1.monthly_ds__year
+            , subq_1.monthly_ds__extract_year
+            , subq_1.monthly_ds__extract_quarter
+            , subq_1.monthly_ds__extract_month
+            , subq_1.booking__monthly_ds__month
+            , subq_1.booking__monthly_ds__quarter
+            , subq_1.booking__monthly_ds__year
+            , subq_1.booking__monthly_ds__extract_year
+            , subq_1.booking__monthly_ds__extract_quarter
+            , subq_1.booking__monthly_ds__extract_month
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.listing
+            , subq_1.booking__listing
+            , subq_1.bookings_monthly
           FROM (
             -- Metric Time Dimension 'monthly_ds'
             SELECT
-              subq_2.monthly_ds__month
-              , subq_2.monthly_ds__quarter
-              , subq_2.monthly_ds__year
-              , subq_2.monthly_ds__extract_year
-              , subq_2.monthly_ds__extract_quarter
-              , subq_2.monthly_ds__extract_month
-              , subq_2.booking__monthly_ds__month
-              , subq_2.booking__monthly_ds__quarter
-              , subq_2.booking__monthly_ds__year
-              , subq_2.booking__monthly_ds__extract_year
-              , subq_2.booking__monthly_ds__extract_quarter
-              , subq_2.booking__monthly_ds__extract_month
-              , subq_2.monthly_ds__month AS metric_time__month
-              , subq_2.monthly_ds__quarter AS metric_time__quarter
-              , subq_2.monthly_ds__year AS metric_time__year
-              , subq_2.monthly_ds__extract_year AS metric_time__extract_year
-              , subq_2.monthly_ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.monthly_ds__extract_month AS metric_time__extract_month
-              , subq_2.listing
-              , subq_2.booking__listing
-              , subq_2.bookings_monthly
+              subq_0.monthly_ds__month
+              , subq_0.monthly_ds__quarter
+              , subq_0.monthly_ds__year
+              , subq_0.monthly_ds__extract_year
+              , subq_0.monthly_ds__extract_quarter
+              , subq_0.monthly_ds__extract_month
+              , subq_0.booking__monthly_ds__month
+              , subq_0.booking__monthly_ds__quarter
+              , subq_0.booking__monthly_ds__year
+              , subq_0.booking__monthly_ds__extract_year
+              , subq_0.booking__monthly_ds__extract_quarter
+              , subq_0.booking__monthly_ds__extract_month
+              , subq_0.monthly_ds__month AS metric_time__month
+              , subq_0.monthly_ds__quarter AS metric_time__quarter
+              , subq_0.monthly_ds__year AS metric_time__year
+              , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+              , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+              , subq_0.listing
+              , subq_0.booking__listing
+              , subq_0.bookings_monthly
             FROM (
               -- Read Elements From Semantic Model 'bookings_monthly_source'
               SELECT
@@ -117,20 +117,20 @@ FROM (
                 , bookings_monthly_source_src_16000.listing_id AS listing
                 , bookings_monthly_source_src_16000.listing_id AS booking__listing
               FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__month <= subq_5.metric_time__month
+            subq_2.metric_time__month <= subq_3.metric_time__month
           ) AND (
-            subq_4.metric_time__month > DATEADD(month, -3, subq_5.metric_time__month)
+            subq_2.metric_time__month > DATEADD(month, -3, subq_3.metric_time__month)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__month
-) subq_10
+    subq_7.metric_time__month
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__month AS metric_time__month
-  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__month <= subq_16.metric_time__month
+    subq_11.metric_time__month <= subq_12.metric_time__month
   ) AND (
-    subq_15.metric_time__month > DATEADD(month, -3, subq_16.metric_time__month)
+    subq_11.metric_time__month > DATEADD(month, -3, subq_12.metric_time__month)
   )
-WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_12.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_16.metric_time__month
+  subq_12.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS revenue_all_time
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,16 +170,16 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
         ON
-          (subq_4.metric_time__day <= subq_5.metric_time__day)
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+          (subq_2.metric_time__day <= subq_3.metric_time__day)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS revenue_all_time
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
-  (subq_15.metric_time__day <= subq_16.metric_time__day)
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_11.metric_time__day <= subq_12.metric_time__day)
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-11-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,20 +170,20 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__day <= subq_5.metric_time__day
+            subq_2.metric_time__day <= subq_3.metric_time__day
           ) AND (
-            subq_4.metric_time__day > DATEADD(month, -2, subq_5.metric_time__day)
+            subq_2.metric_time__day > DATEADD(month, -2, subq_3.metric_time__day)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__day <= subq_16.metric_time__day
+    subq_11.metric_time__day <= subq_12.metric_time__day
   ) AND (
-    subq_15.metric_time__day > DATEADD(month, -2, subq_16.metric_time__day)
+    subq_11.metric_time__day > DATEADD(month, -2, subq_12.metric_time__day)
   )
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_month__plan0.sql
@@ -1,103 +1,103 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
-  , subq_10.bookings_monthly AS trailing_3_months_bookings
+  subq_8.metric_time__month
+  , subq_8.bookings_monthly AS trailing_3_months_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
-    , SUM(subq_9.bookings_monthly) AS bookings_monthly
+    subq_7.metric_time__month
+    , SUM(subq_7.bookings_monthly) AS bookings_monthly
   FROM (
     -- Constrain Time Range to [2020-03-05T00:00:00, 2021-01-04T00:00:00]
     SELECT
-      subq_8.metric_time__month
-      , subq_8.bookings_monthly
+      subq_6.metric_time__month
+      , subq_6.bookings_monthly
     FROM (
       -- Pass Only Elements: ['bookings_monthly', 'metric_time__month']
       SELECT
-        subq_7.metric_time__month
-        , subq_7.bookings_monthly
+        subq_5.metric_time__month
+        , subq_5.bookings_monthly
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
-          , subq_4.monthly_ds__month AS monthly_ds__month
-          , subq_4.monthly_ds__quarter AS monthly_ds__quarter
-          , subq_4.monthly_ds__year AS monthly_ds__year
-          , subq_4.monthly_ds__extract_year AS monthly_ds__extract_year
-          , subq_4.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
-          , subq_4.monthly_ds__extract_month AS monthly_ds__extract_month
-          , subq_4.booking__monthly_ds__month AS booking__monthly_ds__month
-          , subq_4.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
-          , subq_4.booking__monthly_ds__year AS booking__monthly_ds__year
-          , subq_4.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
-          , subq_4.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
-          , subq_4.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.listing AS listing
-          , subq_4.booking__listing AS booking__listing
-          , subq_4.bookings_monthly AS bookings_monthly
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.monthly_ds__month AS monthly_ds__month
+          , subq_2.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_2.monthly_ds__year AS monthly_ds__year
+          , subq_2.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_2.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_2.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_2.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_2.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_2.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_2.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_2.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_2.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.listing AS listing
+          , subq_2.booking__listing AS booking__listing
+          , subq_2.bookings_monthly AS bookings_monthly
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-03-05' AND '2021-01-04'
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-03-05' AND '2021-01-04'
           GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
-        ) subq_5
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-12-05T00:00:00, 2021-01-04T00:00:00]
           SELECT
-            subq_3.monthly_ds__month
-            , subq_3.monthly_ds__quarter
-            , subq_3.monthly_ds__year
-            , subq_3.monthly_ds__extract_year
-            , subq_3.monthly_ds__extract_quarter
-            , subq_3.monthly_ds__extract_month
-            , subq_3.booking__monthly_ds__month
-            , subq_3.booking__monthly_ds__quarter
-            , subq_3.booking__monthly_ds__year
-            , subq_3.booking__monthly_ds__extract_year
-            , subq_3.booking__monthly_ds__extract_quarter
-            , subq_3.booking__monthly_ds__extract_month
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.listing
-            , subq_3.booking__listing
-            , subq_3.bookings_monthly
+            subq_1.monthly_ds__month
+            , subq_1.monthly_ds__quarter
+            , subq_1.monthly_ds__year
+            , subq_1.monthly_ds__extract_year
+            , subq_1.monthly_ds__extract_quarter
+            , subq_1.monthly_ds__extract_month
+            , subq_1.booking__monthly_ds__month
+            , subq_1.booking__monthly_ds__quarter
+            , subq_1.booking__monthly_ds__year
+            , subq_1.booking__monthly_ds__extract_year
+            , subq_1.booking__monthly_ds__extract_quarter
+            , subq_1.booking__monthly_ds__extract_month
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.listing
+            , subq_1.booking__listing
+            , subq_1.bookings_monthly
           FROM (
             -- Metric Time Dimension 'monthly_ds'
             SELECT
-              subq_2.monthly_ds__month
-              , subq_2.monthly_ds__quarter
-              , subq_2.monthly_ds__year
-              , subq_2.monthly_ds__extract_year
-              , subq_2.monthly_ds__extract_quarter
-              , subq_2.monthly_ds__extract_month
-              , subq_2.booking__monthly_ds__month
-              , subq_2.booking__monthly_ds__quarter
-              , subq_2.booking__monthly_ds__year
-              , subq_2.booking__monthly_ds__extract_year
-              , subq_2.booking__monthly_ds__extract_quarter
-              , subq_2.booking__monthly_ds__extract_month
-              , subq_2.monthly_ds__month AS metric_time__month
-              , subq_2.monthly_ds__quarter AS metric_time__quarter
-              , subq_2.monthly_ds__year AS metric_time__year
-              , subq_2.monthly_ds__extract_year AS metric_time__extract_year
-              , subq_2.monthly_ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.monthly_ds__extract_month AS metric_time__extract_month
-              , subq_2.listing
-              , subq_2.booking__listing
-              , subq_2.bookings_monthly
+              subq_0.monthly_ds__month
+              , subq_0.monthly_ds__quarter
+              , subq_0.monthly_ds__year
+              , subq_0.monthly_ds__extract_year
+              , subq_0.monthly_ds__extract_quarter
+              , subq_0.monthly_ds__extract_month
+              , subq_0.booking__monthly_ds__month
+              , subq_0.booking__monthly_ds__quarter
+              , subq_0.booking__monthly_ds__year
+              , subq_0.booking__monthly_ds__extract_year
+              , subq_0.booking__monthly_ds__extract_quarter
+              , subq_0.booking__monthly_ds__extract_month
+              , subq_0.monthly_ds__month AS metric_time__month
+              , subq_0.monthly_ds__quarter AS metric_time__quarter
+              , subq_0.monthly_ds__year AS metric_time__year
+              , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+              , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+              , subq_0.listing
+              , subq_0.booking__listing
+              , subq_0.bookings_monthly
             FROM (
               -- Read Elements From Semantic Model 'bookings_monthly_source'
               SELECT
@@ -117,20 +117,20 @@ FROM (
                 , bookings_monthly_source_src_16000.listing_id AS listing
                 , bookings_monthly_source_src_16000.listing_id AS booking__listing
               FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__month <= subq_5.metric_time__month
+            subq_2.metric_time__month <= subq_3.metric_time__month
           ) AND (
-            subq_4.metric_time__month > subq_5.metric_time__month - INTERVAL 3 month
+            subq_2.metric_time__month > subq_3.metric_time__month - INTERVAL 3 month
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__month
-) subq_10
+    subq_7.metric_time__month
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__month AS metric_time__month
-  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__month <= subq_16.metric_time__month
+    subq_11.metric_time__month <= subq_12.metric_time__month
   ) AND (
-    subq_15.metric_time__month > subq_16.metric_time__month - INTERVAL 3 month
+    subq_11.metric_time__month > subq_12.metric_time__month - INTERVAL 3 month
   )
-WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_12.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_16.metric_time__month
+  subq_12.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS revenue_all_time
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,16 +170,16 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
         ON
-          (subq_4.metric_time__day <= subq_5.metric_time__day)
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+          (subq_2.metric_time__day <= subq_3.metric_time__day)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS revenue_all_time
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
-  (subq_15.metric_time__day <= subq_16.metric_time__day)
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_11.metric_time__day <= subq_12.metric_time__day)
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-11-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,20 +170,20 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__day <= subq_5.metric_time__day
+            subq_2.metric_time__day <= subq_3.metric_time__day
           ) AND (
-            subq_4.metric_time__day > subq_5.metric_time__day - INTERVAL 2 month
+            subq_2.metric_time__day > subq_3.metric_time__day - INTERVAL 2 month
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__day <= subq_16.metric_time__day
+    subq_11.metric_time__day <= subq_12.metric_time__day
   ) AND (
-    subq_15.metric_time__day > subq_16.metric_time__day - INTERVAL 2 month
+    subq_11.metric_time__day > subq_12.metric_time__day - INTERVAL 2 month
   )
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_month__plan0.sql
@@ -1,103 +1,103 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
-  , subq_10.bookings_monthly AS trailing_3_months_bookings
+  subq_8.metric_time__month
+  , subq_8.bookings_monthly AS trailing_3_months_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
-    , SUM(subq_9.bookings_monthly) AS bookings_monthly
+    subq_7.metric_time__month
+    , SUM(subq_7.bookings_monthly) AS bookings_monthly
   FROM (
     -- Constrain Time Range to [2020-03-05T00:00:00, 2021-01-04T00:00:00]
     SELECT
-      subq_8.metric_time__month
-      , subq_8.bookings_monthly
+      subq_6.metric_time__month
+      , subq_6.bookings_monthly
     FROM (
       -- Pass Only Elements: ['bookings_monthly', 'metric_time__month']
       SELECT
-        subq_7.metric_time__month
-        , subq_7.bookings_monthly
+        subq_5.metric_time__month
+        , subq_5.bookings_monthly
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
-          , subq_4.monthly_ds__month AS monthly_ds__month
-          , subq_4.monthly_ds__quarter AS monthly_ds__quarter
-          , subq_4.monthly_ds__year AS monthly_ds__year
-          , subq_4.monthly_ds__extract_year AS monthly_ds__extract_year
-          , subq_4.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
-          , subq_4.monthly_ds__extract_month AS monthly_ds__extract_month
-          , subq_4.booking__monthly_ds__month AS booking__monthly_ds__month
-          , subq_4.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
-          , subq_4.booking__monthly_ds__year AS booking__monthly_ds__year
-          , subq_4.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
-          , subq_4.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
-          , subq_4.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.listing AS listing
-          , subq_4.booking__listing AS booking__listing
-          , subq_4.bookings_monthly AS bookings_monthly
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.monthly_ds__month AS monthly_ds__month
+          , subq_2.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_2.monthly_ds__year AS monthly_ds__year
+          , subq_2.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_2.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_2.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_2.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_2.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_2.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_2.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_2.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_2.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.listing AS listing
+          , subq_2.booking__listing AS booking__listing
+          , subq_2.bookings_monthly AS bookings_monthly
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-03-05' AND '2021-01-04'
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-03-05' AND '2021-01-04'
           GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
-        ) subq_5
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-12-05T00:00:00, 2021-01-04T00:00:00]
           SELECT
-            subq_3.monthly_ds__month
-            , subq_3.monthly_ds__quarter
-            , subq_3.monthly_ds__year
-            , subq_3.monthly_ds__extract_year
-            , subq_3.monthly_ds__extract_quarter
-            , subq_3.monthly_ds__extract_month
-            , subq_3.booking__monthly_ds__month
-            , subq_3.booking__monthly_ds__quarter
-            , subq_3.booking__monthly_ds__year
-            , subq_3.booking__monthly_ds__extract_year
-            , subq_3.booking__monthly_ds__extract_quarter
-            , subq_3.booking__monthly_ds__extract_month
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.listing
-            , subq_3.booking__listing
-            , subq_3.bookings_monthly
+            subq_1.monthly_ds__month
+            , subq_1.monthly_ds__quarter
+            , subq_1.monthly_ds__year
+            , subq_1.monthly_ds__extract_year
+            , subq_1.monthly_ds__extract_quarter
+            , subq_1.monthly_ds__extract_month
+            , subq_1.booking__monthly_ds__month
+            , subq_1.booking__monthly_ds__quarter
+            , subq_1.booking__monthly_ds__year
+            , subq_1.booking__monthly_ds__extract_year
+            , subq_1.booking__monthly_ds__extract_quarter
+            , subq_1.booking__monthly_ds__extract_month
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.listing
+            , subq_1.booking__listing
+            , subq_1.bookings_monthly
           FROM (
             -- Metric Time Dimension 'monthly_ds'
             SELECT
-              subq_2.monthly_ds__month
-              , subq_2.monthly_ds__quarter
-              , subq_2.monthly_ds__year
-              , subq_2.monthly_ds__extract_year
-              , subq_2.monthly_ds__extract_quarter
-              , subq_2.monthly_ds__extract_month
-              , subq_2.booking__monthly_ds__month
-              , subq_2.booking__monthly_ds__quarter
-              , subq_2.booking__monthly_ds__year
-              , subq_2.booking__monthly_ds__extract_year
-              , subq_2.booking__monthly_ds__extract_quarter
-              , subq_2.booking__monthly_ds__extract_month
-              , subq_2.monthly_ds__month AS metric_time__month
-              , subq_2.monthly_ds__quarter AS metric_time__quarter
-              , subq_2.monthly_ds__year AS metric_time__year
-              , subq_2.monthly_ds__extract_year AS metric_time__extract_year
-              , subq_2.monthly_ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.monthly_ds__extract_month AS metric_time__extract_month
-              , subq_2.listing
-              , subq_2.booking__listing
-              , subq_2.bookings_monthly
+              subq_0.monthly_ds__month
+              , subq_0.monthly_ds__quarter
+              , subq_0.monthly_ds__year
+              , subq_0.monthly_ds__extract_year
+              , subq_0.monthly_ds__extract_quarter
+              , subq_0.monthly_ds__extract_month
+              , subq_0.booking__monthly_ds__month
+              , subq_0.booking__monthly_ds__quarter
+              , subq_0.booking__monthly_ds__year
+              , subq_0.booking__monthly_ds__extract_year
+              , subq_0.booking__monthly_ds__extract_quarter
+              , subq_0.booking__monthly_ds__extract_month
+              , subq_0.monthly_ds__month AS metric_time__month
+              , subq_0.monthly_ds__quarter AS metric_time__quarter
+              , subq_0.monthly_ds__year AS metric_time__year
+              , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+              , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+              , subq_0.listing
+              , subq_0.booking__listing
+              , subq_0.bookings_monthly
             FROM (
               -- Read Elements From Semantic Model 'bookings_monthly_source'
               SELECT
@@ -117,20 +117,20 @@ FROM (
                 , bookings_monthly_source_src_16000.listing_id AS listing
                 , bookings_monthly_source_src_16000.listing_id AS booking__listing
               FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__month <= subq_5.metric_time__month
+            subq_2.metric_time__month <= subq_3.metric_time__month
           ) AND (
-            subq_4.metric_time__month > subq_5.metric_time__month - MAKE_INTERVAL(months => 3)
+            subq_2.metric_time__month > subq_3.metric_time__month - MAKE_INTERVAL(months => 3)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__month
-) subq_10
+    subq_7.metric_time__month
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__month AS metric_time__month
-  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__month <= subq_16.metric_time__month
+    subq_11.metric_time__month <= subq_12.metric_time__month
   ) AND (
-    subq_15.metric_time__month > subq_16.metric_time__month - MAKE_INTERVAL(months => 3)
+    subq_11.metric_time__month > subq_12.metric_time__month - MAKE_INTERVAL(months => 3)
   )
-WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_12.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_16.metric_time__month
+  subq_12.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS revenue_all_time
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,16 +170,16 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
         ON
-          (subq_4.metric_time__day <= subq_5.metric_time__day)
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+          (subq_2.metric_time__day <= subq_3.metric_time__day)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS revenue_all_time
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
-  (subq_15.metric_time__day <= subq_16.metric_time__day)
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_11.metric_time__day <= subq_12.metric_time__day)
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-11-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,20 +170,20 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__day <= subq_5.metric_time__day
+            subq_2.metric_time__day <= subq_3.metric_time__day
           ) AND (
-            subq_4.metric_time__day > subq_5.metric_time__day - MAKE_INTERVAL(months => 2)
+            subq_2.metric_time__day > subq_3.metric_time__day - MAKE_INTERVAL(months => 2)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__day <= subq_16.metric_time__day
+    subq_11.metric_time__day <= subq_12.metric_time__day
   ) AND (
-    subq_15.metric_time__day > subq_16.metric_time__day - MAKE_INTERVAL(months => 2)
+    subq_11.metric_time__day > subq_12.metric_time__day - MAKE_INTERVAL(months => 2)
   )
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_month__plan0.sql
@@ -1,103 +1,103 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
-  , subq_10.bookings_monthly AS trailing_3_months_bookings
+  subq_8.metric_time__month
+  , subq_8.bookings_monthly AS trailing_3_months_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
-    , SUM(subq_9.bookings_monthly) AS bookings_monthly
+    subq_7.metric_time__month
+    , SUM(subq_7.bookings_monthly) AS bookings_monthly
   FROM (
     -- Constrain Time Range to [2020-03-05T00:00:00, 2021-01-04T00:00:00]
     SELECT
-      subq_8.metric_time__month
-      , subq_8.bookings_monthly
+      subq_6.metric_time__month
+      , subq_6.bookings_monthly
     FROM (
       -- Pass Only Elements: ['bookings_monthly', 'metric_time__month']
       SELECT
-        subq_7.metric_time__month
-        , subq_7.bookings_monthly
+        subq_5.metric_time__month
+        , subq_5.bookings_monthly
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
-          , subq_4.monthly_ds__month AS monthly_ds__month
-          , subq_4.monthly_ds__quarter AS monthly_ds__quarter
-          , subq_4.monthly_ds__year AS monthly_ds__year
-          , subq_4.monthly_ds__extract_year AS monthly_ds__extract_year
-          , subq_4.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
-          , subq_4.monthly_ds__extract_month AS monthly_ds__extract_month
-          , subq_4.booking__monthly_ds__month AS booking__monthly_ds__month
-          , subq_4.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
-          , subq_4.booking__monthly_ds__year AS booking__monthly_ds__year
-          , subq_4.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
-          , subq_4.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
-          , subq_4.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.listing AS listing
-          , subq_4.booking__listing AS booking__listing
-          , subq_4.bookings_monthly AS bookings_monthly
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.monthly_ds__month AS monthly_ds__month
+          , subq_2.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_2.monthly_ds__year AS monthly_ds__year
+          , subq_2.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_2.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_2.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_2.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_2.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_2.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_2.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_2.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_2.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.listing AS listing
+          , subq_2.booking__listing AS booking__listing
+          , subq_2.bookings_monthly AS bookings_monthly
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-03-05' AND '2021-01-04'
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-03-05' AND '2021-01-04'
           GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
-        ) subq_5
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-12-05T00:00:00, 2021-01-04T00:00:00]
           SELECT
-            subq_3.monthly_ds__month
-            , subq_3.monthly_ds__quarter
-            , subq_3.monthly_ds__year
-            , subq_3.monthly_ds__extract_year
-            , subq_3.monthly_ds__extract_quarter
-            , subq_3.monthly_ds__extract_month
-            , subq_3.booking__monthly_ds__month
-            , subq_3.booking__monthly_ds__quarter
-            , subq_3.booking__monthly_ds__year
-            , subq_3.booking__monthly_ds__extract_year
-            , subq_3.booking__monthly_ds__extract_quarter
-            , subq_3.booking__monthly_ds__extract_month
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.listing
-            , subq_3.booking__listing
-            , subq_3.bookings_monthly
+            subq_1.monthly_ds__month
+            , subq_1.monthly_ds__quarter
+            , subq_1.monthly_ds__year
+            , subq_1.monthly_ds__extract_year
+            , subq_1.monthly_ds__extract_quarter
+            , subq_1.monthly_ds__extract_month
+            , subq_1.booking__monthly_ds__month
+            , subq_1.booking__monthly_ds__quarter
+            , subq_1.booking__monthly_ds__year
+            , subq_1.booking__monthly_ds__extract_year
+            , subq_1.booking__monthly_ds__extract_quarter
+            , subq_1.booking__monthly_ds__extract_month
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.listing
+            , subq_1.booking__listing
+            , subq_1.bookings_monthly
           FROM (
             -- Metric Time Dimension 'monthly_ds'
             SELECT
-              subq_2.monthly_ds__month
-              , subq_2.monthly_ds__quarter
-              , subq_2.monthly_ds__year
-              , subq_2.monthly_ds__extract_year
-              , subq_2.monthly_ds__extract_quarter
-              , subq_2.monthly_ds__extract_month
-              , subq_2.booking__monthly_ds__month
-              , subq_2.booking__monthly_ds__quarter
-              , subq_2.booking__monthly_ds__year
-              , subq_2.booking__monthly_ds__extract_year
-              , subq_2.booking__monthly_ds__extract_quarter
-              , subq_2.booking__monthly_ds__extract_month
-              , subq_2.monthly_ds__month AS metric_time__month
-              , subq_2.monthly_ds__quarter AS metric_time__quarter
-              , subq_2.monthly_ds__year AS metric_time__year
-              , subq_2.monthly_ds__extract_year AS metric_time__extract_year
-              , subq_2.monthly_ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.monthly_ds__extract_month AS metric_time__extract_month
-              , subq_2.listing
-              , subq_2.booking__listing
-              , subq_2.bookings_monthly
+              subq_0.monthly_ds__month
+              , subq_0.monthly_ds__quarter
+              , subq_0.monthly_ds__year
+              , subq_0.monthly_ds__extract_year
+              , subq_0.monthly_ds__extract_quarter
+              , subq_0.monthly_ds__extract_month
+              , subq_0.booking__monthly_ds__month
+              , subq_0.booking__monthly_ds__quarter
+              , subq_0.booking__monthly_ds__year
+              , subq_0.booking__monthly_ds__extract_year
+              , subq_0.booking__monthly_ds__extract_quarter
+              , subq_0.booking__monthly_ds__extract_month
+              , subq_0.monthly_ds__month AS metric_time__month
+              , subq_0.monthly_ds__quarter AS metric_time__quarter
+              , subq_0.monthly_ds__year AS metric_time__year
+              , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+              , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+              , subq_0.listing
+              , subq_0.booking__listing
+              , subq_0.bookings_monthly
             FROM (
               -- Read Elements From Semantic Model 'bookings_monthly_source'
               SELECT
@@ -117,20 +117,20 @@ FROM (
                 , bookings_monthly_source_src_16000.listing_id AS listing
                 , bookings_monthly_source_src_16000.listing_id AS booking__listing
               FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__month <= subq_5.metric_time__month
+            subq_2.metric_time__month <= subq_3.metric_time__month
           ) AND (
-            subq_4.metric_time__month > DATEADD(month, -3, subq_5.metric_time__month)
+            subq_2.metric_time__month > DATEADD(month, -3, subq_3.metric_time__month)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__month
-) subq_10
+    subq_7.metric_time__month
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__month AS metric_time__month
-  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__month <= subq_16.metric_time__month
+    subq_11.metric_time__month <= subq_12.metric_time__month
   ) AND (
-    subq_15.metric_time__month > DATEADD(month, -3, subq_16.metric_time__month)
+    subq_11.metric_time__month > DATEADD(month, -3, subq_12.metric_time__month)
   )
-WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_12.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_16.metric_time__month
+  subq_12.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS revenue_all_time
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,16 +170,16 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
         ON
-          (subq_4.metric_time__day <= subq_5.metric_time__day)
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+          (subq_2.metric_time__day <= subq_3.metric_time__day)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS revenue_all_time
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
-  (subq_15.metric_time__day <= subq_16.metric_time__day)
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_11.metric_time__day <= subq_12.metric_time__day)
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-11-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,20 +170,20 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__day <= subq_5.metric_time__day
+            subq_2.metric_time__day <= subq_3.metric_time__day
           ) AND (
-            subq_4.metric_time__day > DATEADD(month, -2, subq_5.metric_time__day)
+            subq_2.metric_time__day > DATEADD(month, -2, subq_3.metric_time__day)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__day <= subq_16.metric_time__day
+    subq_11.metric_time__day <= subq_12.metric_time__day
   ) AND (
-    subq_15.metric_time__day > DATEADD(month, -2, subq_16.metric_time__day)
+    subq_11.metric_time__day > DATEADD(month, -2, subq_12.metric_time__day)
   )
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_month__plan0.sql
@@ -1,103 +1,103 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
-  , subq_10.bookings_monthly AS trailing_3_months_bookings
+  subq_8.metric_time__month
+  , subq_8.bookings_monthly AS trailing_3_months_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
-    , SUM(subq_9.bookings_monthly) AS bookings_monthly
+    subq_7.metric_time__month
+    , SUM(subq_7.bookings_monthly) AS bookings_monthly
   FROM (
     -- Constrain Time Range to [2020-03-05T00:00:00, 2021-01-04T00:00:00]
     SELECT
-      subq_8.metric_time__month
-      , subq_8.bookings_monthly
+      subq_6.metric_time__month
+      , subq_6.bookings_monthly
     FROM (
       -- Pass Only Elements: ['bookings_monthly', 'metric_time__month']
       SELECT
-        subq_7.metric_time__month
-        , subq_7.bookings_monthly
+        subq_5.metric_time__month
+        , subq_5.bookings_monthly
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
-          , subq_4.monthly_ds__month AS monthly_ds__month
-          , subq_4.monthly_ds__quarter AS monthly_ds__quarter
-          , subq_4.monthly_ds__year AS monthly_ds__year
-          , subq_4.monthly_ds__extract_year AS monthly_ds__extract_year
-          , subq_4.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
-          , subq_4.monthly_ds__extract_month AS monthly_ds__extract_month
-          , subq_4.booking__monthly_ds__month AS booking__monthly_ds__month
-          , subq_4.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
-          , subq_4.booking__monthly_ds__year AS booking__monthly_ds__year
-          , subq_4.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
-          , subq_4.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
-          , subq_4.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.listing AS listing
-          , subq_4.booking__listing AS booking__listing
-          , subq_4.bookings_monthly AS bookings_monthly
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.monthly_ds__month AS monthly_ds__month
+          , subq_2.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_2.monthly_ds__year AS monthly_ds__year
+          , subq_2.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_2.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_2.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_2.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_2.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_2.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_2.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_2.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_2.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.listing AS listing
+          , subq_2.booking__listing AS booking__listing
+          , subq_2.bookings_monthly AS bookings_monthly
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-03-05' AND '2021-01-04'
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-03-05' AND '2021-01-04'
           GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
-        ) subq_5
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-12-05T00:00:00, 2021-01-04T00:00:00]
           SELECT
-            subq_3.monthly_ds__month
-            , subq_3.monthly_ds__quarter
-            , subq_3.monthly_ds__year
-            , subq_3.monthly_ds__extract_year
-            , subq_3.monthly_ds__extract_quarter
-            , subq_3.monthly_ds__extract_month
-            , subq_3.booking__monthly_ds__month
-            , subq_3.booking__monthly_ds__quarter
-            , subq_3.booking__monthly_ds__year
-            , subq_3.booking__monthly_ds__extract_year
-            , subq_3.booking__monthly_ds__extract_quarter
-            , subq_3.booking__monthly_ds__extract_month
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.listing
-            , subq_3.booking__listing
-            , subq_3.bookings_monthly
+            subq_1.monthly_ds__month
+            , subq_1.monthly_ds__quarter
+            , subq_1.monthly_ds__year
+            , subq_1.monthly_ds__extract_year
+            , subq_1.monthly_ds__extract_quarter
+            , subq_1.monthly_ds__extract_month
+            , subq_1.booking__monthly_ds__month
+            , subq_1.booking__monthly_ds__quarter
+            , subq_1.booking__monthly_ds__year
+            , subq_1.booking__monthly_ds__extract_year
+            , subq_1.booking__monthly_ds__extract_quarter
+            , subq_1.booking__monthly_ds__extract_month
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.listing
+            , subq_1.booking__listing
+            , subq_1.bookings_monthly
           FROM (
             -- Metric Time Dimension 'monthly_ds'
             SELECT
-              subq_2.monthly_ds__month
-              , subq_2.monthly_ds__quarter
-              , subq_2.monthly_ds__year
-              , subq_2.monthly_ds__extract_year
-              , subq_2.monthly_ds__extract_quarter
-              , subq_2.monthly_ds__extract_month
-              , subq_2.booking__monthly_ds__month
-              , subq_2.booking__monthly_ds__quarter
-              , subq_2.booking__monthly_ds__year
-              , subq_2.booking__monthly_ds__extract_year
-              , subq_2.booking__monthly_ds__extract_quarter
-              , subq_2.booking__monthly_ds__extract_month
-              , subq_2.monthly_ds__month AS metric_time__month
-              , subq_2.monthly_ds__quarter AS metric_time__quarter
-              , subq_2.monthly_ds__year AS metric_time__year
-              , subq_2.monthly_ds__extract_year AS metric_time__extract_year
-              , subq_2.monthly_ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.monthly_ds__extract_month AS metric_time__extract_month
-              , subq_2.listing
-              , subq_2.booking__listing
-              , subq_2.bookings_monthly
+              subq_0.monthly_ds__month
+              , subq_0.monthly_ds__quarter
+              , subq_0.monthly_ds__year
+              , subq_0.monthly_ds__extract_year
+              , subq_0.monthly_ds__extract_quarter
+              , subq_0.monthly_ds__extract_month
+              , subq_0.booking__monthly_ds__month
+              , subq_0.booking__monthly_ds__quarter
+              , subq_0.booking__monthly_ds__year
+              , subq_0.booking__monthly_ds__extract_year
+              , subq_0.booking__monthly_ds__extract_quarter
+              , subq_0.booking__monthly_ds__extract_month
+              , subq_0.monthly_ds__month AS metric_time__month
+              , subq_0.monthly_ds__quarter AS metric_time__quarter
+              , subq_0.monthly_ds__year AS metric_time__year
+              , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+              , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+              , subq_0.listing
+              , subq_0.booking__listing
+              , subq_0.bookings_monthly
             FROM (
               -- Read Elements From Semantic Model 'bookings_monthly_source'
               SELECT
@@ -117,20 +117,20 @@ FROM (
                 , bookings_monthly_source_src_16000.listing_id AS listing
                 , bookings_monthly_source_src_16000.listing_id AS booking__listing
               FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__month BETWEEN '2019-12-05' AND '2021-01-04'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__month <= subq_5.metric_time__month
+            subq_2.metric_time__month <= subq_3.metric_time__month
           ) AND (
-            subq_4.metric_time__month > DATEADD(month, -3, subq_5.metric_time__month)
+            subq_2.metric_time__month > DATEADD(month, -3, subq_3.metric_time__month)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__month
-) subq_10
+    subq_7.metric_time__month
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__month AS metric_time__month
-  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__month <= subq_16.metric_time__month
+    subq_11.metric_time__month <= subq_12.metric_time__month
   ) AND (
-    subq_15.metric_time__month > DATEADD(month, -3, subq_16.metric_time__month)
+    subq_11.metric_time__month > DATEADD(month, -3, subq_12.metric_time__month)
   )
-WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_12.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_16.metric_time__month
+  subq_12.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS revenue_all_time
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,16 +170,16 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
         ON
-          (subq_4.metric_time__day <= subq_5.metric_time__day)
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+          (subq_2.metric_time__day <= subq_3.metric_time__day)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS revenue_all_time
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
-  (subq_15.metric_time__day <= subq_16.metric_time__day)
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_11.metric_time__day <= subq_12.metric_time__day)
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-11-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,20 +170,20 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-11-01' AND '2020-01-01'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__day <= subq_5.metric_time__day
+            subq_2.metric_time__day <= subq_3.metric_time__day
           ) AND (
-            subq_4.metric_time__day > DATEADD(month, -2, subq_5.metric_time__day)
+            subq_2.metric_time__day > DATEADD(month, -2, subq_3.metric_time__day)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__day <= subq_16.metric_time__day
+    subq_11.metric_time__day <= subq_12.metric_time__day
   ) AND (
-    subq_15.metric_time__day > DATEADD(month, -2, subq_16.metric_time__day)
+    subq_11.metric_time__day > DATEADD(month, -2, subq_12.metric_time__day)
   )
-WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_12.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_month__plan0.sql
@@ -1,103 +1,103 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
-  , subq_10.bookings_monthly AS trailing_3_months_bookings
+  subq_8.metric_time__month
+  , subq_8.bookings_monthly AS trailing_3_months_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
-    , SUM(subq_9.bookings_monthly) AS bookings_monthly
+    subq_7.metric_time__month
+    , SUM(subq_7.bookings_monthly) AS bookings_monthly
   FROM (
     -- Constrain Time Range to [2020-03-05T00:00:00, 2021-01-04T00:00:00]
     SELECT
-      subq_8.metric_time__month
-      , subq_8.bookings_monthly
+      subq_6.metric_time__month
+      , subq_6.bookings_monthly
     FROM (
       -- Pass Only Elements: ['bookings_monthly', 'metric_time__month']
       SELECT
-        subq_7.metric_time__month
-        , subq_7.bookings_monthly
+        subq_5.metric_time__month
+        , subq_5.bookings_monthly
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
-          , subq_4.monthly_ds__month AS monthly_ds__month
-          , subq_4.monthly_ds__quarter AS monthly_ds__quarter
-          , subq_4.monthly_ds__year AS monthly_ds__year
-          , subq_4.monthly_ds__extract_year AS monthly_ds__extract_year
-          , subq_4.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
-          , subq_4.monthly_ds__extract_month AS monthly_ds__extract_month
-          , subq_4.booking__monthly_ds__month AS booking__monthly_ds__month
-          , subq_4.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
-          , subq_4.booking__monthly_ds__year AS booking__monthly_ds__year
-          , subq_4.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
-          , subq_4.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
-          , subq_4.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.listing AS listing
-          , subq_4.booking__listing AS booking__listing
-          , subq_4.bookings_monthly AS bookings_monthly
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.monthly_ds__month AS monthly_ds__month
+          , subq_2.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_2.monthly_ds__year AS monthly_ds__year
+          , subq_2.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_2.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_2.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_2.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_2.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_2.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_2.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_2.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_2.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.listing AS listing
+          , subq_2.booking__listing AS booking__listing
+          , subq_2.bookings_monthly AS bookings_monthly
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
           GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
-        ) subq_5
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-12-05T00:00:00, 2021-01-04T00:00:00]
           SELECT
-            subq_3.monthly_ds__month
-            , subq_3.monthly_ds__quarter
-            , subq_3.monthly_ds__year
-            , subq_3.monthly_ds__extract_year
-            , subq_3.monthly_ds__extract_quarter
-            , subq_3.monthly_ds__extract_month
-            , subq_3.booking__monthly_ds__month
-            , subq_3.booking__monthly_ds__quarter
-            , subq_3.booking__monthly_ds__year
-            , subq_3.booking__monthly_ds__extract_year
-            , subq_3.booking__monthly_ds__extract_quarter
-            , subq_3.booking__monthly_ds__extract_month
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.listing
-            , subq_3.booking__listing
-            , subq_3.bookings_monthly
+            subq_1.monthly_ds__month
+            , subq_1.monthly_ds__quarter
+            , subq_1.monthly_ds__year
+            , subq_1.monthly_ds__extract_year
+            , subq_1.monthly_ds__extract_quarter
+            , subq_1.monthly_ds__extract_month
+            , subq_1.booking__monthly_ds__month
+            , subq_1.booking__monthly_ds__quarter
+            , subq_1.booking__monthly_ds__year
+            , subq_1.booking__monthly_ds__extract_year
+            , subq_1.booking__monthly_ds__extract_quarter
+            , subq_1.booking__monthly_ds__extract_month
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.listing
+            , subq_1.booking__listing
+            , subq_1.bookings_monthly
           FROM (
             -- Metric Time Dimension 'monthly_ds'
             SELECT
-              subq_2.monthly_ds__month
-              , subq_2.monthly_ds__quarter
-              , subq_2.monthly_ds__year
-              , subq_2.monthly_ds__extract_year
-              , subq_2.monthly_ds__extract_quarter
-              , subq_2.monthly_ds__extract_month
-              , subq_2.booking__monthly_ds__month
-              , subq_2.booking__monthly_ds__quarter
-              , subq_2.booking__monthly_ds__year
-              , subq_2.booking__monthly_ds__extract_year
-              , subq_2.booking__monthly_ds__extract_quarter
-              , subq_2.booking__monthly_ds__extract_month
-              , subq_2.monthly_ds__month AS metric_time__month
-              , subq_2.monthly_ds__quarter AS metric_time__quarter
-              , subq_2.monthly_ds__year AS metric_time__year
-              , subq_2.monthly_ds__extract_year AS metric_time__extract_year
-              , subq_2.monthly_ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.monthly_ds__extract_month AS metric_time__extract_month
-              , subq_2.listing
-              , subq_2.booking__listing
-              , subq_2.bookings_monthly
+              subq_0.monthly_ds__month
+              , subq_0.monthly_ds__quarter
+              , subq_0.monthly_ds__year
+              , subq_0.monthly_ds__extract_year
+              , subq_0.monthly_ds__extract_quarter
+              , subq_0.monthly_ds__extract_month
+              , subq_0.booking__monthly_ds__month
+              , subq_0.booking__monthly_ds__quarter
+              , subq_0.booking__monthly_ds__year
+              , subq_0.booking__monthly_ds__extract_year
+              , subq_0.booking__monthly_ds__extract_quarter
+              , subq_0.booking__monthly_ds__extract_month
+              , subq_0.monthly_ds__month AS metric_time__month
+              , subq_0.monthly_ds__quarter AS metric_time__quarter
+              , subq_0.monthly_ds__year AS metric_time__year
+              , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+              , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+              , subq_0.listing
+              , subq_0.booking__listing
+              , subq_0.bookings_monthly
             FROM (
               -- Read Elements From Semantic Model 'bookings_monthly_source'
               SELECT
@@ -117,20 +117,20 @@ FROM (
                 , bookings_monthly_source_src_16000.listing_id AS listing
                 , bookings_monthly_source_src_16000.listing_id AS booking__listing
               FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__month BETWEEN timestamp '2019-12-05' AND timestamp '2021-01-04'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__month BETWEEN timestamp '2019-12-05' AND timestamp '2021-01-04'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__month <= subq_5.metric_time__month
+            subq_2.metric_time__month <= subq_3.metric_time__month
           ) AND (
-            subq_4.metric_time__month > DATE_ADD('month', -3, subq_5.metric_time__month)
+            subq_2.metric_time__month > DATE_ADD('month', -3, subq_3.metric_time__month)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__month
-) subq_10
+    subq_7.metric_time__month
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__month AS metric_time__month
-  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN timestamp '2019-12-05' AND timestamp '2021-01-04'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__month <= subq_16.metric_time__month
+    subq_11.metric_time__month <= subq_12.metric_time__month
   ) AND (
-    subq_15.metric_time__month > DATE_ADD('month', -3, subq_16.metric_time__month)
+    subq_11.metric_time__month > DATE_ADD('month', -3, subq_12.metric_time__month)
   )
-WHERE subq_16.metric_time__month BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
+WHERE subq_12.metric_time__month BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
 GROUP BY
-  subq_16.metric_time__month
+  subq_12.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS revenue_all_time
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,16 +170,16 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
+        ) subq_2
         ON
-          (subq_4.metric_time__day <= subq_5.metric_time__day)
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-  ) subq_9
+          (subq_2.metric_time__day <= subq_3.metric_time__day)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS revenue_all_time
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
-) subq_15
+) subq_11
 ON
-  (subq_15.metric_time__day <= subq_16.metric_time__day)
-WHERE subq_16.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+  (subq_11.metric_time__day <= subq_12.metric_time__day)
+WHERE subq_12.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,146 +1,146 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , subq_10.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__day
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__day
-    , SUM(subq_9.txn_revenue) AS txn_revenue
+    subq_7.metric_time__day
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__day
-      , subq_8.txn_revenue
+      subq_6.metric_time__day
+      , subq_6.txn_revenue
     FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__day
-        , subq_7.txn_revenue
+        subq_5.metric_time__day
+        , subq_5.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
-          , subq_4.ds__week AS ds__week
-          , subq_4.ds__month AS ds__month
-          , subq_4.ds__quarter AS ds__quarter
-          , subq_4.ds__year AS ds__year
-          , subq_4.ds__extract_year AS ds__extract_year
-          , subq_4.ds__extract_quarter AS ds__extract_quarter
-          , subq_4.ds__extract_month AS ds__extract_month
-          , subq_4.ds__extract_day AS ds__extract_day
-          , subq_4.ds__extract_dow AS ds__extract_dow
-          , subq_4.ds__extract_doy AS ds__extract_doy
-          , subq_4.revenue_instance__ds__day AS revenue_instance__ds__day
-          , subq_4.revenue_instance__ds__week AS revenue_instance__ds__week
-          , subq_4.revenue_instance__ds__month AS revenue_instance__ds__month
-          , subq_4.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-          , subq_4.revenue_instance__ds__year AS revenue_instance__ds__year
-          , subq_4.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
-          , subq_4.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
-          , subq_4.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
-          , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
-          , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
-          , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__week AS metric_time__week
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__quarter AS metric_time__quarter
-          , subq_4.metric_time__year AS metric_time__year
-          , subq_4.metric_time__extract_year AS metric_time__extract_year
-          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_4.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__extract_day AS metric_time__extract_day
-          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.user AS user
-          , subq_4.revenue_instance__user AS revenue_instance__user
-          , subq_4.txn_revenue AS txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
           -- Time Spine
           SELECT
-            subq_6.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_6
-          WHERE subq_6.ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-        ) subq_5
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+        ) subq_3
         INNER JOIN (
           -- Constrain Time Range to [2019-11-01T00:00:00, 2020-01-01T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.revenue_instance__ds__day
-            , subq_3.revenue_instance__ds__week
-            , subq_3.revenue_instance__ds__month
-            , subq_3.revenue_instance__ds__quarter
-            , subq_3.revenue_instance__ds__year
-            , subq_3.revenue_instance__ds__extract_year
-            , subq_3.revenue_instance__ds__extract_quarter
-            , subq_3.revenue_instance__ds__extract_month
-            , subq_3.revenue_instance__ds__extract_day
-            , subq_3.revenue_instance__ds__extract_dow
-            , subq_3.revenue_instance__ds__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.user
-            , subq_3.revenue_instance__user
-            , subq_3.txn_revenue
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.revenue_instance__ds__day
-              , subq_2.revenue_instance__ds__week
-              , subq_2.revenue_instance__ds__month
-              , subq_2.revenue_instance__ds__quarter
-              , subq_2.revenue_instance__ds__year
-              , subq_2.revenue_instance__ds__extract_year
-              , subq_2.revenue_instance__ds__extract_quarter
-              , subq_2.revenue_instance__ds__extract_month
-              , subq_2.revenue_instance__ds__extract_day
-              , subq_2.revenue_instance__ds__extract_dow
-              , subq_2.revenue_instance__ds__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.user
-              , subq_2.revenue_instance__user
-              , subq_2.txn_revenue
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
             FROM (
               -- Read Elements From Semantic Model 'revenue'
               SELECT
@@ -170,20 +170,20 @@ FROM (
                 , revenue_src_28000.user_id AS user
                 , revenue_src_28000.user_id AS revenue_instance__user
               FROM ***************************.fct_revenue revenue_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN timestamp '2019-11-01' AND timestamp '2020-01-01'
-        ) subq_4
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN timestamp '2019-11-01' AND timestamp '2020-01-01'
+        ) subq_2
         ON
           (
-            subq_4.metric_time__day <= subq_5.metric_time__day
+            subq_2.metric_time__day <= subq_3.metric_time__day
           ) AND (
-            subq_4.metric_time__day > DATE_ADD('month', -2, subq_5.metric_time__day)
+            subq_2.metric_time__day > DATE_ADD('month', -2, subq_3.metric_time__day)
           )
-      ) subq_7
-    ) subq_8
-    WHERE subq_8.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-  ) subq_9
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_9.metric_time__day
-) subq_10
+    subq_7.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
+  subq_12.metric_time__day AS metric_time__day
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_17
+  FROM ***************************.mf_time_spine subq_13
   WHERE ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-) subq_16
+) subq_12
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN timestamp '2019-11-01' AND timestamp '2020-01-01'
-) subq_15
+) subq_11
 ON
   (
-    subq_15.metric_time__day <= subq_16.metric_time__day
+    subq_11.metric_time__day <= subq_12.metric_time__day
   ) AND (
-    subq_15.metric_time__day > DATE_ADD('month', -2, subq_16.metric_time__day)
+    subq_11.metric_time__day > DATE_ADD('month', -2, subq_12.metric_time__day)
   )
-WHERE subq_16.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+WHERE subq_12.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
 GROUP BY
-  subq_16.metric_time__day
+  subq_12.metric_time__day

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_multihop_joined_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_multihop_joined_plan__ep_0.xml
@@ -2,40 +2,40 @@
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                                             -->
-        <!--   ('-- Join Standard Outputs\n'                                                                         -->
-        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                   -->
-        <!--    '-- Aggregate Measures\n'                                                                            -->
-        <!--    '-- Compute Metrics via Expressions\n'                                                               -->
-        <!--    'SELECT\n'                                                                                           -->
-        <!--    '  subq_14.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
-        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                     -->
-        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                 -->
-        <!--    'LEFT OUTER JOIN (\n'                                                                                -->
-        <!--    '  -- Join Standard Outputs\n'                                                                       -->
-        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"     -->
-        <!--    '  SELECT\n'                                                                                         -->
-        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"              -->
-        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                            -->
-        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                       -->
-        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                           -->
-        <!--    '  LEFT OUTER JOIN\n'                                                                                -->
-        <!--    '    ***************************.customer_table customer_table_src_22000\n'                          -->
-        <!--    '  ON\n'                                                                                             -->
-        <!--    '    (\n'                                                                                            -->
-        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                  -->
-        <!--    '    ) AND (\n'                                                                                      -->
-        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "                -->
-        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                         -->
-        <!--    '    )\n'                                                                                            -->
-        <!--    ') subq_14\n'                                                                                        -->
-        <!--    'ON\n'                                                                                               -->
-        <!--    '  (\n'                                                                                              -->
-        <!--    '    account_month_txns_src_22000.account_id = subq_14.account_id\n'                                 -->
-        <!--    '  ) AND (\n'                                                                                        -->
-        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_14.ds_partitioned__day\n" -->
-        <!--    '  )\n'                                                                                              -->
-        <!--    'GROUP BY\n'                                                                                         -->
-        <!--    '  account_id__customer_id__customer_name')                                                          -->
+        <!-- sql_query =                                                                                            -->
+        <!--   ('-- Join Standard Outputs\n'                                                                        -->
+        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                  -->
+        <!--    '-- Aggregate Measures\n'                                                                           -->
+        <!--    '-- Compute Metrics via Expressions\n'                                                              -->
+        <!--    'SELECT\n'                                                                                          -->
+        <!--    '  subq_9.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
+        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                    -->
+        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                -->
+        <!--    'LEFT OUTER JOIN (\n'                                                                               -->
+        <!--    '  -- Join Standard Outputs\n'                                                                      -->
+        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"    -->
+        <!--    '  SELECT\n'                                                                                        -->
+        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"             -->
+        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                           -->
+        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                      -->
+        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                          -->
+        <!--    '  LEFT OUTER JOIN\n'                                                                               -->
+        <!--    '    ***************************.customer_table customer_table_src_22000\n'                         -->
+        <!--    '  ON\n'                                                                                            -->
+        <!--    '    (\n'                                                                                           -->
+        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                 -->
+        <!--    '    ) AND (\n'                                                                                     -->
+        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "               -->
+        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                        -->
+        <!--    '    )\n'                                                                                           -->
+        <!--    ') subq_9\n'                                                                                        -->
+        <!--    'ON\n'                                                                                              -->
+        <!--    '  (\n'                                                                                             -->
+        <!--    '    account_month_txns_src_22000.account_id = subq_9.account_id\n'                                 -->
+        <!--    '  ) AND (\n'                                                                                       -->
+        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_9.ds_partitioned__day\n" -->
+        <!--    '  )\n'                                                                                             -->
+        <!--    'GROUP BY\n'                                                                                        -->
+        <!--    '  account_id__customer_id__customer_name')                                                         -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_multihop_joined_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_multihop_joined_plan__ep_0.xml
@@ -2,40 +2,40 @@
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                                             -->
-        <!--   ('-- Join Standard Outputs\n'                                                                         -->
-        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                   -->
-        <!--    '-- Aggregate Measures\n'                                                                            -->
-        <!--    '-- Compute Metrics via Expressions\n'                                                               -->
-        <!--    'SELECT\n'                                                                                           -->
-        <!--    '  subq_14.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
-        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                     -->
-        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                 -->
-        <!--    'LEFT OUTER JOIN (\n'                                                                                -->
-        <!--    '  -- Join Standard Outputs\n'                                                                       -->
-        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"     -->
-        <!--    '  SELECT\n'                                                                                         -->
-        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"              -->
-        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                            -->
-        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                       -->
-        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                           -->
-        <!--    '  LEFT OUTER JOIN\n'                                                                                -->
-        <!--    '    ***************************.customer_table customer_table_src_22000\n'                          -->
-        <!--    '  ON\n'                                                                                             -->
-        <!--    '    (\n'                                                                                            -->
-        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                  -->
-        <!--    '    ) AND (\n'                                                                                      -->
-        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "                -->
-        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                         -->
-        <!--    '    )\n'                                                                                            -->
-        <!--    ') subq_14\n'                                                                                        -->
-        <!--    'ON\n'                                                                                               -->
-        <!--    '  (\n'                                                                                              -->
-        <!--    '    account_month_txns_src_22000.account_id = subq_14.account_id\n'                                 -->
-        <!--    '  ) AND (\n'                                                                                        -->
-        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_14.ds_partitioned__day\n" -->
-        <!--    '  )\n'                                                                                              -->
-        <!--    'GROUP BY\n'                                                                                         -->
-        <!--    '  subq_14.customer_id__customer_name')                                                              -->
+        <!-- sql_query =                                                                                            -->
+        <!--   ('-- Join Standard Outputs\n'                                                                        -->
+        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                  -->
+        <!--    '-- Aggregate Measures\n'                                                                           -->
+        <!--    '-- Compute Metrics via Expressions\n'                                                              -->
+        <!--    'SELECT\n'                                                                                          -->
+        <!--    '  subq_9.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
+        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                    -->
+        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                -->
+        <!--    'LEFT OUTER JOIN (\n'                                                                               -->
+        <!--    '  -- Join Standard Outputs\n'                                                                      -->
+        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"    -->
+        <!--    '  SELECT\n'                                                                                        -->
+        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"             -->
+        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                           -->
+        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                      -->
+        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                          -->
+        <!--    '  LEFT OUTER JOIN\n'                                                                               -->
+        <!--    '    ***************************.customer_table customer_table_src_22000\n'                         -->
+        <!--    '  ON\n'                                                                                            -->
+        <!--    '    (\n'                                                                                           -->
+        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                 -->
+        <!--    '    ) AND (\n'                                                                                     -->
+        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "               -->
+        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                        -->
+        <!--    '    )\n'                                                                                           -->
+        <!--    ') subq_9\n'                                                                                        -->
+        <!--    'ON\n'                                                                                              -->
+        <!--    '  (\n'                                                                                             -->
+        <!--    '    account_month_txns_src_22000.account_id = subq_9.account_id\n'                                 -->
+        <!--    '  ) AND (\n'                                                                                       -->
+        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_9.ds_partitioned__day\n" -->
+        <!--    '  )\n'                                                                                             -->
+        <!--    'GROUP BY\n'                                                                                        -->
+        <!--    '  subq_9.customer_id__customer_name')                                                              -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_multihop_joined_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_multihop_joined_plan__ep_0.xml
@@ -2,40 +2,40 @@
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                                             -->
-        <!--   ('-- Join Standard Outputs\n'                                                                         -->
-        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                   -->
-        <!--    '-- Aggregate Measures\n'                                                                            -->
-        <!--    '-- Compute Metrics via Expressions\n'                                                               -->
-        <!--    'SELECT\n'                                                                                           -->
-        <!--    '  subq_14.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
-        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                     -->
-        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                 -->
-        <!--    'LEFT OUTER JOIN (\n'                                                                                -->
-        <!--    '  -- Join Standard Outputs\n'                                                                       -->
-        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"     -->
-        <!--    '  SELECT\n'                                                                                         -->
-        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"              -->
-        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                            -->
-        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                       -->
-        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                           -->
-        <!--    '  LEFT OUTER JOIN\n'                                                                                -->
-        <!--    '    ***************************.customer_table customer_table_src_22000\n'                          -->
-        <!--    '  ON\n'                                                                                             -->
-        <!--    '    (\n'                                                                                            -->
-        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                  -->
-        <!--    '    ) AND (\n'                                                                                      -->
-        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "                -->
-        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                         -->
-        <!--    '    )\n'                                                                                            -->
-        <!--    ') subq_14\n'                                                                                        -->
-        <!--    'ON\n'                                                                                               -->
-        <!--    '  (\n'                                                                                              -->
-        <!--    '    account_month_txns_src_22000.account_id = subq_14.account_id\n'                                 -->
-        <!--    '  ) AND (\n'                                                                                        -->
-        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_14.ds_partitioned__day\n" -->
-        <!--    '  )\n'                                                                                              -->
-        <!--    'GROUP BY\n'                                                                                         -->
-        <!--    '  subq_14.customer_id__customer_name')                                                              -->
+        <!-- sql_query =                                                                                            -->
+        <!--   ('-- Join Standard Outputs\n'                                                                        -->
+        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                  -->
+        <!--    '-- Aggregate Measures\n'                                                                           -->
+        <!--    '-- Compute Metrics via Expressions\n'                                                              -->
+        <!--    'SELECT\n'                                                                                          -->
+        <!--    '  subq_9.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
+        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                    -->
+        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                -->
+        <!--    'LEFT OUTER JOIN (\n'                                                                               -->
+        <!--    '  -- Join Standard Outputs\n'                                                                      -->
+        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"    -->
+        <!--    '  SELECT\n'                                                                                        -->
+        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"             -->
+        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                           -->
+        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                      -->
+        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                          -->
+        <!--    '  LEFT OUTER JOIN\n'                                                                               -->
+        <!--    '    ***************************.customer_table customer_table_src_22000\n'                         -->
+        <!--    '  ON\n'                                                                                            -->
+        <!--    '    (\n'                                                                                           -->
+        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                 -->
+        <!--    '    ) AND (\n'                                                                                     -->
+        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "               -->
+        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                        -->
+        <!--    '    )\n'                                                                                           -->
+        <!--    ') subq_9\n'                                                                                        -->
+        <!--    'ON\n'                                                                                              -->
+        <!--    '  (\n'                                                                                             -->
+        <!--    '    account_month_txns_src_22000.account_id = subq_9.account_id\n'                                 -->
+        <!--    '  ) AND (\n'                                                                                       -->
+        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_9.ds_partitioned__day\n" -->
+        <!--    '  )\n'                                                                                             -->
+        <!--    'GROUP BY\n'                                                                                        -->
+        <!--    '  subq_9.customer_id__customer_name')                                                              -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_multihop_joined_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_multihop_joined_plan__ep_0.xml
@@ -2,40 +2,40 @@
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                                             -->
-        <!--   ('-- Join Standard Outputs\n'                                                                         -->
-        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                   -->
-        <!--    '-- Aggregate Measures\n'                                                                            -->
-        <!--    '-- Compute Metrics via Expressions\n'                                                               -->
-        <!--    'SELECT\n'                                                                                           -->
-        <!--    '  subq_14.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
-        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                     -->
-        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                 -->
-        <!--    'LEFT OUTER JOIN (\n'                                                                                -->
-        <!--    '  -- Join Standard Outputs\n'                                                                       -->
-        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"     -->
-        <!--    '  SELECT\n'                                                                                         -->
-        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"              -->
-        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                            -->
-        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                       -->
-        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                           -->
-        <!--    '  LEFT OUTER JOIN\n'                                                                                -->
-        <!--    '    ***************************.customer_table customer_table_src_22000\n'                          -->
-        <!--    '  ON\n'                                                                                             -->
-        <!--    '    (\n'                                                                                            -->
-        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                  -->
-        <!--    '    ) AND (\n'                                                                                      -->
-        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "                -->
-        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                         -->
-        <!--    '    )\n'                                                                                            -->
-        <!--    ') subq_14\n'                                                                                        -->
-        <!--    'ON\n'                                                                                               -->
-        <!--    '  (\n'                                                                                              -->
-        <!--    '    account_month_txns_src_22000.account_id = subq_14.account_id\n'                                 -->
-        <!--    '  ) AND (\n'                                                                                        -->
-        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_14.ds_partitioned__day\n" -->
-        <!--    '  )\n'                                                                                              -->
-        <!--    'GROUP BY\n'                                                                                         -->
-        <!--    '  subq_14.customer_id__customer_name')                                                              -->
+        <!-- sql_query =                                                                                            -->
+        <!--   ('-- Join Standard Outputs\n'                                                                        -->
+        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                  -->
+        <!--    '-- Aggregate Measures\n'                                                                           -->
+        <!--    '-- Compute Metrics via Expressions\n'                                                              -->
+        <!--    'SELECT\n'                                                                                          -->
+        <!--    '  subq_9.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
+        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                    -->
+        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                -->
+        <!--    'LEFT OUTER JOIN (\n'                                                                               -->
+        <!--    '  -- Join Standard Outputs\n'                                                                      -->
+        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"    -->
+        <!--    '  SELECT\n'                                                                                        -->
+        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"             -->
+        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                           -->
+        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                      -->
+        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                          -->
+        <!--    '  LEFT OUTER JOIN\n'                                                                               -->
+        <!--    '    ***************************.customer_table customer_table_src_22000\n'                         -->
+        <!--    '  ON\n'                                                                                            -->
+        <!--    '    (\n'                                                                                           -->
+        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                 -->
+        <!--    '    ) AND (\n'                                                                                     -->
+        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "               -->
+        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                        -->
+        <!--    '    )\n'                                                                                           -->
+        <!--    ') subq_9\n'                                                                                        -->
+        <!--    'ON\n'                                                                                              -->
+        <!--    '  (\n'                                                                                             -->
+        <!--    '    account_month_txns_src_22000.account_id = subq_9.account_id\n'                                 -->
+        <!--    '  ) AND (\n'                                                                                       -->
+        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_9.ds_partitioned__day\n" -->
+        <!--    '  )\n'                                                                                             -->
+        <!--    'GROUP BY\n'                                                                                        -->
+        <!--    '  subq_9.customer_id__customer_name')                                                              -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_multihop_joined_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_multihop_joined_plan__ep_0.xml
@@ -2,40 +2,40 @@
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                                             -->
-        <!--   ('-- Join Standard Outputs\n'                                                                         -->
-        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                   -->
-        <!--    '-- Aggregate Measures\n'                                                                            -->
-        <!--    '-- Compute Metrics via Expressions\n'                                                               -->
-        <!--    'SELECT\n'                                                                                           -->
-        <!--    '  subq_14.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
-        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                     -->
-        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                 -->
-        <!--    'LEFT OUTER JOIN (\n'                                                                                -->
-        <!--    '  -- Join Standard Outputs\n'                                                                       -->
-        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"     -->
-        <!--    '  SELECT\n'                                                                                         -->
-        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"              -->
-        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                            -->
-        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                       -->
-        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                           -->
-        <!--    '  LEFT OUTER JOIN\n'                                                                                -->
-        <!--    '    ***************************.customer_table customer_table_src_22000\n'                          -->
-        <!--    '  ON\n'                                                                                             -->
-        <!--    '    (\n'                                                                                            -->
-        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                  -->
-        <!--    '    ) AND (\n'                                                                                      -->
-        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "                -->
-        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                         -->
-        <!--    '    )\n'                                                                                            -->
-        <!--    ') subq_14\n'                                                                                        -->
-        <!--    'ON\n'                                                                                               -->
-        <!--    '  (\n'                                                                                              -->
-        <!--    '    account_month_txns_src_22000.account_id = subq_14.account_id\n'                                 -->
-        <!--    '  ) AND (\n'                                                                                        -->
-        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_14.ds_partitioned__day\n" -->
-        <!--    '  )\n'                                                                                              -->
-        <!--    'GROUP BY\n'                                                                                         -->
-        <!--    '  subq_14.customer_id__customer_name')                                                              -->
+        <!-- sql_query =                                                                                            -->
+        <!--   ('-- Join Standard Outputs\n'                                                                        -->
+        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                  -->
+        <!--    '-- Aggregate Measures\n'                                                                           -->
+        <!--    '-- Compute Metrics via Expressions\n'                                                              -->
+        <!--    'SELECT\n'                                                                                          -->
+        <!--    '  subq_9.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
+        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                    -->
+        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                -->
+        <!--    'LEFT OUTER JOIN (\n'                                                                               -->
+        <!--    '  -- Join Standard Outputs\n'                                                                      -->
+        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"    -->
+        <!--    '  SELECT\n'                                                                                        -->
+        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"             -->
+        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                           -->
+        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                      -->
+        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                          -->
+        <!--    '  LEFT OUTER JOIN\n'                                                                               -->
+        <!--    '    ***************************.customer_table customer_table_src_22000\n'                         -->
+        <!--    '  ON\n'                                                                                            -->
+        <!--    '    (\n'                                                                                           -->
+        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                 -->
+        <!--    '    ) AND (\n'                                                                                     -->
+        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "               -->
+        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                        -->
+        <!--    '    )\n'                                                                                           -->
+        <!--    ') subq_9\n'                                                                                        -->
+        <!--    'ON\n'                                                                                              -->
+        <!--    '  (\n'                                                                                             -->
+        <!--    '    account_month_txns_src_22000.account_id = subq_9.account_id\n'                                 -->
+        <!--    '  ) AND (\n'                                                                                       -->
+        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_9.ds_partitioned__day\n" -->
+        <!--    '  )\n'                                                                                             -->
+        <!--    'GROUP BY\n'                                                                                        -->
+        <!--    '  subq_9.customer_id__customer_name')                                                              -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_multihop_joined_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_multihop_joined_plan__ep_0.xml
@@ -2,40 +2,40 @@
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                                             -->
-        <!--   ('-- Join Standard Outputs\n'                                                                         -->
-        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                   -->
-        <!--    '-- Aggregate Measures\n'                                                                            -->
-        <!--    '-- Compute Metrics via Expressions\n'                                                               -->
-        <!--    'SELECT\n'                                                                                           -->
-        <!--    '  subq_14.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
-        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                     -->
-        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                 -->
-        <!--    'LEFT OUTER JOIN (\n'                                                                                -->
-        <!--    '  -- Join Standard Outputs\n'                                                                       -->
-        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"     -->
-        <!--    '  SELECT\n'                                                                                         -->
-        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"              -->
-        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                            -->
-        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                       -->
-        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                           -->
-        <!--    '  LEFT OUTER JOIN\n'                                                                                -->
-        <!--    '    ***************************.customer_table customer_table_src_22000\n'                          -->
-        <!--    '  ON\n'                                                                                             -->
-        <!--    '    (\n'                                                                                            -->
-        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                  -->
-        <!--    '    ) AND (\n'                                                                                      -->
-        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "                -->
-        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                         -->
-        <!--    '    )\n'                                                                                            -->
-        <!--    ') subq_14\n'                                                                                        -->
-        <!--    'ON\n'                                                                                               -->
-        <!--    '  (\n'                                                                                              -->
-        <!--    '    account_month_txns_src_22000.account_id = subq_14.account_id\n'                                 -->
-        <!--    '  ) AND (\n'                                                                                        -->
-        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_14.ds_partitioned__day\n" -->
-        <!--    '  )\n'                                                                                              -->
-        <!--    'GROUP BY\n'                                                                                         -->
-        <!--    '  subq_14.customer_id__customer_name')                                                              -->
+        <!-- sql_query =                                                                                            -->
+        <!--   ('-- Join Standard Outputs\n'                                                                        -->
+        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                  -->
+        <!--    '-- Aggregate Measures\n'                                                                           -->
+        <!--    '-- Compute Metrics via Expressions\n'                                                              -->
+        <!--    'SELECT\n'                                                                                          -->
+        <!--    '  subq_9.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
+        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                    -->
+        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                -->
+        <!--    'LEFT OUTER JOIN (\n'                                                                               -->
+        <!--    '  -- Join Standard Outputs\n'                                                                      -->
+        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"    -->
+        <!--    '  SELECT\n'                                                                                        -->
+        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"             -->
+        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                           -->
+        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                      -->
+        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                          -->
+        <!--    '  LEFT OUTER JOIN\n'                                                                               -->
+        <!--    '    ***************************.customer_table customer_table_src_22000\n'                         -->
+        <!--    '  ON\n'                                                                                            -->
+        <!--    '    (\n'                                                                                           -->
+        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                 -->
+        <!--    '    ) AND (\n'                                                                                     -->
+        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "               -->
+        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                        -->
+        <!--    '    )\n'                                                                                           -->
+        <!--    ') subq_9\n'                                                                                        -->
+        <!--    'ON\n'                                                                                              -->
+        <!--    '  (\n'                                                                                             -->
+        <!--    '    account_month_txns_src_22000.account_id = subq_9.account_id\n'                                 -->
+        <!--    '  ) AND (\n'                                                                                       -->
+        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_9.ds_partitioned__day\n" -->
+        <!--    '  )\n'                                                                                             -->
+        <!--    'GROUP BY\n'                                                                                        -->
+        <!--    '  subq_9.customer_id__customer_name')                                                              -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Trino/test_multihop_joined_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Trino/test_multihop_joined_plan__ep_0.xml
@@ -2,40 +2,40 @@
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                                             -->
-        <!--   ('-- Join Standard Outputs\n'                                                                         -->
-        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                   -->
-        <!--    '-- Aggregate Measures\n'                                                                            -->
-        <!--    '-- Compute Metrics via Expressions\n'                                                               -->
-        <!--    'SELECT\n'                                                                                           -->
-        <!--    '  subq_14.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
-        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                     -->
-        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                 -->
-        <!--    'LEFT OUTER JOIN (\n'                                                                                -->
-        <!--    '  -- Join Standard Outputs\n'                                                                       -->
-        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"     -->
-        <!--    '  SELECT\n'                                                                                         -->
-        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"              -->
-        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                            -->
-        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                       -->
-        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                           -->
-        <!--    '  LEFT OUTER JOIN\n'                                                                                -->
-        <!--    '    ***************************.customer_table customer_table_src_22000\n'                          -->
-        <!--    '  ON\n'                                                                                             -->
-        <!--    '    (\n'                                                                                            -->
-        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                  -->
-        <!--    '    ) AND (\n'                                                                                      -->
-        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "                -->
-        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                         -->
-        <!--    '    )\n'                                                                                            -->
-        <!--    ') subq_14\n'                                                                                        -->
-        <!--    'ON\n'                                                                                               -->
-        <!--    '  (\n'                                                                                              -->
-        <!--    '    account_month_txns_src_22000.account_id = subq_14.account_id\n'                                 -->
-        <!--    '  ) AND (\n'                                                                                        -->
-        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_14.ds_partitioned__day\n" -->
-        <!--    '  )\n'                                                                                              -->
-        <!--    'GROUP BY\n'                                                                                         -->
-        <!--    '  subq_14.customer_id__customer_name')                                                              -->
+        <!-- sql_query =                                                                                            -->
+        <!--   ('-- Join Standard Outputs\n'                                                                        -->
+        <!--    "-- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']\n"                  -->
+        <!--    '-- Aggregate Measures\n'                                                                           -->
+        <!--    '-- Compute Metrics via Expressions\n'                                                              -->
+        <!--    'SELECT\n'                                                                                          -->
+        <!--    '  subq_9.customer_id__customer_name AS account_id__customer_id__customer_name\n'                   -->
+        <!--    '  , SUM(account_month_txns_src_22000.txn_count) AS txn_count\n'                                    -->
+        <!--    'FROM ***************************.account_month_txns account_month_txns_src_22000\n'                -->
+        <!--    'LEFT OUTER JOIN (\n'                                                                               -->
+        <!--    '  -- Join Standard Outputs\n'                                                                      -->
+        <!--    "  -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']\n"    -->
+        <!--    '  SELECT\n'                                                                                        -->
+        <!--    "    DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) AS ds_partitioned__day\n"             -->
+        <!--    '    , bridge_table_src_22000.account_id AS account_id\n'                                           -->
+        <!--    '    , customer_table_src_22000.customer_name AS customer_id__customer_name\n'                      -->
+        <!--    '  FROM ***************************.bridge_table bridge_table_src_22000\n'                          -->
+        <!--    '  LEFT OUTER JOIN\n'                                                                               -->
+        <!--    '    ***************************.customer_table customer_table_src_22000\n'                         -->
+        <!--    '  ON\n'                                                                                            -->
+        <!--    '    (\n'                                                                                           -->
+        <!--    '      bridge_table_src_22000.customer_id = customer_table_src_22000.customer_id\n'                 -->
+        <!--    '    ) AND (\n'                                                                                     -->
+        <!--    "      DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', "               -->
+        <!--    'customer_table_src_22000.ds_partitioned)\n'                                                        -->
+        <!--    '    )\n'                                                                                           -->
+        <!--    ') subq_9\n'                                                                                        -->
+        <!--    'ON\n'                                                                                              -->
+        <!--    '  (\n'                                                                                             -->
+        <!--    '    account_month_txns_src_22000.account_id = subq_9.account_id\n'                                 -->
+        <!--    '  ) AND (\n'                                                                                       -->
+        <!--    "    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_9.ds_partitioned__day\n" -->
+        <!--    '  )\n'                                                                                             -->
+        <!--    'GROUP BY\n'                                                                                        -->
+        <!--    '  subq_9.customer_id__customer_name')                                                              -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0.sql
@@ -8,248 +8,248 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_18.average_booking_value) AS average_booking_value
-      , MAX(subq_31.bookings) AS bookings
-      , MAX(subq_39.booking_value) AS booking_value
+      MAX(subq_12.average_booking_value) AS average_booking_value
+      , MAX(subq_25.bookings) AS bookings
+      , MAX(subq_33.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.average_booking_value
+        subq_11.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_16.average_booking_value) AS average_booking_value
+          AVG(subq_10.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_15.average_booking_value
+            subq_9.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.booking__is_instant
-              , subq_14.listing__is_lux_latest
-              , subq_14.average_booking_value
+              subq_8.booking__is_instant
+              , subq_8.listing__is_lux_latest
+              , subq_8.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_13.booking__is_instant
-                , subq_13.listing__is_lux_latest
-                , subq_13.average_booking_value
+                subq_7.booking__is_instant
+                , subq_7.listing__is_lux_latest
+                , subq_7.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_9.listing AS listing
-                  , subq_9.booking__is_instant AS booking__is_instant
-                  , subq_12.is_lux_latest AS listing__is_lux_latest
-                  , subq_9.average_booking_value AS average_booking_value
+                  subq_3.listing AS listing
+                  , subq_3.booking__is_instant AS booking__is_instant
+                  , subq_6.is_lux_latest AS listing__is_lux_latest
+                  , subq_3.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.booking__is_instant
-                    , subq_8.average_booking_value
+                    subq_2.listing
+                    , subq_2.booking__is_instant
+                    , subq_2.average_booking_value
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.metric_time__day
-                      , subq_7.metric_time__week
-                      , subq_7.metric_time__month
-                      , subq_7.metric_time__quarter
-                      , subq_7.metric_time__year
-                      , subq_7.metric_time__extract_year
-                      , subq_7.metric_time__extract_quarter
-                      , subq_7.metric_time__extract_month
-                      , subq_7.metric_time__extract_day
-                      , subq_7.metric_time__extract_dow
-                      , subq_7.metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_1.ds__day
+                      , subq_1.ds__week
+                      , subq_1.ds__month
+                      , subq_1.ds__quarter
+                      , subq_1.ds__year
+                      , subq_1.ds__extract_year
+                      , subq_1.ds__extract_quarter
+                      , subq_1.ds__extract_month
+                      , subq_1.ds__extract_day
+                      , subq_1.ds__extract_dow
+                      , subq_1.ds__extract_doy
+                      , subq_1.ds_partitioned__day
+                      , subq_1.ds_partitioned__week
+                      , subq_1.ds_partitioned__month
+                      , subq_1.ds_partitioned__quarter
+                      , subq_1.ds_partitioned__year
+                      , subq_1.ds_partitioned__extract_year
+                      , subq_1.ds_partitioned__extract_quarter
+                      , subq_1.ds_partitioned__extract_month
+                      , subq_1.ds_partitioned__extract_day
+                      , subq_1.ds_partitioned__extract_dow
+                      , subq_1.ds_partitioned__extract_doy
+                      , subq_1.paid_at__day
+                      , subq_1.paid_at__week
+                      , subq_1.paid_at__month
+                      , subq_1.paid_at__quarter
+                      , subq_1.paid_at__year
+                      , subq_1.paid_at__extract_year
+                      , subq_1.paid_at__extract_quarter
+                      , subq_1.paid_at__extract_month
+                      , subq_1.paid_at__extract_day
+                      , subq_1.paid_at__extract_dow
+                      , subq_1.paid_at__extract_doy
+                      , subq_1.booking__ds__day
+                      , subq_1.booking__ds__week
+                      , subq_1.booking__ds__month
+                      , subq_1.booking__ds__quarter
+                      , subq_1.booking__ds__year
+                      , subq_1.booking__ds__extract_year
+                      , subq_1.booking__ds__extract_quarter
+                      , subq_1.booking__ds__extract_month
+                      , subq_1.booking__ds__extract_day
+                      , subq_1.booking__ds__extract_dow
+                      , subq_1.booking__ds__extract_doy
+                      , subq_1.booking__ds_partitioned__day
+                      , subq_1.booking__ds_partitioned__week
+                      , subq_1.booking__ds_partitioned__month
+                      , subq_1.booking__ds_partitioned__quarter
+                      , subq_1.booking__ds_partitioned__year
+                      , subq_1.booking__ds_partitioned__extract_year
+                      , subq_1.booking__ds_partitioned__extract_quarter
+                      , subq_1.booking__ds_partitioned__extract_month
+                      , subq_1.booking__ds_partitioned__extract_day
+                      , subq_1.booking__ds_partitioned__extract_dow
+                      , subq_1.booking__ds_partitioned__extract_doy
+                      , subq_1.booking__paid_at__day
+                      , subq_1.booking__paid_at__week
+                      , subq_1.booking__paid_at__month
+                      , subq_1.booking__paid_at__quarter
+                      , subq_1.booking__paid_at__year
+                      , subq_1.booking__paid_at__extract_year
+                      , subq_1.booking__paid_at__extract_quarter
+                      , subq_1.booking__paid_at__extract_month
+                      , subq_1.booking__paid_at__extract_day
+                      , subq_1.booking__paid_at__extract_dow
+                      , subq_1.booking__paid_at__extract_doy
+                      , subq_1.metric_time__day
+                      , subq_1.metric_time__week
+                      , subq_1.metric_time__month
+                      , subq_1.metric_time__quarter
+                      , subq_1.metric_time__year
+                      , subq_1.metric_time__extract_year
+                      , subq_1.metric_time__extract_quarter
+                      , subq_1.metric_time__extract_month
+                      , subq_1.metric_time__extract_day
+                      , subq_1.metric_time__extract_dow
+                      , subq_1.metric_time__extract_doy
+                      , subq_1.listing
+                      , subq_1.guest
+                      , subq_1.host
+                      , subq_1.booking__listing
+                      , subq_1.booking__guest
+                      , subq_1.booking__host
+                      , subq_1.is_instant
+                      , subq_1.booking__is_instant
+                      , subq_1.bookings
+                      , subq_1.instant_bookings
+                      , subq_1.booking_value
+                      , subq_1.max_booking_value
+                      , subq_1.min_booking_value
+                      , subq_1.bookers
+                      , subq_1.average_booking_value
+                      , subq_1.referred_bookings
+                      , subq_1.median_booking_value
+                      , subq_1.booking_value_p99
+                      , subq_1.discrete_booking_value_p99
+                      , subq_1.approximate_continuous_booking_value_p99
+                      , subq_1.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_6.ds__day
-                        , subq_6.ds__week
-                        , subq_6.ds__month
-                        , subq_6.ds__quarter
-                        , subq_6.ds__year
-                        , subq_6.ds__extract_year
-                        , subq_6.ds__extract_quarter
-                        , subq_6.ds__extract_month
-                        , subq_6.ds__extract_day
-                        , subq_6.ds__extract_dow
-                        , subq_6.ds__extract_doy
-                        , subq_6.ds_partitioned__day
-                        , subq_6.ds_partitioned__week
-                        , subq_6.ds_partitioned__month
-                        , subq_6.ds_partitioned__quarter
-                        , subq_6.ds_partitioned__year
-                        , subq_6.ds_partitioned__extract_year
-                        , subq_6.ds_partitioned__extract_quarter
-                        , subq_6.ds_partitioned__extract_month
-                        , subq_6.ds_partitioned__extract_day
-                        , subq_6.ds_partitioned__extract_dow
-                        , subq_6.ds_partitioned__extract_doy
-                        , subq_6.paid_at__day
-                        , subq_6.paid_at__week
-                        , subq_6.paid_at__month
-                        , subq_6.paid_at__quarter
-                        , subq_6.paid_at__year
-                        , subq_6.paid_at__extract_year
-                        , subq_6.paid_at__extract_quarter
-                        , subq_6.paid_at__extract_month
-                        , subq_6.paid_at__extract_day
-                        , subq_6.paid_at__extract_dow
-                        , subq_6.paid_at__extract_doy
-                        , subq_6.booking__ds__day
-                        , subq_6.booking__ds__week
-                        , subq_6.booking__ds__month
-                        , subq_6.booking__ds__quarter
-                        , subq_6.booking__ds__year
-                        , subq_6.booking__ds__extract_year
-                        , subq_6.booking__ds__extract_quarter
-                        , subq_6.booking__ds__extract_month
-                        , subq_6.booking__ds__extract_day
-                        , subq_6.booking__ds__extract_dow
-                        , subq_6.booking__ds__extract_doy
-                        , subq_6.booking__ds_partitioned__day
-                        , subq_6.booking__ds_partitioned__week
-                        , subq_6.booking__ds_partitioned__month
-                        , subq_6.booking__ds_partitioned__quarter
-                        , subq_6.booking__ds_partitioned__year
-                        , subq_6.booking__ds_partitioned__extract_year
-                        , subq_6.booking__ds_partitioned__extract_quarter
-                        , subq_6.booking__ds_partitioned__extract_month
-                        , subq_6.booking__ds_partitioned__extract_day
-                        , subq_6.booking__ds_partitioned__extract_dow
-                        , subq_6.booking__ds_partitioned__extract_doy
-                        , subq_6.booking__paid_at__day
-                        , subq_6.booking__paid_at__week
-                        , subq_6.booking__paid_at__month
-                        , subq_6.booking__paid_at__quarter
-                        , subq_6.booking__paid_at__year
-                        , subq_6.booking__paid_at__extract_year
-                        , subq_6.booking__paid_at__extract_quarter
-                        , subq_6.booking__paid_at__extract_month
-                        , subq_6.booking__paid_at__extract_day
-                        , subq_6.booking__paid_at__extract_dow
-                        , subq_6.booking__paid_at__extract_doy
-                        , subq_6.ds__day AS metric_time__day
-                        , subq_6.ds__week AS metric_time__week
-                        , subq_6.ds__month AS metric_time__month
-                        , subq_6.ds__quarter AS metric_time__quarter
-                        , subq_6.ds__year AS metric_time__year
-                        , subq_6.ds__extract_year AS metric_time__extract_year
-                        , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_6.ds__extract_month AS metric_time__extract_month
-                        , subq_6.ds__extract_day AS metric_time__extract_day
-                        , subq_6.ds__extract_dow AS metric_time__extract_dow
-                        , subq_6.ds__extract_doy AS metric_time__extract_doy
-                        , subq_6.listing
-                        , subq_6.guest
-                        , subq_6.host
-                        , subq_6.booking__listing
-                        , subq_6.booking__guest
-                        , subq_6.booking__host
-                        , subq_6.is_instant
-                        , subq_6.booking__is_instant
-                        , subq_6.bookings
-                        , subq_6.instant_bookings
-                        , subq_6.booking_value
-                        , subq_6.max_booking_value
-                        , subq_6.min_booking_value
-                        , subq_6.bookers
-                        , subq_6.average_booking_value
-                        , subq_6.referred_bookings
-                        , subq_6.median_booking_value
-                        , subq_6.booking_value_p99
-                        , subq_6.discrete_booking_value_p99
-                        , subq_6.approximate_continuous_booking_value_p99
-                        , subq_6.approximate_discrete_booking_value_p99
+                        subq_0.ds__day
+                        , subq_0.ds__week
+                        , subq_0.ds__month
+                        , subq_0.ds__quarter
+                        , subq_0.ds__year
+                        , subq_0.ds__extract_year
+                        , subq_0.ds__extract_quarter
+                        , subq_0.ds__extract_month
+                        , subq_0.ds__extract_day
+                        , subq_0.ds__extract_dow
+                        , subq_0.ds__extract_doy
+                        , subq_0.ds_partitioned__day
+                        , subq_0.ds_partitioned__week
+                        , subq_0.ds_partitioned__month
+                        , subq_0.ds_partitioned__quarter
+                        , subq_0.ds_partitioned__year
+                        , subq_0.ds_partitioned__extract_year
+                        , subq_0.ds_partitioned__extract_quarter
+                        , subq_0.ds_partitioned__extract_month
+                        , subq_0.ds_partitioned__extract_day
+                        , subq_0.ds_partitioned__extract_dow
+                        , subq_0.ds_partitioned__extract_doy
+                        , subq_0.paid_at__day
+                        , subq_0.paid_at__week
+                        , subq_0.paid_at__month
+                        , subq_0.paid_at__quarter
+                        , subq_0.paid_at__year
+                        , subq_0.paid_at__extract_year
+                        , subq_0.paid_at__extract_quarter
+                        , subq_0.paid_at__extract_month
+                        , subq_0.paid_at__extract_day
+                        , subq_0.paid_at__extract_dow
+                        , subq_0.paid_at__extract_doy
+                        , subq_0.booking__ds__day
+                        , subq_0.booking__ds__week
+                        , subq_0.booking__ds__month
+                        , subq_0.booking__ds__quarter
+                        , subq_0.booking__ds__year
+                        , subq_0.booking__ds__extract_year
+                        , subq_0.booking__ds__extract_quarter
+                        , subq_0.booking__ds__extract_month
+                        , subq_0.booking__ds__extract_day
+                        , subq_0.booking__ds__extract_dow
+                        , subq_0.booking__ds__extract_doy
+                        , subq_0.booking__ds_partitioned__day
+                        , subq_0.booking__ds_partitioned__week
+                        , subq_0.booking__ds_partitioned__month
+                        , subq_0.booking__ds_partitioned__quarter
+                        , subq_0.booking__ds_partitioned__year
+                        , subq_0.booking__ds_partitioned__extract_year
+                        , subq_0.booking__ds_partitioned__extract_quarter
+                        , subq_0.booking__ds_partitioned__extract_month
+                        , subq_0.booking__ds_partitioned__extract_day
+                        , subq_0.booking__ds_partitioned__extract_dow
+                        , subq_0.booking__ds_partitioned__extract_doy
+                        , subq_0.booking__paid_at__day
+                        , subq_0.booking__paid_at__week
+                        , subq_0.booking__paid_at__month
+                        , subq_0.booking__paid_at__quarter
+                        , subq_0.booking__paid_at__year
+                        , subq_0.booking__paid_at__extract_year
+                        , subq_0.booking__paid_at__extract_quarter
+                        , subq_0.booking__paid_at__extract_month
+                        , subq_0.booking__paid_at__extract_day
+                        , subq_0.booking__paid_at__extract_dow
+                        , subq_0.booking__paid_at__extract_doy
+                        , subq_0.ds__day AS metric_time__day
+                        , subq_0.ds__week AS metric_time__week
+                        , subq_0.ds__month AS metric_time__month
+                        , subq_0.ds__quarter AS metric_time__quarter
+                        , subq_0.ds__year AS metric_time__year
+                        , subq_0.ds__extract_year AS metric_time__extract_year
+                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_0.ds__extract_month AS metric_time__extract_month
+                        , subq_0.ds__extract_day AS metric_time__extract_day
+                        , subq_0.ds__extract_dow AS metric_time__extract_dow
+                        , subq_0.ds__extract_doy AS metric_time__extract_doy
+                        , subq_0.listing
+                        , subq_0.guest
+                        , subq_0.host
+                        , subq_0.booking__listing
+                        , subq_0.booking__guest
+                        , subq_0.booking__host
+                        , subq_0.is_instant
+                        , subq_0.booking__is_instant
+                        , subq_0.bookings
+                        , subq_0.instant_bookings
+                        , subq_0.booking_value
+                        , subq_0.max_booking_value
+                        , subq_0.min_booking_value
+                        , subq_0.bookers
+                        , subq_0.average_booking_value
+                        , subq_0.referred_bookings
+                        , subq_0.median_booking_value
+                        , subq_0.booking_value_p99
+                        , subq_0.discrete_booking_value_p99
+                        , subq_0.approximate_continuous_booking_value_p99
+                        , subq_0.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -342,86 +342,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_6
-                    ) subq_7
+                      ) subq_0
+                    ) subq_1
                     WHERE booking__is_instant
-                  ) subq_8
-                ) subq_9
+                  ) subq_2
+                ) subq_3
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_11.listing
-                    , subq_11.is_lux_latest
+                    subq_5.listing
+                    , subq_5.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_10.ds__day
-                      , subq_10.ds__week
-                      , subq_10.ds__month
-                      , subq_10.ds__quarter
-                      , subq_10.ds__year
-                      , subq_10.ds__extract_year
-                      , subq_10.ds__extract_quarter
-                      , subq_10.ds__extract_month
-                      , subq_10.ds__extract_day
-                      , subq_10.ds__extract_dow
-                      , subq_10.ds__extract_doy
-                      , subq_10.created_at__day
-                      , subq_10.created_at__week
-                      , subq_10.created_at__month
-                      , subq_10.created_at__quarter
-                      , subq_10.created_at__year
-                      , subq_10.created_at__extract_year
-                      , subq_10.created_at__extract_quarter
-                      , subq_10.created_at__extract_month
-                      , subq_10.created_at__extract_day
-                      , subq_10.created_at__extract_dow
-                      , subq_10.created_at__extract_doy
-                      , subq_10.listing__ds__day
-                      , subq_10.listing__ds__week
-                      , subq_10.listing__ds__month
-                      , subq_10.listing__ds__quarter
-                      , subq_10.listing__ds__year
-                      , subq_10.listing__ds__extract_year
-                      , subq_10.listing__ds__extract_quarter
-                      , subq_10.listing__ds__extract_month
-                      , subq_10.listing__ds__extract_day
-                      , subq_10.listing__ds__extract_dow
-                      , subq_10.listing__ds__extract_doy
-                      , subq_10.listing__created_at__day
-                      , subq_10.listing__created_at__week
-                      , subq_10.listing__created_at__month
-                      , subq_10.listing__created_at__quarter
-                      , subq_10.listing__created_at__year
-                      , subq_10.listing__created_at__extract_year
-                      , subq_10.listing__created_at__extract_quarter
-                      , subq_10.listing__created_at__extract_month
-                      , subq_10.listing__created_at__extract_day
-                      , subq_10.listing__created_at__extract_dow
-                      , subq_10.listing__created_at__extract_doy
-                      , subq_10.ds__day AS metric_time__day
-                      , subq_10.ds__week AS metric_time__week
-                      , subq_10.ds__month AS metric_time__month
-                      , subq_10.ds__quarter AS metric_time__quarter
-                      , subq_10.ds__year AS metric_time__year
-                      , subq_10.ds__extract_year AS metric_time__extract_year
-                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_10.ds__extract_month AS metric_time__extract_month
-                      , subq_10.ds__extract_day AS metric_time__extract_day
-                      , subq_10.ds__extract_dow AS metric_time__extract_dow
-                      , subq_10.ds__extract_doy AS metric_time__extract_doy
-                      , subq_10.listing
-                      , subq_10.user
-                      , subq_10.listing__user
-                      , subq_10.country_latest
-                      , subq_10.is_lux_latest
-                      , subq_10.capacity_latest
-                      , subq_10.listing__country_latest
-                      , subq_10.listing__is_lux_latest
-                      , subq_10.listing__capacity_latest
-                      , subq_10.listings
-                      , subq_10.largest_listing
-                      , subq_10.smallest_listing
+                      subq_4.ds__day
+                      , subq_4.ds__week
+                      , subq_4.ds__month
+                      , subq_4.ds__quarter
+                      , subq_4.ds__year
+                      , subq_4.ds__extract_year
+                      , subq_4.ds__extract_quarter
+                      , subq_4.ds__extract_month
+                      , subq_4.ds__extract_day
+                      , subq_4.ds__extract_dow
+                      , subq_4.ds__extract_doy
+                      , subq_4.created_at__day
+                      , subq_4.created_at__week
+                      , subq_4.created_at__month
+                      , subq_4.created_at__quarter
+                      , subq_4.created_at__year
+                      , subq_4.created_at__extract_year
+                      , subq_4.created_at__extract_quarter
+                      , subq_4.created_at__extract_month
+                      , subq_4.created_at__extract_day
+                      , subq_4.created_at__extract_dow
+                      , subq_4.created_at__extract_doy
+                      , subq_4.listing__ds__day
+                      , subq_4.listing__ds__week
+                      , subq_4.listing__ds__month
+                      , subq_4.listing__ds__quarter
+                      , subq_4.listing__ds__year
+                      , subq_4.listing__ds__extract_year
+                      , subq_4.listing__ds__extract_quarter
+                      , subq_4.listing__ds__extract_month
+                      , subq_4.listing__ds__extract_day
+                      , subq_4.listing__ds__extract_dow
+                      , subq_4.listing__ds__extract_doy
+                      , subq_4.listing__created_at__day
+                      , subq_4.listing__created_at__week
+                      , subq_4.listing__created_at__month
+                      , subq_4.listing__created_at__quarter
+                      , subq_4.listing__created_at__year
+                      , subq_4.listing__created_at__extract_year
+                      , subq_4.listing__created_at__extract_quarter
+                      , subq_4.listing__created_at__extract_month
+                      , subq_4.listing__created_at__extract_day
+                      , subq_4.listing__created_at__extract_dow
+                      , subq_4.listing__created_at__extract_doy
+                      , subq_4.ds__day AS metric_time__day
+                      , subq_4.ds__week AS metric_time__week
+                      , subq_4.ds__month AS metric_time__month
+                      , subq_4.ds__quarter AS metric_time__quarter
+                      , subq_4.ds__year AS metric_time__year
+                      , subq_4.ds__extract_year AS metric_time__extract_year
+                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_4.ds__extract_month AS metric_time__extract_month
+                      , subq_4.ds__extract_day AS metric_time__extract_day
+                      , subq_4.ds__extract_dow AS metric_time__extract_dow
+                      , subq_4.ds__extract_doy AS metric_time__extract_doy
+                      , subq_4.listing
+                      , subq_4.user
+                      , subq_4.listing__user
+                      , subq_4.country_latest
+                      , subq_4.is_lux_latest
+                      , subq_4.capacity_latest
+                      , subq_4.listing__country_latest
+                      , subq_4.listing__is_lux_latest
+                      , subq_4.listing__capacity_latest
+                      , subq_4.listings
+                      , subq_4.largest_listing
+                      , subq_4.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,257 +482,257 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_10
-                  ) subq_11
-                ) subq_12
+                    ) subq_4
+                  ) subq_5
+                ) subq_6
                 ON
-                  subq_9.listing = subq_12.listing
-              ) subq_13
-            ) subq_14
+                  subq_3.listing = subq_6.listing
+              ) subq_7
+            ) subq_8
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_15
-        ) subq_16
-      ) subq_17
-    ) subq_18
+          ) subq_9
+        ) subq_10
+      ) subq_11
+    ) subq_12
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_30.bookings
+        subq_24.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_29.bookings) AS bookings
+          SUM(subq_23.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_28.bookings
+            subq_22.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_27.booking__is_instant
-              , subq_27.listing__is_lux_latest
-              , subq_27.bookings
+              subq_21.booking__is_instant
+              , subq_21.listing__is_lux_latest
+              , subq_21.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_26.booking__is_instant
-                , subq_26.listing__is_lux_latest
-                , subq_26.bookings
+                subq_20.booking__is_instant
+                , subq_20.listing__is_lux_latest
+                , subq_20.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_22.listing AS listing
-                  , subq_22.booking__is_instant AS booking__is_instant
-                  , subq_25.is_lux_latest AS listing__is_lux_latest
-                  , subq_22.bookings AS bookings
+                  subq_16.listing AS listing
+                  , subq_16.booking__is_instant AS booking__is_instant
+                  , subq_19.is_lux_latest AS listing__is_lux_latest
+                  , subq_16.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_21.listing
-                    , subq_21.booking__is_instant
-                    , subq_21.bookings
+                    subq_15.listing
+                    , subq_15.booking__is_instant
+                    , subq_15.bookings
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_20.ds__day
-                      , subq_20.ds__week
-                      , subq_20.ds__month
-                      , subq_20.ds__quarter
-                      , subq_20.ds__year
-                      , subq_20.ds__extract_year
-                      , subq_20.ds__extract_quarter
-                      , subq_20.ds__extract_month
-                      , subq_20.ds__extract_day
-                      , subq_20.ds__extract_dow
-                      , subq_20.ds__extract_doy
-                      , subq_20.ds_partitioned__day
-                      , subq_20.ds_partitioned__week
-                      , subq_20.ds_partitioned__month
-                      , subq_20.ds_partitioned__quarter
-                      , subq_20.ds_partitioned__year
-                      , subq_20.ds_partitioned__extract_year
-                      , subq_20.ds_partitioned__extract_quarter
-                      , subq_20.ds_partitioned__extract_month
-                      , subq_20.ds_partitioned__extract_day
-                      , subq_20.ds_partitioned__extract_dow
-                      , subq_20.ds_partitioned__extract_doy
-                      , subq_20.paid_at__day
-                      , subq_20.paid_at__week
-                      , subq_20.paid_at__month
-                      , subq_20.paid_at__quarter
-                      , subq_20.paid_at__year
-                      , subq_20.paid_at__extract_year
-                      , subq_20.paid_at__extract_quarter
-                      , subq_20.paid_at__extract_month
-                      , subq_20.paid_at__extract_day
-                      , subq_20.paid_at__extract_dow
-                      , subq_20.paid_at__extract_doy
-                      , subq_20.booking__ds__day
-                      , subq_20.booking__ds__week
-                      , subq_20.booking__ds__month
-                      , subq_20.booking__ds__quarter
-                      , subq_20.booking__ds__year
-                      , subq_20.booking__ds__extract_year
-                      , subq_20.booking__ds__extract_quarter
-                      , subq_20.booking__ds__extract_month
-                      , subq_20.booking__ds__extract_day
-                      , subq_20.booking__ds__extract_dow
-                      , subq_20.booking__ds__extract_doy
-                      , subq_20.booking__ds_partitioned__day
-                      , subq_20.booking__ds_partitioned__week
-                      , subq_20.booking__ds_partitioned__month
-                      , subq_20.booking__ds_partitioned__quarter
-                      , subq_20.booking__ds_partitioned__year
-                      , subq_20.booking__ds_partitioned__extract_year
-                      , subq_20.booking__ds_partitioned__extract_quarter
-                      , subq_20.booking__ds_partitioned__extract_month
-                      , subq_20.booking__ds_partitioned__extract_day
-                      , subq_20.booking__ds_partitioned__extract_dow
-                      , subq_20.booking__ds_partitioned__extract_doy
-                      , subq_20.booking__paid_at__day
-                      , subq_20.booking__paid_at__week
-                      , subq_20.booking__paid_at__month
-                      , subq_20.booking__paid_at__quarter
-                      , subq_20.booking__paid_at__year
-                      , subq_20.booking__paid_at__extract_year
-                      , subq_20.booking__paid_at__extract_quarter
-                      , subq_20.booking__paid_at__extract_month
-                      , subq_20.booking__paid_at__extract_day
-                      , subq_20.booking__paid_at__extract_dow
-                      , subq_20.booking__paid_at__extract_doy
-                      , subq_20.metric_time__day
-                      , subq_20.metric_time__week
-                      , subq_20.metric_time__month
-                      , subq_20.metric_time__quarter
-                      , subq_20.metric_time__year
-                      , subq_20.metric_time__extract_year
-                      , subq_20.metric_time__extract_quarter
-                      , subq_20.metric_time__extract_month
-                      , subq_20.metric_time__extract_day
-                      , subq_20.metric_time__extract_dow
-                      , subq_20.metric_time__extract_doy
-                      , subq_20.listing
-                      , subq_20.guest
-                      , subq_20.host
-                      , subq_20.booking__listing
-                      , subq_20.booking__guest
-                      , subq_20.booking__host
-                      , subq_20.is_instant
-                      , subq_20.booking__is_instant
-                      , subq_20.bookings
-                      , subq_20.instant_bookings
-                      , subq_20.booking_value
-                      , subq_20.max_booking_value
-                      , subq_20.min_booking_value
-                      , subq_20.bookers
-                      , subq_20.average_booking_value
-                      , subq_20.referred_bookings
-                      , subq_20.median_booking_value
-                      , subq_20.booking_value_p99
-                      , subq_20.discrete_booking_value_p99
-                      , subq_20.approximate_continuous_booking_value_p99
-                      , subq_20.approximate_discrete_booking_value_p99
+                      subq_14.ds__day
+                      , subq_14.ds__week
+                      , subq_14.ds__month
+                      , subq_14.ds__quarter
+                      , subq_14.ds__year
+                      , subq_14.ds__extract_year
+                      , subq_14.ds__extract_quarter
+                      , subq_14.ds__extract_month
+                      , subq_14.ds__extract_day
+                      , subq_14.ds__extract_dow
+                      , subq_14.ds__extract_doy
+                      , subq_14.ds_partitioned__day
+                      , subq_14.ds_partitioned__week
+                      , subq_14.ds_partitioned__month
+                      , subq_14.ds_partitioned__quarter
+                      , subq_14.ds_partitioned__year
+                      , subq_14.ds_partitioned__extract_year
+                      , subq_14.ds_partitioned__extract_quarter
+                      , subq_14.ds_partitioned__extract_month
+                      , subq_14.ds_partitioned__extract_day
+                      , subq_14.ds_partitioned__extract_dow
+                      , subq_14.ds_partitioned__extract_doy
+                      , subq_14.paid_at__day
+                      , subq_14.paid_at__week
+                      , subq_14.paid_at__month
+                      , subq_14.paid_at__quarter
+                      , subq_14.paid_at__year
+                      , subq_14.paid_at__extract_year
+                      , subq_14.paid_at__extract_quarter
+                      , subq_14.paid_at__extract_month
+                      , subq_14.paid_at__extract_day
+                      , subq_14.paid_at__extract_dow
+                      , subq_14.paid_at__extract_doy
+                      , subq_14.booking__ds__day
+                      , subq_14.booking__ds__week
+                      , subq_14.booking__ds__month
+                      , subq_14.booking__ds__quarter
+                      , subq_14.booking__ds__year
+                      , subq_14.booking__ds__extract_year
+                      , subq_14.booking__ds__extract_quarter
+                      , subq_14.booking__ds__extract_month
+                      , subq_14.booking__ds__extract_day
+                      , subq_14.booking__ds__extract_dow
+                      , subq_14.booking__ds__extract_doy
+                      , subq_14.booking__ds_partitioned__day
+                      , subq_14.booking__ds_partitioned__week
+                      , subq_14.booking__ds_partitioned__month
+                      , subq_14.booking__ds_partitioned__quarter
+                      , subq_14.booking__ds_partitioned__year
+                      , subq_14.booking__ds_partitioned__extract_year
+                      , subq_14.booking__ds_partitioned__extract_quarter
+                      , subq_14.booking__ds_partitioned__extract_month
+                      , subq_14.booking__ds_partitioned__extract_day
+                      , subq_14.booking__ds_partitioned__extract_dow
+                      , subq_14.booking__ds_partitioned__extract_doy
+                      , subq_14.booking__paid_at__day
+                      , subq_14.booking__paid_at__week
+                      , subq_14.booking__paid_at__month
+                      , subq_14.booking__paid_at__quarter
+                      , subq_14.booking__paid_at__year
+                      , subq_14.booking__paid_at__extract_year
+                      , subq_14.booking__paid_at__extract_quarter
+                      , subq_14.booking__paid_at__extract_month
+                      , subq_14.booking__paid_at__extract_day
+                      , subq_14.booking__paid_at__extract_dow
+                      , subq_14.booking__paid_at__extract_doy
+                      , subq_14.metric_time__day
+                      , subq_14.metric_time__week
+                      , subq_14.metric_time__month
+                      , subq_14.metric_time__quarter
+                      , subq_14.metric_time__year
+                      , subq_14.metric_time__extract_year
+                      , subq_14.metric_time__extract_quarter
+                      , subq_14.metric_time__extract_month
+                      , subq_14.metric_time__extract_day
+                      , subq_14.metric_time__extract_dow
+                      , subq_14.metric_time__extract_doy
+                      , subq_14.listing
+                      , subq_14.guest
+                      , subq_14.host
+                      , subq_14.booking__listing
+                      , subq_14.booking__guest
+                      , subq_14.booking__host
+                      , subq_14.is_instant
+                      , subq_14.booking__is_instant
+                      , subq_14.bookings
+                      , subq_14.instant_bookings
+                      , subq_14.booking_value
+                      , subq_14.max_booking_value
+                      , subq_14.min_booking_value
+                      , subq_14.bookers
+                      , subq_14.average_booking_value
+                      , subq_14.referred_bookings
+                      , subq_14.median_booking_value
+                      , subq_14.booking_value_p99
+                      , subq_14.discrete_booking_value_p99
+                      , subq_14.approximate_continuous_booking_value_p99
+                      , subq_14.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_19.ds__day
-                        , subq_19.ds__week
-                        , subq_19.ds__month
-                        , subq_19.ds__quarter
-                        , subq_19.ds__year
-                        , subq_19.ds__extract_year
-                        , subq_19.ds__extract_quarter
-                        , subq_19.ds__extract_month
-                        , subq_19.ds__extract_day
-                        , subq_19.ds__extract_dow
-                        , subq_19.ds__extract_doy
-                        , subq_19.ds_partitioned__day
-                        , subq_19.ds_partitioned__week
-                        , subq_19.ds_partitioned__month
-                        , subq_19.ds_partitioned__quarter
-                        , subq_19.ds_partitioned__year
-                        , subq_19.ds_partitioned__extract_year
-                        , subq_19.ds_partitioned__extract_quarter
-                        , subq_19.ds_partitioned__extract_month
-                        , subq_19.ds_partitioned__extract_day
-                        , subq_19.ds_partitioned__extract_dow
-                        , subq_19.ds_partitioned__extract_doy
-                        , subq_19.paid_at__day
-                        , subq_19.paid_at__week
-                        , subq_19.paid_at__month
-                        , subq_19.paid_at__quarter
-                        , subq_19.paid_at__year
-                        , subq_19.paid_at__extract_year
-                        , subq_19.paid_at__extract_quarter
-                        , subq_19.paid_at__extract_month
-                        , subq_19.paid_at__extract_day
-                        , subq_19.paid_at__extract_dow
-                        , subq_19.paid_at__extract_doy
-                        , subq_19.booking__ds__day
-                        , subq_19.booking__ds__week
-                        , subq_19.booking__ds__month
-                        , subq_19.booking__ds__quarter
-                        , subq_19.booking__ds__year
-                        , subq_19.booking__ds__extract_year
-                        , subq_19.booking__ds__extract_quarter
-                        , subq_19.booking__ds__extract_month
-                        , subq_19.booking__ds__extract_day
-                        , subq_19.booking__ds__extract_dow
-                        , subq_19.booking__ds__extract_doy
-                        , subq_19.booking__ds_partitioned__day
-                        , subq_19.booking__ds_partitioned__week
-                        , subq_19.booking__ds_partitioned__month
-                        , subq_19.booking__ds_partitioned__quarter
-                        , subq_19.booking__ds_partitioned__year
-                        , subq_19.booking__ds_partitioned__extract_year
-                        , subq_19.booking__ds_partitioned__extract_quarter
-                        , subq_19.booking__ds_partitioned__extract_month
-                        , subq_19.booking__ds_partitioned__extract_day
-                        , subq_19.booking__ds_partitioned__extract_dow
-                        , subq_19.booking__ds_partitioned__extract_doy
-                        , subq_19.booking__paid_at__day
-                        , subq_19.booking__paid_at__week
-                        , subq_19.booking__paid_at__month
-                        , subq_19.booking__paid_at__quarter
-                        , subq_19.booking__paid_at__year
-                        , subq_19.booking__paid_at__extract_year
-                        , subq_19.booking__paid_at__extract_quarter
-                        , subq_19.booking__paid_at__extract_month
-                        , subq_19.booking__paid_at__extract_day
-                        , subq_19.booking__paid_at__extract_dow
-                        , subq_19.booking__paid_at__extract_doy
-                        , subq_19.ds__day AS metric_time__day
-                        , subq_19.ds__week AS metric_time__week
-                        , subq_19.ds__month AS metric_time__month
-                        , subq_19.ds__quarter AS metric_time__quarter
-                        , subq_19.ds__year AS metric_time__year
-                        , subq_19.ds__extract_year AS metric_time__extract_year
-                        , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_19.ds__extract_month AS metric_time__extract_month
-                        , subq_19.ds__extract_day AS metric_time__extract_day
-                        , subq_19.ds__extract_dow AS metric_time__extract_dow
-                        , subq_19.ds__extract_doy AS metric_time__extract_doy
-                        , subq_19.listing
-                        , subq_19.guest
-                        , subq_19.host
-                        , subq_19.booking__listing
-                        , subq_19.booking__guest
-                        , subq_19.booking__host
-                        , subq_19.is_instant
-                        , subq_19.booking__is_instant
-                        , subq_19.bookings
-                        , subq_19.instant_bookings
-                        , subq_19.booking_value
-                        , subq_19.max_booking_value
-                        , subq_19.min_booking_value
-                        , subq_19.bookers
-                        , subq_19.average_booking_value
-                        , subq_19.referred_bookings
-                        , subq_19.median_booking_value
-                        , subq_19.booking_value_p99
-                        , subq_19.discrete_booking_value_p99
-                        , subq_19.approximate_continuous_booking_value_p99
-                        , subq_19.approximate_discrete_booking_value_p99
+                        subq_13.ds__day
+                        , subq_13.ds__week
+                        , subq_13.ds__month
+                        , subq_13.ds__quarter
+                        , subq_13.ds__year
+                        , subq_13.ds__extract_year
+                        , subq_13.ds__extract_quarter
+                        , subq_13.ds__extract_month
+                        , subq_13.ds__extract_day
+                        , subq_13.ds__extract_dow
+                        , subq_13.ds__extract_doy
+                        , subq_13.ds_partitioned__day
+                        , subq_13.ds_partitioned__week
+                        , subq_13.ds_partitioned__month
+                        , subq_13.ds_partitioned__quarter
+                        , subq_13.ds_partitioned__year
+                        , subq_13.ds_partitioned__extract_year
+                        , subq_13.ds_partitioned__extract_quarter
+                        , subq_13.ds_partitioned__extract_month
+                        , subq_13.ds_partitioned__extract_day
+                        , subq_13.ds_partitioned__extract_dow
+                        , subq_13.ds_partitioned__extract_doy
+                        , subq_13.paid_at__day
+                        , subq_13.paid_at__week
+                        , subq_13.paid_at__month
+                        , subq_13.paid_at__quarter
+                        , subq_13.paid_at__year
+                        , subq_13.paid_at__extract_year
+                        , subq_13.paid_at__extract_quarter
+                        , subq_13.paid_at__extract_month
+                        , subq_13.paid_at__extract_day
+                        , subq_13.paid_at__extract_dow
+                        , subq_13.paid_at__extract_doy
+                        , subq_13.booking__ds__day
+                        , subq_13.booking__ds__week
+                        , subq_13.booking__ds__month
+                        , subq_13.booking__ds__quarter
+                        , subq_13.booking__ds__year
+                        , subq_13.booking__ds__extract_year
+                        , subq_13.booking__ds__extract_quarter
+                        , subq_13.booking__ds__extract_month
+                        , subq_13.booking__ds__extract_day
+                        , subq_13.booking__ds__extract_dow
+                        , subq_13.booking__ds__extract_doy
+                        , subq_13.booking__ds_partitioned__day
+                        , subq_13.booking__ds_partitioned__week
+                        , subq_13.booking__ds_partitioned__month
+                        , subq_13.booking__ds_partitioned__quarter
+                        , subq_13.booking__ds_partitioned__year
+                        , subq_13.booking__ds_partitioned__extract_year
+                        , subq_13.booking__ds_partitioned__extract_quarter
+                        , subq_13.booking__ds_partitioned__extract_month
+                        , subq_13.booking__ds_partitioned__extract_day
+                        , subq_13.booking__ds_partitioned__extract_dow
+                        , subq_13.booking__ds_partitioned__extract_doy
+                        , subq_13.booking__paid_at__day
+                        , subq_13.booking__paid_at__week
+                        , subq_13.booking__paid_at__month
+                        , subq_13.booking__paid_at__quarter
+                        , subq_13.booking__paid_at__year
+                        , subq_13.booking__paid_at__extract_year
+                        , subq_13.booking__paid_at__extract_quarter
+                        , subq_13.booking__paid_at__extract_month
+                        , subq_13.booking__paid_at__extract_day
+                        , subq_13.booking__paid_at__extract_dow
+                        , subq_13.booking__paid_at__extract_doy
+                        , subq_13.ds__day AS metric_time__day
+                        , subq_13.ds__week AS metric_time__week
+                        , subq_13.ds__month AS metric_time__month
+                        , subq_13.ds__quarter AS metric_time__quarter
+                        , subq_13.ds__year AS metric_time__year
+                        , subq_13.ds__extract_year AS metric_time__extract_year
+                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_13.ds__extract_month AS metric_time__extract_month
+                        , subq_13.ds__extract_day AS metric_time__extract_day
+                        , subq_13.ds__extract_dow AS metric_time__extract_dow
+                        , subq_13.ds__extract_doy AS metric_time__extract_doy
+                        , subq_13.listing
+                        , subq_13.guest
+                        , subq_13.host
+                        , subq_13.booking__listing
+                        , subq_13.booking__guest
+                        , subq_13.booking__host
+                        , subq_13.is_instant
+                        , subq_13.booking__is_instant
+                        , subq_13.bookings
+                        , subq_13.instant_bookings
+                        , subq_13.booking_value
+                        , subq_13.max_booking_value
+                        , subq_13.min_booking_value
+                        , subq_13.bookers
+                        , subq_13.average_booking_value
+                        , subq_13.referred_bookings
+                        , subq_13.median_booking_value
+                        , subq_13.booking_value_p99
+                        , subq_13.discrete_booking_value_p99
+                        , subq_13.approximate_continuous_booking_value_p99
+                        , subq_13.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -825,86 +825,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_19
-                    ) subq_20
+                      ) subq_13
+                    ) subq_14
                     WHERE booking__is_instant
-                  ) subq_21
-                ) subq_22
+                  ) subq_15
+                ) subq_16
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_24.listing
-                    , subq_24.is_lux_latest
+                    subq_18.listing
+                    , subq_18.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_23.ds__day
-                      , subq_23.ds__week
-                      , subq_23.ds__month
-                      , subq_23.ds__quarter
-                      , subq_23.ds__year
-                      , subq_23.ds__extract_year
-                      , subq_23.ds__extract_quarter
-                      , subq_23.ds__extract_month
-                      , subq_23.ds__extract_day
-                      , subq_23.ds__extract_dow
-                      , subq_23.ds__extract_doy
-                      , subq_23.created_at__day
-                      , subq_23.created_at__week
-                      , subq_23.created_at__month
-                      , subq_23.created_at__quarter
-                      , subq_23.created_at__year
-                      , subq_23.created_at__extract_year
-                      , subq_23.created_at__extract_quarter
-                      , subq_23.created_at__extract_month
-                      , subq_23.created_at__extract_day
-                      , subq_23.created_at__extract_dow
-                      , subq_23.created_at__extract_doy
-                      , subq_23.listing__ds__day
-                      , subq_23.listing__ds__week
-                      , subq_23.listing__ds__month
-                      , subq_23.listing__ds__quarter
-                      , subq_23.listing__ds__year
-                      , subq_23.listing__ds__extract_year
-                      , subq_23.listing__ds__extract_quarter
-                      , subq_23.listing__ds__extract_month
-                      , subq_23.listing__ds__extract_day
-                      , subq_23.listing__ds__extract_dow
-                      , subq_23.listing__ds__extract_doy
-                      , subq_23.listing__created_at__day
-                      , subq_23.listing__created_at__week
-                      , subq_23.listing__created_at__month
-                      , subq_23.listing__created_at__quarter
-                      , subq_23.listing__created_at__year
-                      , subq_23.listing__created_at__extract_year
-                      , subq_23.listing__created_at__extract_quarter
-                      , subq_23.listing__created_at__extract_month
-                      , subq_23.listing__created_at__extract_day
-                      , subq_23.listing__created_at__extract_dow
-                      , subq_23.listing__created_at__extract_doy
-                      , subq_23.ds__day AS metric_time__day
-                      , subq_23.ds__week AS metric_time__week
-                      , subq_23.ds__month AS metric_time__month
-                      , subq_23.ds__quarter AS metric_time__quarter
-                      , subq_23.ds__year AS metric_time__year
-                      , subq_23.ds__extract_year AS metric_time__extract_year
-                      , subq_23.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_23.ds__extract_month AS metric_time__extract_month
-                      , subq_23.ds__extract_day AS metric_time__extract_day
-                      , subq_23.ds__extract_dow AS metric_time__extract_dow
-                      , subq_23.ds__extract_doy AS metric_time__extract_doy
-                      , subq_23.listing
-                      , subq_23.user
-                      , subq_23.listing__user
-                      , subq_23.country_latest
-                      , subq_23.is_lux_latest
-                      , subq_23.capacity_latest
-                      , subq_23.listing__country_latest
-                      , subq_23.listing__is_lux_latest
-                      , subq_23.listing__capacity_latest
-                      , subq_23.listings
-                      , subq_23.largest_listing
-                      , subq_23.smallest_listing
+                      subq_17.ds__day
+                      , subq_17.ds__week
+                      , subq_17.ds__month
+                      , subq_17.ds__quarter
+                      , subq_17.ds__year
+                      , subq_17.ds__extract_year
+                      , subq_17.ds__extract_quarter
+                      , subq_17.ds__extract_month
+                      , subq_17.ds__extract_day
+                      , subq_17.ds__extract_dow
+                      , subq_17.ds__extract_doy
+                      , subq_17.created_at__day
+                      , subq_17.created_at__week
+                      , subq_17.created_at__month
+                      , subq_17.created_at__quarter
+                      , subq_17.created_at__year
+                      , subq_17.created_at__extract_year
+                      , subq_17.created_at__extract_quarter
+                      , subq_17.created_at__extract_month
+                      , subq_17.created_at__extract_day
+                      , subq_17.created_at__extract_dow
+                      , subq_17.created_at__extract_doy
+                      , subq_17.listing__ds__day
+                      , subq_17.listing__ds__week
+                      , subq_17.listing__ds__month
+                      , subq_17.listing__ds__quarter
+                      , subq_17.listing__ds__year
+                      , subq_17.listing__ds__extract_year
+                      , subq_17.listing__ds__extract_quarter
+                      , subq_17.listing__ds__extract_month
+                      , subq_17.listing__ds__extract_day
+                      , subq_17.listing__ds__extract_dow
+                      , subq_17.listing__ds__extract_doy
+                      , subq_17.listing__created_at__day
+                      , subq_17.listing__created_at__week
+                      , subq_17.listing__created_at__month
+                      , subq_17.listing__created_at__quarter
+                      , subq_17.listing__created_at__year
+                      , subq_17.listing__created_at__extract_year
+                      , subq_17.listing__created_at__extract_quarter
+                      , subq_17.listing__created_at__extract_month
+                      , subq_17.listing__created_at__extract_day
+                      , subq_17.listing__created_at__extract_dow
+                      , subq_17.listing__created_at__extract_doy
+                      , subq_17.ds__day AS metric_time__day
+                      , subq_17.ds__week AS metric_time__week
+                      , subq_17.ds__month AS metric_time__month
+                      , subq_17.ds__quarter AS metric_time__quarter
+                      , subq_17.ds__year AS metric_time__year
+                      , subq_17.ds__extract_year AS metric_time__extract_year
+                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_17.ds__extract_month AS metric_time__extract_month
+                      , subq_17.ds__extract_day AS metric_time__extract_day
+                      , subq_17.ds__extract_dow AS metric_time__extract_dow
+                      , subq_17.ds__extract_doy AS metric_time__extract_doy
+                      , subq_17.listing
+                      , subq_17.user
+                      , subq_17.listing__user
+                      , subq_17.country_latest
+                      , subq_17.is_lux_latest
+                      , subq_17.capacity_latest
+                      , subq_17.listing__country_latest
+                      , subq_17.listing__is_lux_latest
+                      , subq_17.listing__capacity_latest
+                      , subq_17.listings
+                      , subq_17.largest_listing
+                      , subq_17.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,242 +965,242 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_23
-                  ) subq_24
-                ) subq_25
+                    ) subq_17
+                  ) subq_18
+                ) subq_19
                 ON
-                  subq_22.listing = subq_25.listing
-              ) subq_26
-            ) subq_27
+                  subq_16.listing = subq_19.listing
+              ) subq_20
+            ) subq_21
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_28
-        ) subq_29
-      ) subq_30
-    ) subq_31
+          ) subq_22
+        ) subq_23
+      ) subq_24
+    ) subq_25
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_38.booking_value
+        subq_32.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_37.booking_value) AS booking_value
+          SUM(subq_31.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_36.booking_value
+            subq_30.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_35.booking__is_instant
-              , subq_35.booking_value
+              subq_29.booking__is_instant
+              , subq_29.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_34.booking__is_instant
-                , subq_34.booking_value
+                subq_28.booking__is_instant
+                , subq_28.booking_value
               FROM (
                 -- Constrain Output with WHERE
                 SELECT
-                  subq_33.ds__day
-                  , subq_33.ds__week
-                  , subq_33.ds__month
-                  , subq_33.ds__quarter
-                  , subq_33.ds__year
-                  , subq_33.ds__extract_year
-                  , subq_33.ds__extract_quarter
-                  , subq_33.ds__extract_month
-                  , subq_33.ds__extract_day
-                  , subq_33.ds__extract_dow
-                  , subq_33.ds__extract_doy
-                  , subq_33.ds_partitioned__day
-                  , subq_33.ds_partitioned__week
-                  , subq_33.ds_partitioned__month
-                  , subq_33.ds_partitioned__quarter
-                  , subq_33.ds_partitioned__year
-                  , subq_33.ds_partitioned__extract_year
-                  , subq_33.ds_partitioned__extract_quarter
-                  , subq_33.ds_partitioned__extract_month
-                  , subq_33.ds_partitioned__extract_day
-                  , subq_33.ds_partitioned__extract_dow
-                  , subq_33.ds_partitioned__extract_doy
-                  , subq_33.paid_at__day
-                  , subq_33.paid_at__week
-                  , subq_33.paid_at__month
-                  , subq_33.paid_at__quarter
-                  , subq_33.paid_at__year
-                  , subq_33.paid_at__extract_year
-                  , subq_33.paid_at__extract_quarter
-                  , subq_33.paid_at__extract_month
-                  , subq_33.paid_at__extract_day
-                  , subq_33.paid_at__extract_dow
-                  , subq_33.paid_at__extract_doy
-                  , subq_33.booking__ds__day
-                  , subq_33.booking__ds__week
-                  , subq_33.booking__ds__month
-                  , subq_33.booking__ds__quarter
-                  , subq_33.booking__ds__year
-                  , subq_33.booking__ds__extract_year
-                  , subq_33.booking__ds__extract_quarter
-                  , subq_33.booking__ds__extract_month
-                  , subq_33.booking__ds__extract_day
-                  , subq_33.booking__ds__extract_dow
-                  , subq_33.booking__ds__extract_doy
-                  , subq_33.booking__ds_partitioned__day
-                  , subq_33.booking__ds_partitioned__week
-                  , subq_33.booking__ds_partitioned__month
-                  , subq_33.booking__ds_partitioned__quarter
-                  , subq_33.booking__ds_partitioned__year
-                  , subq_33.booking__ds_partitioned__extract_year
-                  , subq_33.booking__ds_partitioned__extract_quarter
-                  , subq_33.booking__ds_partitioned__extract_month
-                  , subq_33.booking__ds_partitioned__extract_day
-                  , subq_33.booking__ds_partitioned__extract_dow
-                  , subq_33.booking__ds_partitioned__extract_doy
-                  , subq_33.booking__paid_at__day
-                  , subq_33.booking__paid_at__week
-                  , subq_33.booking__paid_at__month
-                  , subq_33.booking__paid_at__quarter
-                  , subq_33.booking__paid_at__year
-                  , subq_33.booking__paid_at__extract_year
-                  , subq_33.booking__paid_at__extract_quarter
-                  , subq_33.booking__paid_at__extract_month
-                  , subq_33.booking__paid_at__extract_day
-                  , subq_33.booking__paid_at__extract_dow
-                  , subq_33.booking__paid_at__extract_doy
-                  , subq_33.metric_time__day
-                  , subq_33.metric_time__week
-                  , subq_33.metric_time__month
-                  , subq_33.metric_time__quarter
-                  , subq_33.metric_time__year
-                  , subq_33.metric_time__extract_year
-                  , subq_33.metric_time__extract_quarter
-                  , subq_33.metric_time__extract_month
-                  , subq_33.metric_time__extract_day
-                  , subq_33.metric_time__extract_dow
-                  , subq_33.metric_time__extract_doy
-                  , subq_33.listing
-                  , subq_33.guest
-                  , subq_33.host
-                  , subq_33.booking__listing
-                  , subq_33.booking__guest
-                  , subq_33.booking__host
-                  , subq_33.is_instant
-                  , subq_33.booking__is_instant
-                  , subq_33.bookings
-                  , subq_33.instant_bookings
-                  , subq_33.booking_value
-                  , subq_33.max_booking_value
-                  , subq_33.min_booking_value
-                  , subq_33.bookers
-                  , subq_33.average_booking_value
-                  , subq_33.referred_bookings
-                  , subq_33.median_booking_value
-                  , subq_33.booking_value_p99
-                  , subq_33.discrete_booking_value_p99
-                  , subq_33.approximate_continuous_booking_value_p99
-                  , subq_33.approximate_discrete_booking_value_p99
+                  subq_27.ds__day
+                  , subq_27.ds__week
+                  , subq_27.ds__month
+                  , subq_27.ds__quarter
+                  , subq_27.ds__year
+                  , subq_27.ds__extract_year
+                  , subq_27.ds__extract_quarter
+                  , subq_27.ds__extract_month
+                  , subq_27.ds__extract_day
+                  , subq_27.ds__extract_dow
+                  , subq_27.ds__extract_doy
+                  , subq_27.ds_partitioned__day
+                  , subq_27.ds_partitioned__week
+                  , subq_27.ds_partitioned__month
+                  , subq_27.ds_partitioned__quarter
+                  , subq_27.ds_partitioned__year
+                  , subq_27.ds_partitioned__extract_year
+                  , subq_27.ds_partitioned__extract_quarter
+                  , subq_27.ds_partitioned__extract_month
+                  , subq_27.ds_partitioned__extract_day
+                  , subq_27.ds_partitioned__extract_dow
+                  , subq_27.ds_partitioned__extract_doy
+                  , subq_27.paid_at__day
+                  , subq_27.paid_at__week
+                  , subq_27.paid_at__month
+                  , subq_27.paid_at__quarter
+                  , subq_27.paid_at__year
+                  , subq_27.paid_at__extract_year
+                  , subq_27.paid_at__extract_quarter
+                  , subq_27.paid_at__extract_month
+                  , subq_27.paid_at__extract_day
+                  , subq_27.paid_at__extract_dow
+                  , subq_27.paid_at__extract_doy
+                  , subq_27.booking__ds__day
+                  , subq_27.booking__ds__week
+                  , subq_27.booking__ds__month
+                  , subq_27.booking__ds__quarter
+                  , subq_27.booking__ds__year
+                  , subq_27.booking__ds__extract_year
+                  , subq_27.booking__ds__extract_quarter
+                  , subq_27.booking__ds__extract_month
+                  , subq_27.booking__ds__extract_day
+                  , subq_27.booking__ds__extract_dow
+                  , subq_27.booking__ds__extract_doy
+                  , subq_27.booking__ds_partitioned__day
+                  , subq_27.booking__ds_partitioned__week
+                  , subq_27.booking__ds_partitioned__month
+                  , subq_27.booking__ds_partitioned__quarter
+                  , subq_27.booking__ds_partitioned__year
+                  , subq_27.booking__ds_partitioned__extract_year
+                  , subq_27.booking__ds_partitioned__extract_quarter
+                  , subq_27.booking__ds_partitioned__extract_month
+                  , subq_27.booking__ds_partitioned__extract_day
+                  , subq_27.booking__ds_partitioned__extract_dow
+                  , subq_27.booking__ds_partitioned__extract_doy
+                  , subq_27.booking__paid_at__day
+                  , subq_27.booking__paid_at__week
+                  , subq_27.booking__paid_at__month
+                  , subq_27.booking__paid_at__quarter
+                  , subq_27.booking__paid_at__year
+                  , subq_27.booking__paid_at__extract_year
+                  , subq_27.booking__paid_at__extract_quarter
+                  , subq_27.booking__paid_at__extract_month
+                  , subq_27.booking__paid_at__extract_day
+                  , subq_27.booking__paid_at__extract_dow
+                  , subq_27.booking__paid_at__extract_doy
+                  , subq_27.metric_time__day
+                  , subq_27.metric_time__week
+                  , subq_27.metric_time__month
+                  , subq_27.metric_time__quarter
+                  , subq_27.metric_time__year
+                  , subq_27.metric_time__extract_year
+                  , subq_27.metric_time__extract_quarter
+                  , subq_27.metric_time__extract_month
+                  , subq_27.metric_time__extract_day
+                  , subq_27.metric_time__extract_dow
+                  , subq_27.metric_time__extract_doy
+                  , subq_27.listing
+                  , subq_27.guest
+                  , subq_27.host
+                  , subq_27.booking__listing
+                  , subq_27.booking__guest
+                  , subq_27.booking__host
+                  , subq_27.is_instant
+                  , subq_27.booking__is_instant
+                  , subq_27.bookings
+                  , subq_27.instant_bookings
+                  , subq_27.booking_value
+                  , subq_27.max_booking_value
+                  , subq_27.min_booking_value
+                  , subq_27.bookers
+                  , subq_27.average_booking_value
+                  , subq_27.referred_bookings
+                  , subq_27.median_booking_value
+                  , subq_27.booking_value_p99
+                  , subq_27.discrete_booking_value_p99
+                  , subq_27.approximate_continuous_booking_value_p99
+                  , subq_27.approximate_discrete_booking_value_p99
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_32.ds__day
-                    , subq_32.ds__week
-                    , subq_32.ds__month
-                    , subq_32.ds__quarter
-                    , subq_32.ds__year
-                    , subq_32.ds__extract_year
-                    , subq_32.ds__extract_quarter
-                    , subq_32.ds__extract_month
-                    , subq_32.ds__extract_day
-                    , subq_32.ds__extract_dow
-                    , subq_32.ds__extract_doy
-                    , subq_32.ds_partitioned__day
-                    , subq_32.ds_partitioned__week
-                    , subq_32.ds_partitioned__month
-                    , subq_32.ds_partitioned__quarter
-                    , subq_32.ds_partitioned__year
-                    , subq_32.ds_partitioned__extract_year
-                    , subq_32.ds_partitioned__extract_quarter
-                    , subq_32.ds_partitioned__extract_month
-                    , subq_32.ds_partitioned__extract_day
-                    , subq_32.ds_partitioned__extract_dow
-                    , subq_32.ds_partitioned__extract_doy
-                    , subq_32.paid_at__day
-                    , subq_32.paid_at__week
-                    , subq_32.paid_at__month
-                    , subq_32.paid_at__quarter
-                    , subq_32.paid_at__year
-                    , subq_32.paid_at__extract_year
-                    , subq_32.paid_at__extract_quarter
-                    , subq_32.paid_at__extract_month
-                    , subq_32.paid_at__extract_day
-                    , subq_32.paid_at__extract_dow
-                    , subq_32.paid_at__extract_doy
-                    , subq_32.booking__ds__day
-                    , subq_32.booking__ds__week
-                    , subq_32.booking__ds__month
-                    , subq_32.booking__ds__quarter
-                    , subq_32.booking__ds__year
-                    , subq_32.booking__ds__extract_year
-                    , subq_32.booking__ds__extract_quarter
-                    , subq_32.booking__ds__extract_month
-                    , subq_32.booking__ds__extract_day
-                    , subq_32.booking__ds__extract_dow
-                    , subq_32.booking__ds__extract_doy
-                    , subq_32.booking__ds_partitioned__day
-                    , subq_32.booking__ds_partitioned__week
-                    , subq_32.booking__ds_partitioned__month
-                    , subq_32.booking__ds_partitioned__quarter
-                    , subq_32.booking__ds_partitioned__year
-                    , subq_32.booking__ds_partitioned__extract_year
-                    , subq_32.booking__ds_partitioned__extract_quarter
-                    , subq_32.booking__ds_partitioned__extract_month
-                    , subq_32.booking__ds_partitioned__extract_day
-                    , subq_32.booking__ds_partitioned__extract_dow
-                    , subq_32.booking__ds_partitioned__extract_doy
-                    , subq_32.booking__paid_at__day
-                    , subq_32.booking__paid_at__week
-                    , subq_32.booking__paid_at__month
-                    , subq_32.booking__paid_at__quarter
-                    , subq_32.booking__paid_at__year
-                    , subq_32.booking__paid_at__extract_year
-                    , subq_32.booking__paid_at__extract_quarter
-                    , subq_32.booking__paid_at__extract_month
-                    , subq_32.booking__paid_at__extract_day
-                    , subq_32.booking__paid_at__extract_dow
-                    , subq_32.booking__paid_at__extract_doy
-                    , subq_32.ds__day AS metric_time__day
-                    , subq_32.ds__week AS metric_time__week
-                    , subq_32.ds__month AS metric_time__month
-                    , subq_32.ds__quarter AS metric_time__quarter
-                    , subq_32.ds__year AS metric_time__year
-                    , subq_32.ds__extract_year AS metric_time__extract_year
-                    , subq_32.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_32.ds__extract_month AS metric_time__extract_month
-                    , subq_32.ds__extract_day AS metric_time__extract_day
-                    , subq_32.ds__extract_dow AS metric_time__extract_dow
-                    , subq_32.ds__extract_doy AS metric_time__extract_doy
-                    , subq_32.listing
-                    , subq_32.guest
-                    , subq_32.host
-                    , subq_32.booking__listing
-                    , subq_32.booking__guest
-                    , subq_32.booking__host
-                    , subq_32.is_instant
-                    , subq_32.booking__is_instant
-                    , subq_32.bookings
-                    , subq_32.instant_bookings
-                    , subq_32.booking_value
-                    , subq_32.max_booking_value
-                    , subq_32.min_booking_value
-                    , subq_32.bookers
-                    , subq_32.average_booking_value
-                    , subq_32.referred_bookings
-                    , subq_32.median_booking_value
-                    , subq_32.booking_value_p99
-                    , subq_32.discrete_booking_value_p99
-                    , subq_32.approximate_continuous_booking_value_p99
-                    , subq_32.approximate_discrete_booking_value_p99
+                    subq_26.ds__day
+                    , subq_26.ds__week
+                    , subq_26.ds__month
+                    , subq_26.ds__quarter
+                    , subq_26.ds__year
+                    , subq_26.ds__extract_year
+                    , subq_26.ds__extract_quarter
+                    , subq_26.ds__extract_month
+                    , subq_26.ds__extract_day
+                    , subq_26.ds__extract_dow
+                    , subq_26.ds__extract_doy
+                    , subq_26.ds_partitioned__day
+                    , subq_26.ds_partitioned__week
+                    , subq_26.ds_partitioned__month
+                    , subq_26.ds_partitioned__quarter
+                    , subq_26.ds_partitioned__year
+                    , subq_26.ds_partitioned__extract_year
+                    , subq_26.ds_partitioned__extract_quarter
+                    , subq_26.ds_partitioned__extract_month
+                    , subq_26.ds_partitioned__extract_day
+                    , subq_26.ds_partitioned__extract_dow
+                    , subq_26.ds_partitioned__extract_doy
+                    , subq_26.paid_at__day
+                    , subq_26.paid_at__week
+                    , subq_26.paid_at__month
+                    , subq_26.paid_at__quarter
+                    , subq_26.paid_at__year
+                    , subq_26.paid_at__extract_year
+                    , subq_26.paid_at__extract_quarter
+                    , subq_26.paid_at__extract_month
+                    , subq_26.paid_at__extract_day
+                    , subq_26.paid_at__extract_dow
+                    , subq_26.paid_at__extract_doy
+                    , subq_26.booking__ds__day
+                    , subq_26.booking__ds__week
+                    , subq_26.booking__ds__month
+                    , subq_26.booking__ds__quarter
+                    , subq_26.booking__ds__year
+                    , subq_26.booking__ds__extract_year
+                    , subq_26.booking__ds__extract_quarter
+                    , subq_26.booking__ds__extract_month
+                    , subq_26.booking__ds__extract_day
+                    , subq_26.booking__ds__extract_dow
+                    , subq_26.booking__ds__extract_doy
+                    , subq_26.booking__ds_partitioned__day
+                    , subq_26.booking__ds_partitioned__week
+                    , subq_26.booking__ds_partitioned__month
+                    , subq_26.booking__ds_partitioned__quarter
+                    , subq_26.booking__ds_partitioned__year
+                    , subq_26.booking__ds_partitioned__extract_year
+                    , subq_26.booking__ds_partitioned__extract_quarter
+                    , subq_26.booking__ds_partitioned__extract_month
+                    , subq_26.booking__ds_partitioned__extract_day
+                    , subq_26.booking__ds_partitioned__extract_dow
+                    , subq_26.booking__ds_partitioned__extract_doy
+                    , subq_26.booking__paid_at__day
+                    , subq_26.booking__paid_at__week
+                    , subq_26.booking__paid_at__month
+                    , subq_26.booking__paid_at__quarter
+                    , subq_26.booking__paid_at__year
+                    , subq_26.booking__paid_at__extract_year
+                    , subq_26.booking__paid_at__extract_quarter
+                    , subq_26.booking__paid_at__extract_month
+                    , subq_26.booking__paid_at__extract_day
+                    , subq_26.booking__paid_at__extract_dow
+                    , subq_26.booking__paid_at__extract_doy
+                    , subq_26.ds__day AS metric_time__day
+                    , subq_26.ds__week AS metric_time__week
+                    , subq_26.ds__month AS metric_time__month
+                    , subq_26.ds__quarter AS metric_time__quarter
+                    , subq_26.ds__year AS metric_time__year
+                    , subq_26.ds__extract_year AS metric_time__extract_year
+                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_26.ds__extract_month AS metric_time__extract_month
+                    , subq_26.ds__extract_day AS metric_time__extract_day
+                    , subq_26.ds__extract_dow AS metric_time__extract_dow
+                    , subq_26.ds__extract_doy AS metric_time__extract_doy
+                    , subq_26.listing
+                    , subq_26.guest
+                    , subq_26.host
+                    , subq_26.booking__listing
+                    , subq_26.booking__guest
+                    , subq_26.booking__host
+                    , subq_26.is_instant
+                    , subq_26.booking__is_instant
+                    , subq_26.bookings
+                    , subq_26.instant_bookings
+                    , subq_26.booking_value
+                    , subq_26.max_booking_value
+                    , subq_26.min_booking_value
+                    , subq_26.bookers
+                    , subq_26.average_booking_value
+                    , subq_26.referred_bookings
+                    , subq_26.median_booking_value
+                    , subq_26.booking_value_p99
+                    , subq_26.discrete_booking_value_p99
+                    , subq_26.approximate_continuous_booking_value_p99
+                    , subq_26.approximate_discrete_booking_value_p99
                   FROM (
                     -- Read Elements From Semantic Model 'bookings_source'
                     SELECT
@@ -1293,15 +1293,15 @@ FROM (
                       , bookings_source_src_28000.guest_id AS booking__guest
                       , bookings_source_src_28000.host_id AS booking__host
                     FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_32
-                ) subq_33
+                  ) subq_26
+                ) subq_27
                 WHERE booking__is_instant
-              ) subq_34
-            ) subq_35
+              ) subq_28
+            ) subq_29
             WHERE booking__is_instant
-          ) subq_36
-        ) subq_37
-      ) subq_38
-    ) subq_39
-  ) subq_40
-) subq_41
+          ) subq_30
+        ) subq_31
+      ) subq_32
+    ) subq_33
+  ) subq_34
+) subq_35

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_60.average_booking_value) AS average_booking_value
-      , MAX(subq_73.bookings) AS bookings
-      , MAX(subq_81.booking_value) AS booking_value
+      MAX(subq_48.average_booking_value) AS average_booking_value
+      , MAX(subq_61.bookings) AS bookings
+      , MAX(subq_69.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_51.booking__is_instant AS booking__is_instant
+          subq_39.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_51.average_booking_value AS average_booking_value
+          , subq_39.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_49
+          ) subq_37
           WHERE booking__is_instant
-        ) subq_51
+        ) subq_39
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_51.listing = listings_latest_src_28000.listing_id
-      ) subq_56
+          subq_39.listing = listings_latest_src_28000.listing_id
+      ) subq_44
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_60
+    ) subq_48
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_64.booking__is_instant AS booking__is_instant
+          subq_52.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_64.bookings AS bookings
+          , subq_52.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_62
+          ) subq_50
           WHERE booking__is_instant
-        ) subq_64
+        ) subq_52
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_64.listing = listings_latest_src_28000.listing_id
-      ) subq_69
+          subq_52.listing = listings_latest_src_28000.listing_id
+      ) subq_57
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_73
+    ) subq_61
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_75
+        ) subq_63
         WHERE booking__is_instant
-      ) subq_77
+      ) subq_65
       WHERE booking__is_instant
-    ) subq_81
-  ) subq_82
-) subq_83
+    ) subq_69
+  ) subq_70
+) subq_71

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0.sql
@@ -8,248 +8,248 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_18.average_booking_value) AS average_booking_value
-      , MAX(subq_31.bookings) AS bookings
-      , MAX(subq_39.booking_value) AS booking_value
+      MAX(subq_12.average_booking_value) AS average_booking_value
+      , MAX(subq_25.bookings) AS bookings
+      , MAX(subq_33.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.average_booking_value
+        subq_11.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_16.average_booking_value) AS average_booking_value
+          AVG(subq_10.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_15.average_booking_value
+            subq_9.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.booking__is_instant
-              , subq_14.listing__is_lux_latest
-              , subq_14.average_booking_value
+              subq_8.booking__is_instant
+              , subq_8.listing__is_lux_latest
+              , subq_8.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_13.booking__is_instant
-                , subq_13.listing__is_lux_latest
-                , subq_13.average_booking_value
+                subq_7.booking__is_instant
+                , subq_7.listing__is_lux_latest
+                , subq_7.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_9.listing AS listing
-                  , subq_9.booking__is_instant AS booking__is_instant
-                  , subq_12.is_lux_latest AS listing__is_lux_latest
-                  , subq_9.average_booking_value AS average_booking_value
+                  subq_3.listing AS listing
+                  , subq_3.booking__is_instant AS booking__is_instant
+                  , subq_6.is_lux_latest AS listing__is_lux_latest
+                  , subq_3.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.booking__is_instant
-                    , subq_8.average_booking_value
+                    subq_2.listing
+                    , subq_2.booking__is_instant
+                    , subq_2.average_booking_value
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.metric_time__day
-                      , subq_7.metric_time__week
-                      , subq_7.metric_time__month
-                      , subq_7.metric_time__quarter
-                      , subq_7.metric_time__year
-                      , subq_7.metric_time__extract_year
-                      , subq_7.metric_time__extract_quarter
-                      , subq_7.metric_time__extract_month
-                      , subq_7.metric_time__extract_day
-                      , subq_7.metric_time__extract_dow
-                      , subq_7.metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_1.ds__day
+                      , subq_1.ds__week
+                      , subq_1.ds__month
+                      , subq_1.ds__quarter
+                      , subq_1.ds__year
+                      , subq_1.ds__extract_year
+                      , subq_1.ds__extract_quarter
+                      , subq_1.ds__extract_month
+                      , subq_1.ds__extract_day
+                      , subq_1.ds__extract_dow
+                      , subq_1.ds__extract_doy
+                      , subq_1.ds_partitioned__day
+                      , subq_1.ds_partitioned__week
+                      , subq_1.ds_partitioned__month
+                      , subq_1.ds_partitioned__quarter
+                      , subq_1.ds_partitioned__year
+                      , subq_1.ds_partitioned__extract_year
+                      , subq_1.ds_partitioned__extract_quarter
+                      , subq_1.ds_partitioned__extract_month
+                      , subq_1.ds_partitioned__extract_day
+                      , subq_1.ds_partitioned__extract_dow
+                      , subq_1.ds_partitioned__extract_doy
+                      , subq_1.paid_at__day
+                      , subq_1.paid_at__week
+                      , subq_1.paid_at__month
+                      , subq_1.paid_at__quarter
+                      , subq_1.paid_at__year
+                      , subq_1.paid_at__extract_year
+                      , subq_1.paid_at__extract_quarter
+                      , subq_1.paid_at__extract_month
+                      , subq_1.paid_at__extract_day
+                      , subq_1.paid_at__extract_dow
+                      , subq_1.paid_at__extract_doy
+                      , subq_1.booking__ds__day
+                      , subq_1.booking__ds__week
+                      , subq_1.booking__ds__month
+                      , subq_1.booking__ds__quarter
+                      , subq_1.booking__ds__year
+                      , subq_1.booking__ds__extract_year
+                      , subq_1.booking__ds__extract_quarter
+                      , subq_1.booking__ds__extract_month
+                      , subq_1.booking__ds__extract_day
+                      , subq_1.booking__ds__extract_dow
+                      , subq_1.booking__ds__extract_doy
+                      , subq_1.booking__ds_partitioned__day
+                      , subq_1.booking__ds_partitioned__week
+                      , subq_1.booking__ds_partitioned__month
+                      , subq_1.booking__ds_partitioned__quarter
+                      , subq_1.booking__ds_partitioned__year
+                      , subq_1.booking__ds_partitioned__extract_year
+                      , subq_1.booking__ds_partitioned__extract_quarter
+                      , subq_1.booking__ds_partitioned__extract_month
+                      , subq_1.booking__ds_partitioned__extract_day
+                      , subq_1.booking__ds_partitioned__extract_dow
+                      , subq_1.booking__ds_partitioned__extract_doy
+                      , subq_1.booking__paid_at__day
+                      , subq_1.booking__paid_at__week
+                      , subq_1.booking__paid_at__month
+                      , subq_1.booking__paid_at__quarter
+                      , subq_1.booking__paid_at__year
+                      , subq_1.booking__paid_at__extract_year
+                      , subq_1.booking__paid_at__extract_quarter
+                      , subq_1.booking__paid_at__extract_month
+                      , subq_1.booking__paid_at__extract_day
+                      , subq_1.booking__paid_at__extract_dow
+                      , subq_1.booking__paid_at__extract_doy
+                      , subq_1.metric_time__day
+                      , subq_1.metric_time__week
+                      , subq_1.metric_time__month
+                      , subq_1.metric_time__quarter
+                      , subq_1.metric_time__year
+                      , subq_1.metric_time__extract_year
+                      , subq_1.metric_time__extract_quarter
+                      , subq_1.metric_time__extract_month
+                      , subq_1.metric_time__extract_day
+                      , subq_1.metric_time__extract_dow
+                      , subq_1.metric_time__extract_doy
+                      , subq_1.listing
+                      , subq_1.guest
+                      , subq_1.host
+                      , subq_1.booking__listing
+                      , subq_1.booking__guest
+                      , subq_1.booking__host
+                      , subq_1.is_instant
+                      , subq_1.booking__is_instant
+                      , subq_1.bookings
+                      , subq_1.instant_bookings
+                      , subq_1.booking_value
+                      , subq_1.max_booking_value
+                      , subq_1.min_booking_value
+                      , subq_1.bookers
+                      , subq_1.average_booking_value
+                      , subq_1.referred_bookings
+                      , subq_1.median_booking_value
+                      , subq_1.booking_value_p99
+                      , subq_1.discrete_booking_value_p99
+                      , subq_1.approximate_continuous_booking_value_p99
+                      , subq_1.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_6.ds__day
-                        , subq_6.ds__week
-                        , subq_6.ds__month
-                        , subq_6.ds__quarter
-                        , subq_6.ds__year
-                        , subq_6.ds__extract_year
-                        , subq_6.ds__extract_quarter
-                        , subq_6.ds__extract_month
-                        , subq_6.ds__extract_day
-                        , subq_6.ds__extract_dow
-                        , subq_6.ds__extract_doy
-                        , subq_6.ds_partitioned__day
-                        , subq_6.ds_partitioned__week
-                        , subq_6.ds_partitioned__month
-                        , subq_6.ds_partitioned__quarter
-                        , subq_6.ds_partitioned__year
-                        , subq_6.ds_partitioned__extract_year
-                        , subq_6.ds_partitioned__extract_quarter
-                        , subq_6.ds_partitioned__extract_month
-                        , subq_6.ds_partitioned__extract_day
-                        , subq_6.ds_partitioned__extract_dow
-                        , subq_6.ds_partitioned__extract_doy
-                        , subq_6.paid_at__day
-                        , subq_6.paid_at__week
-                        , subq_6.paid_at__month
-                        , subq_6.paid_at__quarter
-                        , subq_6.paid_at__year
-                        , subq_6.paid_at__extract_year
-                        , subq_6.paid_at__extract_quarter
-                        , subq_6.paid_at__extract_month
-                        , subq_6.paid_at__extract_day
-                        , subq_6.paid_at__extract_dow
-                        , subq_6.paid_at__extract_doy
-                        , subq_6.booking__ds__day
-                        , subq_6.booking__ds__week
-                        , subq_6.booking__ds__month
-                        , subq_6.booking__ds__quarter
-                        , subq_6.booking__ds__year
-                        , subq_6.booking__ds__extract_year
-                        , subq_6.booking__ds__extract_quarter
-                        , subq_6.booking__ds__extract_month
-                        , subq_6.booking__ds__extract_day
-                        , subq_6.booking__ds__extract_dow
-                        , subq_6.booking__ds__extract_doy
-                        , subq_6.booking__ds_partitioned__day
-                        , subq_6.booking__ds_partitioned__week
-                        , subq_6.booking__ds_partitioned__month
-                        , subq_6.booking__ds_partitioned__quarter
-                        , subq_6.booking__ds_partitioned__year
-                        , subq_6.booking__ds_partitioned__extract_year
-                        , subq_6.booking__ds_partitioned__extract_quarter
-                        , subq_6.booking__ds_partitioned__extract_month
-                        , subq_6.booking__ds_partitioned__extract_day
-                        , subq_6.booking__ds_partitioned__extract_dow
-                        , subq_6.booking__ds_partitioned__extract_doy
-                        , subq_6.booking__paid_at__day
-                        , subq_6.booking__paid_at__week
-                        , subq_6.booking__paid_at__month
-                        , subq_6.booking__paid_at__quarter
-                        , subq_6.booking__paid_at__year
-                        , subq_6.booking__paid_at__extract_year
-                        , subq_6.booking__paid_at__extract_quarter
-                        , subq_6.booking__paid_at__extract_month
-                        , subq_6.booking__paid_at__extract_day
-                        , subq_6.booking__paid_at__extract_dow
-                        , subq_6.booking__paid_at__extract_doy
-                        , subq_6.ds__day AS metric_time__day
-                        , subq_6.ds__week AS metric_time__week
-                        , subq_6.ds__month AS metric_time__month
-                        , subq_6.ds__quarter AS metric_time__quarter
-                        , subq_6.ds__year AS metric_time__year
-                        , subq_6.ds__extract_year AS metric_time__extract_year
-                        , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_6.ds__extract_month AS metric_time__extract_month
-                        , subq_6.ds__extract_day AS metric_time__extract_day
-                        , subq_6.ds__extract_dow AS metric_time__extract_dow
-                        , subq_6.ds__extract_doy AS metric_time__extract_doy
-                        , subq_6.listing
-                        , subq_6.guest
-                        , subq_6.host
-                        , subq_6.booking__listing
-                        , subq_6.booking__guest
-                        , subq_6.booking__host
-                        , subq_6.is_instant
-                        , subq_6.booking__is_instant
-                        , subq_6.bookings
-                        , subq_6.instant_bookings
-                        , subq_6.booking_value
-                        , subq_6.max_booking_value
-                        , subq_6.min_booking_value
-                        , subq_6.bookers
-                        , subq_6.average_booking_value
-                        , subq_6.referred_bookings
-                        , subq_6.median_booking_value
-                        , subq_6.booking_value_p99
-                        , subq_6.discrete_booking_value_p99
-                        , subq_6.approximate_continuous_booking_value_p99
-                        , subq_6.approximate_discrete_booking_value_p99
+                        subq_0.ds__day
+                        , subq_0.ds__week
+                        , subq_0.ds__month
+                        , subq_0.ds__quarter
+                        , subq_0.ds__year
+                        , subq_0.ds__extract_year
+                        , subq_0.ds__extract_quarter
+                        , subq_0.ds__extract_month
+                        , subq_0.ds__extract_day
+                        , subq_0.ds__extract_dow
+                        , subq_0.ds__extract_doy
+                        , subq_0.ds_partitioned__day
+                        , subq_0.ds_partitioned__week
+                        , subq_0.ds_partitioned__month
+                        , subq_0.ds_partitioned__quarter
+                        , subq_0.ds_partitioned__year
+                        , subq_0.ds_partitioned__extract_year
+                        , subq_0.ds_partitioned__extract_quarter
+                        , subq_0.ds_partitioned__extract_month
+                        , subq_0.ds_partitioned__extract_day
+                        , subq_0.ds_partitioned__extract_dow
+                        , subq_0.ds_partitioned__extract_doy
+                        , subq_0.paid_at__day
+                        , subq_0.paid_at__week
+                        , subq_0.paid_at__month
+                        , subq_0.paid_at__quarter
+                        , subq_0.paid_at__year
+                        , subq_0.paid_at__extract_year
+                        , subq_0.paid_at__extract_quarter
+                        , subq_0.paid_at__extract_month
+                        , subq_0.paid_at__extract_day
+                        , subq_0.paid_at__extract_dow
+                        , subq_0.paid_at__extract_doy
+                        , subq_0.booking__ds__day
+                        , subq_0.booking__ds__week
+                        , subq_0.booking__ds__month
+                        , subq_0.booking__ds__quarter
+                        , subq_0.booking__ds__year
+                        , subq_0.booking__ds__extract_year
+                        , subq_0.booking__ds__extract_quarter
+                        , subq_0.booking__ds__extract_month
+                        , subq_0.booking__ds__extract_day
+                        , subq_0.booking__ds__extract_dow
+                        , subq_0.booking__ds__extract_doy
+                        , subq_0.booking__ds_partitioned__day
+                        , subq_0.booking__ds_partitioned__week
+                        , subq_0.booking__ds_partitioned__month
+                        , subq_0.booking__ds_partitioned__quarter
+                        , subq_0.booking__ds_partitioned__year
+                        , subq_0.booking__ds_partitioned__extract_year
+                        , subq_0.booking__ds_partitioned__extract_quarter
+                        , subq_0.booking__ds_partitioned__extract_month
+                        , subq_0.booking__ds_partitioned__extract_day
+                        , subq_0.booking__ds_partitioned__extract_dow
+                        , subq_0.booking__ds_partitioned__extract_doy
+                        , subq_0.booking__paid_at__day
+                        , subq_0.booking__paid_at__week
+                        , subq_0.booking__paid_at__month
+                        , subq_0.booking__paid_at__quarter
+                        , subq_0.booking__paid_at__year
+                        , subq_0.booking__paid_at__extract_year
+                        , subq_0.booking__paid_at__extract_quarter
+                        , subq_0.booking__paid_at__extract_month
+                        , subq_0.booking__paid_at__extract_day
+                        , subq_0.booking__paid_at__extract_dow
+                        , subq_0.booking__paid_at__extract_doy
+                        , subq_0.ds__day AS metric_time__day
+                        , subq_0.ds__week AS metric_time__week
+                        , subq_0.ds__month AS metric_time__month
+                        , subq_0.ds__quarter AS metric_time__quarter
+                        , subq_0.ds__year AS metric_time__year
+                        , subq_0.ds__extract_year AS metric_time__extract_year
+                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_0.ds__extract_month AS metric_time__extract_month
+                        , subq_0.ds__extract_day AS metric_time__extract_day
+                        , subq_0.ds__extract_dow AS metric_time__extract_dow
+                        , subq_0.ds__extract_doy AS metric_time__extract_doy
+                        , subq_0.listing
+                        , subq_0.guest
+                        , subq_0.host
+                        , subq_0.booking__listing
+                        , subq_0.booking__guest
+                        , subq_0.booking__host
+                        , subq_0.is_instant
+                        , subq_0.booking__is_instant
+                        , subq_0.bookings
+                        , subq_0.instant_bookings
+                        , subq_0.booking_value
+                        , subq_0.max_booking_value
+                        , subq_0.min_booking_value
+                        , subq_0.bookers
+                        , subq_0.average_booking_value
+                        , subq_0.referred_bookings
+                        , subq_0.median_booking_value
+                        , subq_0.booking_value_p99
+                        , subq_0.discrete_booking_value_p99
+                        , subq_0.approximate_continuous_booking_value_p99
+                        , subq_0.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -342,86 +342,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_6
-                    ) subq_7
+                      ) subq_0
+                    ) subq_1
                     WHERE booking__is_instant
-                  ) subq_8
-                ) subq_9
+                  ) subq_2
+                ) subq_3
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_11.listing
-                    , subq_11.is_lux_latest
+                    subq_5.listing
+                    , subq_5.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_10.ds__day
-                      , subq_10.ds__week
-                      , subq_10.ds__month
-                      , subq_10.ds__quarter
-                      , subq_10.ds__year
-                      , subq_10.ds__extract_year
-                      , subq_10.ds__extract_quarter
-                      , subq_10.ds__extract_month
-                      , subq_10.ds__extract_day
-                      , subq_10.ds__extract_dow
-                      , subq_10.ds__extract_doy
-                      , subq_10.created_at__day
-                      , subq_10.created_at__week
-                      , subq_10.created_at__month
-                      , subq_10.created_at__quarter
-                      , subq_10.created_at__year
-                      , subq_10.created_at__extract_year
-                      , subq_10.created_at__extract_quarter
-                      , subq_10.created_at__extract_month
-                      , subq_10.created_at__extract_day
-                      , subq_10.created_at__extract_dow
-                      , subq_10.created_at__extract_doy
-                      , subq_10.listing__ds__day
-                      , subq_10.listing__ds__week
-                      , subq_10.listing__ds__month
-                      , subq_10.listing__ds__quarter
-                      , subq_10.listing__ds__year
-                      , subq_10.listing__ds__extract_year
-                      , subq_10.listing__ds__extract_quarter
-                      , subq_10.listing__ds__extract_month
-                      , subq_10.listing__ds__extract_day
-                      , subq_10.listing__ds__extract_dow
-                      , subq_10.listing__ds__extract_doy
-                      , subq_10.listing__created_at__day
-                      , subq_10.listing__created_at__week
-                      , subq_10.listing__created_at__month
-                      , subq_10.listing__created_at__quarter
-                      , subq_10.listing__created_at__year
-                      , subq_10.listing__created_at__extract_year
-                      , subq_10.listing__created_at__extract_quarter
-                      , subq_10.listing__created_at__extract_month
-                      , subq_10.listing__created_at__extract_day
-                      , subq_10.listing__created_at__extract_dow
-                      , subq_10.listing__created_at__extract_doy
-                      , subq_10.ds__day AS metric_time__day
-                      , subq_10.ds__week AS metric_time__week
-                      , subq_10.ds__month AS metric_time__month
-                      , subq_10.ds__quarter AS metric_time__quarter
-                      , subq_10.ds__year AS metric_time__year
-                      , subq_10.ds__extract_year AS metric_time__extract_year
-                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_10.ds__extract_month AS metric_time__extract_month
-                      , subq_10.ds__extract_day AS metric_time__extract_day
-                      , subq_10.ds__extract_dow AS metric_time__extract_dow
-                      , subq_10.ds__extract_doy AS metric_time__extract_doy
-                      , subq_10.listing
-                      , subq_10.user
-                      , subq_10.listing__user
-                      , subq_10.country_latest
-                      , subq_10.is_lux_latest
-                      , subq_10.capacity_latest
-                      , subq_10.listing__country_latest
-                      , subq_10.listing__is_lux_latest
-                      , subq_10.listing__capacity_latest
-                      , subq_10.listings
-                      , subq_10.largest_listing
-                      , subq_10.smallest_listing
+                      subq_4.ds__day
+                      , subq_4.ds__week
+                      , subq_4.ds__month
+                      , subq_4.ds__quarter
+                      , subq_4.ds__year
+                      , subq_4.ds__extract_year
+                      , subq_4.ds__extract_quarter
+                      , subq_4.ds__extract_month
+                      , subq_4.ds__extract_day
+                      , subq_4.ds__extract_dow
+                      , subq_4.ds__extract_doy
+                      , subq_4.created_at__day
+                      , subq_4.created_at__week
+                      , subq_4.created_at__month
+                      , subq_4.created_at__quarter
+                      , subq_4.created_at__year
+                      , subq_4.created_at__extract_year
+                      , subq_4.created_at__extract_quarter
+                      , subq_4.created_at__extract_month
+                      , subq_4.created_at__extract_day
+                      , subq_4.created_at__extract_dow
+                      , subq_4.created_at__extract_doy
+                      , subq_4.listing__ds__day
+                      , subq_4.listing__ds__week
+                      , subq_4.listing__ds__month
+                      , subq_4.listing__ds__quarter
+                      , subq_4.listing__ds__year
+                      , subq_4.listing__ds__extract_year
+                      , subq_4.listing__ds__extract_quarter
+                      , subq_4.listing__ds__extract_month
+                      , subq_4.listing__ds__extract_day
+                      , subq_4.listing__ds__extract_dow
+                      , subq_4.listing__ds__extract_doy
+                      , subq_4.listing__created_at__day
+                      , subq_4.listing__created_at__week
+                      , subq_4.listing__created_at__month
+                      , subq_4.listing__created_at__quarter
+                      , subq_4.listing__created_at__year
+                      , subq_4.listing__created_at__extract_year
+                      , subq_4.listing__created_at__extract_quarter
+                      , subq_4.listing__created_at__extract_month
+                      , subq_4.listing__created_at__extract_day
+                      , subq_4.listing__created_at__extract_dow
+                      , subq_4.listing__created_at__extract_doy
+                      , subq_4.ds__day AS metric_time__day
+                      , subq_4.ds__week AS metric_time__week
+                      , subq_4.ds__month AS metric_time__month
+                      , subq_4.ds__quarter AS metric_time__quarter
+                      , subq_4.ds__year AS metric_time__year
+                      , subq_4.ds__extract_year AS metric_time__extract_year
+                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_4.ds__extract_month AS metric_time__extract_month
+                      , subq_4.ds__extract_day AS metric_time__extract_day
+                      , subq_4.ds__extract_dow AS metric_time__extract_dow
+                      , subq_4.ds__extract_doy AS metric_time__extract_doy
+                      , subq_4.listing
+                      , subq_4.user
+                      , subq_4.listing__user
+                      , subq_4.country_latest
+                      , subq_4.is_lux_latest
+                      , subq_4.capacity_latest
+                      , subq_4.listing__country_latest
+                      , subq_4.listing__is_lux_latest
+                      , subq_4.listing__capacity_latest
+                      , subq_4.listings
+                      , subq_4.largest_listing
+                      , subq_4.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,257 +482,257 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_10
-                  ) subq_11
-                ) subq_12
+                    ) subq_4
+                  ) subq_5
+                ) subq_6
                 ON
-                  subq_9.listing = subq_12.listing
-              ) subq_13
-            ) subq_14
+                  subq_3.listing = subq_6.listing
+              ) subq_7
+            ) subq_8
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_15
-        ) subq_16
-      ) subq_17
-    ) subq_18
+          ) subq_9
+        ) subq_10
+      ) subq_11
+    ) subq_12
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_30.bookings
+        subq_24.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_29.bookings) AS bookings
+          SUM(subq_23.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_28.bookings
+            subq_22.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_27.booking__is_instant
-              , subq_27.listing__is_lux_latest
-              , subq_27.bookings
+              subq_21.booking__is_instant
+              , subq_21.listing__is_lux_latest
+              , subq_21.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_26.booking__is_instant
-                , subq_26.listing__is_lux_latest
-                , subq_26.bookings
+                subq_20.booking__is_instant
+                , subq_20.listing__is_lux_latest
+                , subq_20.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_22.listing AS listing
-                  , subq_22.booking__is_instant AS booking__is_instant
-                  , subq_25.is_lux_latest AS listing__is_lux_latest
-                  , subq_22.bookings AS bookings
+                  subq_16.listing AS listing
+                  , subq_16.booking__is_instant AS booking__is_instant
+                  , subq_19.is_lux_latest AS listing__is_lux_latest
+                  , subq_16.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_21.listing
-                    , subq_21.booking__is_instant
-                    , subq_21.bookings
+                    subq_15.listing
+                    , subq_15.booking__is_instant
+                    , subq_15.bookings
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_20.ds__day
-                      , subq_20.ds__week
-                      , subq_20.ds__month
-                      , subq_20.ds__quarter
-                      , subq_20.ds__year
-                      , subq_20.ds__extract_year
-                      , subq_20.ds__extract_quarter
-                      , subq_20.ds__extract_month
-                      , subq_20.ds__extract_day
-                      , subq_20.ds__extract_dow
-                      , subq_20.ds__extract_doy
-                      , subq_20.ds_partitioned__day
-                      , subq_20.ds_partitioned__week
-                      , subq_20.ds_partitioned__month
-                      , subq_20.ds_partitioned__quarter
-                      , subq_20.ds_partitioned__year
-                      , subq_20.ds_partitioned__extract_year
-                      , subq_20.ds_partitioned__extract_quarter
-                      , subq_20.ds_partitioned__extract_month
-                      , subq_20.ds_partitioned__extract_day
-                      , subq_20.ds_partitioned__extract_dow
-                      , subq_20.ds_partitioned__extract_doy
-                      , subq_20.paid_at__day
-                      , subq_20.paid_at__week
-                      , subq_20.paid_at__month
-                      , subq_20.paid_at__quarter
-                      , subq_20.paid_at__year
-                      , subq_20.paid_at__extract_year
-                      , subq_20.paid_at__extract_quarter
-                      , subq_20.paid_at__extract_month
-                      , subq_20.paid_at__extract_day
-                      , subq_20.paid_at__extract_dow
-                      , subq_20.paid_at__extract_doy
-                      , subq_20.booking__ds__day
-                      , subq_20.booking__ds__week
-                      , subq_20.booking__ds__month
-                      , subq_20.booking__ds__quarter
-                      , subq_20.booking__ds__year
-                      , subq_20.booking__ds__extract_year
-                      , subq_20.booking__ds__extract_quarter
-                      , subq_20.booking__ds__extract_month
-                      , subq_20.booking__ds__extract_day
-                      , subq_20.booking__ds__extract_dow
-                      , subq_20.booking__ds__extract_doy
-                      , subq_20.booking__ds_partitioned__day
-                      , subq_20.booking__ds_partitioned__week
-                      , subq_20.booking__ds_partitioned__month
-                      , subq_20.booking__ds_partitioned__quarter
-                      , subq_20.booking__ds_partitioned__year
-                      , subq_20.booking__ds_partitioned__extract_year
-                      , subq_20.booking__ds_partitioned__extract_quarter
-                      , subq_20.booking__ds_partitioned__extract_month
-                      , subq_20.booking__ds_partitioned__extract_day
-                      , subq_20.booking__ds_partitioned__extract_dow
-                      , subq_20.booking__ds_partitioned__extract_doy
-                      , subq_20.booking__paid_at__day
-                      , subq_20.booking__paid_at__week
-                      , subq_20.booking__paid_at__month
-                      , subq_20.booking__paid_at__quarter
-                      , subq_20.booking__paid_at__year
-                      , subq_20.booking__paid_at__extract_year
-                      , subq_20.booking__paid_at__extract_quarter
-                      , subq_20.booking__paid_at__extract_month
-                      , subq_20.booking__paid_at__extract_day
-                      , subq_20.booking__paid_at__extract_dow
-                      , subq_20.booking__paid_at__extract_doy
-                      , subq_20.metric_time__day
-                      , subq_20.metric_time__week
-                      , subq_20.metric_time__month
-                      , subq_20.metric_time__quarter
-                      , subq_20.metric_time__year
-                      , subq_20.metric_time__extract_year
-                      , subq_20.metric_time__extract_quarter
-                      , subq_20.metric_time__extract_month
-                      , subq_20.metric_time__extract_day
-                      , subq_20.metric_time__extract_dow
-                      , subq_20.metric_time__extract_doy
-                      , subq_20.listing
-                      , subq_20.guest
-                      , subq_20.host
-                      , subq_20.booking__listing
-                      , subq_20.booking__guest
-                      , subq_20.booking__host
-                      , subq_20.is_instant
-                      , subq_20.booking__is_instant
-                      , subq_20.bookings
-                      , subq_20.instant_bookings
-                      , subq_20.booking_value
-                      , subq_20.max_booking_value
-                      , subq_20.min_booking_value
-                      , subq_20.bookers
-                      , subq_20.average_booking_value
-                      , subq_20.referred_bookings
-                      , subq_20.median_booking_value
-                      , subq_20.booking_value_p99
-                      , subq_20.discrete_booking_value_p99
-                      , subq_20.approximate_continuous_booking_value_p99
-                      , subq_20.approximate_discrete_booking_value_p99
+                      subq_14.ds__day
+                      , subq_14.ds__week
+                      , subq_14.ds__month
+                      , subq_14.ds__quarter
+                      , subq_14.ds__year
+                      , subq_14.ds__extract_year
+                      , subq_14.ds__extract_quarter
+                      , subq_14.ds__extract_month
+                      , subq_14.ds__extract_day
+                      , subq_14.ds__extract_dow
+                      , subq_14.ds__extract_doy
+                      , subq_14.ds_partitioned__day
+                      , subq_14.ds_partitioned__week
+                      , subq_14.ds_partitioned__month
+                      , subq_14.ds_partitioned__quarter
+                      , subq_14.ds_partitioned__year
+                      , subq_14.ds_partitioned__extract_year
+                      , subq_14.ds_partitioned__extract_quarter
+                      , subq_14.ds_partitioned__extract_month
+                      , subq_14.ds_partitioned__extract_day
+                      , subq_14.ds_partitioned__extract_dow
+                      , subq_14.ds_partitioned__extract_doy
+                      , subq_14.paid_at__day
+                      , subq_14.paid_at__week
+                      , subq_14.paid_at__month
+                      , subq_14.paid_at__quarter
+                      , subq_14.paid_at__year
+                      , subq_14.paid_at__extract_year
+                      , subq_14.paid_at__extract_quarter
+                      , subq_14.paid_at__extract_month
+                      , subq_14.paid_at__extract_day
+                      , subq_14.paid_at__extract_dow
+                      , subq_14.paid_at__extract_doy
+                      , subq_14.booking__ds__day
+                      , subq_14.booking__ds__week
+                      , subq_14.booking__ds__month
+                      , subq_14.booking__ds__quarter
+                      , subq_14.booking__ds__year
+                      , subq_14.booking__ds__extract_year
+                      , subq_14.booking__ds__extract_quarter
+                      , subq_14.booking__ds__extract_month
+                      , subq_14.booking__ds__extract_day
+                      , subq_14.booking__ds__extract_dow
+                      , subq_14.booking__ds__extract_doy
+                      , subq_14.booking__ds_partitioned__day
+                      , subq_14.booking__ds_partitioned__week
+                      , subq_14.booking__ds_partitioned__month
+                      , subq_14.booking__ds_partitioned__quarter
+                      , subq_14.booking__ds_partitioned__year
+                      , subq_14.booking__ds_partitioned__extract_year
+                      , subq_14.booking__ds_partitioned__extract_quarter
+                      , subq_14.booking__ds_partitioned__extract_month
+                      , subq_14.booking__ds_partitioned__extract_day
+                      , subq_14.booking__ds_partitioned__extract_dow
+                      , subq_14.booking__ds_partitioned__extract_doy
+                      , subq_14.booking__paid_at__day
+                      , subq_14.booking__paid_at__week
+                      , subq_14.booking__paid_at__month
+                      , subq_14.booking__paid_at__quarter
+                      , subq_14.booking__paid_at__year
+                      , subq_14.booking__paid_at__extract_year
+                      , subq_14.booking__paid_at__extract_quarter
+                      , subq_14.booking__paid_at__extract_month
+                      , subq_14.booking__paid_at__extract_day
+                      , subq_14.booking__paid_at__extract_dow
+                      , subq_14.booking__paid_at__extract_doy
+                      , subq_14.metric_time__day
+                      , subq_14.metric_time__week
+                      , subq_14.metric_time__month
+                      , subq_14.metric_time__quarter
+                      , subq_14.metric_time__year
+                      , subq_14.metric_time__extract_year
+                      , subq_14.metric_time__extract_quarter
+                      , subq_14.metric_time__extract_month
+                      , subq_14.metric_time__extract_day
+                      , subq_14.metric_time__extract_dow
+                      , subq_14.metric_time__extract_doy
+                      , subq_14.listing
+                      , subq_14.guest
+                      , subq_14.host
+                      , subq_14.booking__listing
+                      , subq_14.booking__guest
+                      , subq_14.booking__host
+                      , subq_14.is_instant
+                      , subq_14.booking__is_instant
+                      , subq_14.bookings
+                      , subq_14.instant_bookings
+                      , subq_14.booking_value
+                      , subq_14.max_booking_value
+                      , subq_14.min_booking_value
+                      , subq_14.bookers
+                      , subq_14.average_booking_value
+                      , subq_14.referred_bookings
+                      , subq_14.median_booking_value
+                      , subq_14.booking_value_p99
+                      , subq_14.discrete_booking_value_p99
+                      , subq_14.approximate_continuous_booking_value_p99
+                      , subq_14.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_19.ds__day
-                        , subq_19.ds__week
-                        , subq_19.ds__month
-                        , subq_19.ds__quarter
-                        , subq_19.ds__year
-                        , subq_19.ds__extract_year
-                        , subq_19.ds__extract_quarter
-                        , subq_19.ds__extract_month
-                        , subq_19.ds__extract_day
-                        , subq_19.ds__extract_dow
-                        , subq_19.ds__extract_doy
-                        , subq_19.ds_partitioned__day
-                        , subq_19.ds_partitioned__week
-                        , subq_19.ds_partitioned__month
-                        , subq_19.ds_partitioned__quarter
-                        , subq_19.ds_partitioned__year
-                        , subq_19.ds_partitioned__extract_year
-                        , subq_19.ds_partitioned__extract_quarter
-                        , subq_19.ds_partitioned__extract_month
-                        , subq_19.ds_partitioned__extract_day
-                        , subq_19.ds_partitioned__extract_dow
-                        , subq_19.ds_partitioned__extract_doy
-                        , subq_19.paid_at__day
-                        , subq_19.paid_at__week
-                        , subq_19.paid_at__month
-                        , subq_19.paid_at__quarter
-                        , subq_19.paid_at__year
-                        , subq_19.paid_at__extract_year
-                        , subq_19.paid_at__extract_quarter
-                        , subq_19.paid_at__extract_month
-                        , subq_19.paid_at__extract_day
-                        , subq_19.paid_at__extract_dow
-                        , subq_19.paid_at__extract_doy
-                        , subq_19.booking__ds__day
-                        , subq_19.booking__ds__week
-                        , subq_19.booking__ds__month
-                        , subq_19.booking__ds__quarter
-                        , subq_19.booking__ds__year
-                        , subq_19.booking__ds__extract_year
-                        , subq_19.booking__ds__extract_quarter
-                        , subq_19.booking__ds__extract_month
-                        , subq_19.booking__ds__extract_day
-                        , subq_19.booking__ds__extract_dow
-                        , subq_19.booking__ds__extract_doy
-                        , subq_19.booking__ds_partitioned__day
-                        , subq_19.booking__ds_partitioned__week
-                        , subq_19.booking__ds_partitioned__month
-                        , subq_19.booking__ds_partitioned__quarter
-                        , subq_19.booking__ds_partitioned__year
-                        , subq_19.booking__ds_partitioned__extract_year
-                        , subq_19.booking__ds_partitioned__extract_quarter
-                        , subq_19.booking__ds_partitioned__extract_month
-                        , subq_19.booking__ds_partitioned__extract_day
-                        , subq_19.booking__ds_partitioned__extract_dow
-                        , subq_19.booking__ds_partitioned__extract_doy
-                        , subq_19.booking__paid_at__day
-                        , subq_19.booking__paid_at__week
-                        , subq_19.booking__paid_at__month
-                        , subq_19.booking__paid_at__quarter
-                        , subq_19.booking__paid_at__year
-                        , subq_19.booking__paid_at__extract_year
-                        , subq_19.booking__paid_at__extract_quarter
-                        , subq_19.booking__paid_at__extract_month
-                        , subq_19.booking__paid_at__extract_day
-                        , subq_19.booking__paid_at__extract_dow
-                        , subq_19.booking__paid_at__extract_doy
-                        , subq_19.ds__day AS metric_time__day
-                        , subq_19.ds__week AS metric_time__week
-                        , subq_19.ds__month AS metric_time__month
-                        , subq_19.ds__quarter AS metric_time__quarter
-                        , subq_19.ds__year AS metric_time__year
-                        , subq_19.ds__extract_year AS metric_time__extract_year
-                        , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_19.ds__extract_month AS metric_time__extract_month
-                        , subq_19.ds__extract_day AS metric_time__extract_day
-                        , subq_19.ds__extract_dow AS metric_time__extract_dow
-                        , subq_19.ds__extract_doy AS metric_time__extract_doy
-                        , subq_19.listing
-                        , subq_19.guest
-                        , subq_19.host
-                        , subq_19.booking__listing
-                        , subq_19.booking__guest
-                        , subq_19.booking__host
-                        , subq_19.is_instant
-                        , subq_19.booking__is_instant
-                        , subq_19.bookings
-                        , subq_19.instant_bookings
-                        , subq_19.booking_value
-                        , subq_19.max_booking_value
-                        , subq_19.min_booking_value
-                        , subq_19.bookers
-                        , subq_19.average_booking_value
-                        , subq_19.referred_bookings
-                        , subq_19.median_booking_value
-                        , subq_19.booking_value_p99
-                        , subq_19.discrete_booking_value_p99
-                        , subq_19.approximate_continuous_booking_value_p99
-                        , subq_19.approximate_discrete_booking_value_p99
+                        subq_13.ds__day
+                        , subq_13.ds__week
+                        , subq_13.ds__month
+                        , subq_13.ds__quarter
+                        , subq_13.ds__year
+                        , subq_13.ds__extract_year
+                        , subq_13.ds__extract_quarter
+                        , subq_13.ds__extract_month
+                        , subq_13.ds__extract_day
+                        , subq_13.ds__extract_dow
+                        , subq_13.ds__extract_doy
+                        , subq_13.ds_partitioned__day
+                        , subq_13.ds_partitioned__week
+                        , subq_13.ds_partitioned__month
+                        , subq_13.ds_partitioned__quarter
+                        , subq_13.ds_partitioned__year
+                        , subq_13.ds_partitioned__extract_year
+                        , subq_13.ds_partitioned__extract_quarter
+                        , subq_13.ds_partitioned__extract_month
+                        , subq_13.ds_partitioned__extract_day
+                        , subq_13.ds_partitioned__extract_dow
+                        , subq_13.ds_partitioned__extract_doy
+                        , subq_13.paid_at__day
+                        , subq_13.paid_at__week
+                        , subq_13.paid_at__month
+                        , subq_13.paid_at__quarter
+                        , subq_13.paid_at__year
+                        , subq_13.paid_at__extract_year
+                        , subq_13.paid_at__extract_quarter
+                        , subq_13.paid_at__extract_month
+                        , subq_13.paid_at__extract_day
+                        , subq_13.paid_at__extract_dow
+                        , subq_13.paid_at__extract_doy
+                        , subq_13.booking__ds__day
+                        , subq_13.booking__ds__week
+                        , subq_13.booking__ds__month
+                        , subq_13.booking__ds__quarter
+                        , subq_13.booking__ds__year
+                        , subq_13.booking__ds__extract_year
+                        , subq_13.booking__ds__extract_quarter
+                        , subq_13.booking__ds__extract_month
+                        , subq_13.booking__ds__extract_day
+                        , subq_13.booking__ds__extract_dow
+                        , subq_13.booking__ds__extract_doy
+                        , subq_13.booking__ds_partitioned__day
+                        , subq_13.booking__ds_partitioned__week
+                        , subq_13.booking__ds_partitioned__month
+                        , subq_13.booking__ds_partitioned__quarter
+                        , subq_13.booking__ds_partitioned__year
+                        , subq_13.booking__ds_partitioned__extract_year
+                        , subq_13.booking__ds_partitioned__extract_quarter
+                        , subq_13.booking__ds_partitioned__extract_month
+                        , subq_13.booking__ds_partitioned__extract_day
+                        , subq_13.booking__ds_partitioned__extract_dow
+                        , subq_13.booking__ds_partitioned__extract_doy
+                        , subq_13.booking__paid_at__day
+                        , subq_13.booking__paid_at__week
+                        , subq_13.booking__paid_at__month
+                        , subq_13.booking__paid_at__quarter
+                        , subq_13.booking__paid_at__year
+                        , subq_13.booking__paid_at__extract_year
+                        , subq_13.booking__paid_at__extract_quarter
+                        , subq_13.booking__paid_at__extract_month
+                        , subq_13.booking__paid_at__extract_day
+                        , subq_13.booking__paid_at__extract_dow
+                        , subq_13.booking__paid_at__extract_doy
+                        , subq_13.ds__day AS metric_time__day
+                        , subq_13.ds__week AS metric_time__week
+                        , subq_13.ds__month AS metric_time__month
+                        , subq_13.ds__quarter AS metric_time__quarter
+                        , subq_13.ds__year AS metric_time__year
+                        , subq_13.ds__extract_year AS metric_time__extract_year
+                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_13.ds__extract_month AS metric_time__extract_month
+                        , subq_13.ds__extract_day AS metric_time__extract_day
+                        , subq_13.ds__extract_dow AS metric_time__extract_dow
+                        , subq_13.ds__extract_doy AS metric_time__extract_doy
+                        , subq_13.listing
+                        , subq_13.guest
+                        , subq_13.host
+                        , subq_13.booking__listing
+                        , subq_13.booking__guest
+                        , subq_13.booking__host
+                        , subq_13.is_instant
+                        , subq_13.booking__is_instant
+                        , subq_13.bookings
+                        , subq_13.instant_bookings
+                        , subq_13.booking_value
+                        , subq_13.max_booking_value
+                        , subq_13.min_booking_value
+                        , subq_13.bookers
+                        , subq_13.average_booking_value
+                        , subq_13.referred_bookings
+                        , subq_13.median_booking_value
+                        , subq_13.booking_value_p99
+                        , subq_13.discrete_booking_value_p99
+                        , subq_13.approximate_continuous_booking_value_p99
+                        , subq_13.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -825,86 +825,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_19
-                    ) subq_20
+                      ) subq_13
+                    ) subq_14
                     WHERE booking__is_instant
-                  ) subq_21
-                ) subq_22
+                  ) subq_15
+                ) subq_16
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_24.listing
-                    , subq_24.is_lux_latest
+                    subq_18.listing
+                    , subq_18.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_23.ds__day
-                      , subq_23.ds__week
-                      , subq_23.ds__month
-                      , subq_23.ds__quarter
-                      , subq_23.ds__year
-                      , subq_23.ds__extract_year
-                      , subq_23.ds__extract_quarter
-                      , subq_23.ds__extract_month
-                      , subq_23.ds__extract_day
-                      , subq_23.ds__extract_dow
-                      , subq_23.ds__extract_doy
-                      , subq_23.created_at__day
-                      , subq_23.created_at__week
-                      , subq_23.created_at__month
-                      , subq_23.created_at__quarter
-                      , subq_23.created_at__year
-                      , subq_23.created_at__extract_year
-                      , subq_23.created_at__extract_quarter
-                      , subq_23.created_at__extract_month
-                      , subq_23.created_at__extract_day
-                      , subq_23.created_at__extract_dow
-                      , subq_23.created_at__extract_doy
-                      , subq_23.listing__ds__day
-                      , subq_23.listing__ds__week
-                      , subq_23.listing__ds__month
-                      , subq_23.listing__ds__quarter
-                      , subq_23.listing__ds__year
-                      , subq_23.listing__ds__extract_year
-                      , subq_23.listing__ds__extract_quarter
-                      , subq_23.listing__ds__extract_month
-                      , subq_23.listing__ds__extract_day
-                      , subq_23.listing__ds__extract_dow
-                      , subq_23.listing__ds__extract_doy
-                      , subq_23.listing__created_at__day
-                      , subq_23.listing__created_at__week
-                      , subq_23.listing__created_at__month
-                      , subq_23.listing__created_at__quarter
-                      , subq_23.listing__created_at__year
-                      , subq_23.listing__created_at__extract_year
-                      , subq_23.listing__created_at__extract_quarter
-                      , subq_23.listing__created_at__extract_month
-                      , subq_23.listing__created_at__extract_day
-                      , subq_23.listing__created_at__extract_dow
-                      , subq_23.listing__created_at__extract_doy
-                      , subq_23.ds__day AS metric_time__day
-                      , subq_23.ds__week AS metric_time__week
-                      , subq_23.ds__month AS metric_time__month
-                      , subq_23.ds__quarter AS metric_time__quarter
-                      , subq_23.ds__year AS metric_time__year
-                      , subq_23.ds__extract_year AS metric_time__extract_year
-                      , subq_23.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_23.ds__extract_month AS metric_time__extract_month
-                      , subq_23.ds__extract_day AS metric_time__extract_day
-                      , subq_23.ds__extract_dow AS metric_time__extract_dow
-                      , subq_23.ds__extract_doy AS metric_time__extract_doy
-                      , subq_23.listing
-                      , subq_23.user
-                      , subq_23.listing__user
-                      , subq_23.country_latest
-                      , subq_23.is_lux_latest
-                      , subq_23.capacity_latest
-                      , subq_23.listing__country_latest
-                      , subq_23.listing__is_lux_latest
-                      , subq_23.listing__capacity_latest
-                      , subq_23.listings
-                      , subq_23.largest_listing
-                      , subq_23.smallest_listing
+                      subq_17.ds__day
+                      , subq_17.ds__week
+                      , subq_17.ds__month
+                      , subq_17.ds__quarter
+                      , subq_17.ds__year
+                      , subq_17.ds__extract_year
+                      , subq_17.ds__extract_quarter
+                      , subq_17.ds__extract_month
+                      , subq_17.ds__extract_day
+                      , subq_17.ds__extract_dow
+                      , subq_17.ds__extract_doy
+                      , subq_17.created_at__day
+                      , subq_17.created_at__week
+                      , subq_17.created_at__month
+                      , subq_17.created_at__quarter
+                      , subq_17.created_at__year
+                      , subq_17.created_at__extract_year
+                      , subq_17.created_at__extract_quarter
+                      , subq_17.created_at__extract_month
+                      , subq_17.created_at__extract_day
+                      , subq_17.created_at__extract_dow
+                      , subq_17.created_at__extract_doy
+                      , subq_17.listing__ds__day
+                      , subq_17.listing__ds__week
+                      , subq_17.listing__ds__month
+                      , subq_17.listing__ds__quarter
+                      , subq_17.listing__ds__year
+                      , subq_17.listing__ds__extract_year
+                      , subq_17.listing__ds__extract_quarter
+                      , subq_17.listing__ds__extract_month
+                      , subq_17.listing__ds__extract_day
+                      , subq_17.listing__ds__extract_dow
+                      , subq_17.listing__ds__extract_doy
+                      , subq_17.listing__created_at__day
+                      , subq_17.listing__created_at__week
+                      , subq_17.listing__created_at__month
+                      , subq_17.listing__created_at__quarter
+                      , subq_17.listing__created_at__year
+                      , subq_17.listing__created_at__extract_year
+                      , subq_17.listing__created_at__extract_quarter
+                      , subq_17.listing__created_at__extract_month
+                      , subq_17.listing__created_at__extract_day
+                      , subq_17.listing__created_at__extract_dow
+                      , subq_17.listing__created_at__extract_doy
+                      , subq_17.ds__day AS metric_time__day
+                      , subq_17.ds__week AS metric_time__week
+                      , subq_17.ds__month AS metric_time__month
+                      , subq_17.ds__quarter AS metric_time__quarter
+                      , subq_17.ds__year AS metric_time__year
+                      , subq_17.ds__extract_year AS metric_time__extract_year
+                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_17.ds__extract_month AS metric_time__extract_month
+                      , subq_17.ds__extract_day AS metric_time__extract_day
+                      , subq_17.ds__extract_dow AS metric_time__extract_dow
+                      , subq_17.ds__extract_doy AS metric_time__extract_doy
+                      , subq_17.listing
+                      , subq_17.user
+                      , subq_17.listing__user
+                      , subq_17.country_latest
+                      , subq_17.is_lux_latest
+                      , subq_17.capacity_latest
+                      , subq_17.listing__country_latest
+                      , subq_17.listing__is_lux_latest
+                      , subq_17.listing__capacity_latest
+                      , subq_17.listings
+                      , subq_17.largest_listing
+                      , subq_17.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,242 +965,242 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_23
-                  ) subq_24
-                ) subq_25
+                    ) subq_17
+                  ) subq_18
+                ) subq_19
                 ON
-                  subq_22.listing = subq_25.listing
-              ) subq_26
-            ) subq_27
+                  subq_16.listing = subq_19.listing
+              ) subq_20
+            ) subq_21
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_28
-        ) subq_29
-      ) subq_30
-    ) subq_31
+          ) subq_22
+        ) subq_23
+      ) subq_24
+    ) subq_25
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_38.booking_value
+        subq_32.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_37.booking_value) AS booking_value
+          SUM(subq_31.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_36.booking_value
+            subq_30.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_35.booking__is_instant
-              , subq_35.booking_value
+              subq_29.booking__is_instant
+              , subq_29.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_34.booking__is_instant
-                , subq_34.booking_value
+                subq_28.booking__is_instant
+                , subq_28.booking_value
               FROM (
                 -- Constrain Output with WHERE
                 SELECT
-                  subq_33.ds__day
-                  , subq_33.ds__week
-                  , subq_33.ds__month
-                  , subq_33.ds__quarter
-                  , subq_33.ds__year
-                  , subq_33.ds__extract_year
-                  , subq_33.ds__extract_quarter
-                  , subq_33.ds__extract_month
-                  , subq_33.ds__extract_day
-                  , subq_33.ds__extract_dow
-                  , subq_33.ds__extract_doy
-                  , subq_33.ds_partitioned__day
-                  , subq_33.ds_partitioned__week
-                  , subq_33.ds_partitioned__month
-                  , subq_33.ds_partitioned__quarter
-                  , subq_33.ds_partitioned__year
-                  , subq_33.ds_partitioned__extract_year
-                  , subq_33.ds_partitioned__extract_quarter
-                  , subq_33.ds_partitioned__extract_month
-                  , subq_33.ds_partitioned__extract_day
-                  , subq_33.ds_partitioned__extract_dow
-                  , subq_33.ds_partitioned__extract_doy
-                  , subq_33.paid_at__day
-                  , subq_33.paid_at__week
-                  , subq_33.paid_at__month
-                  , subq_33.paid_at__quarter
-                  , subq_33.paid_at__year
-                  , subq_33.paid_at__extract_year
-                  , subq_33.paid_at__extract_quarter
-                  , subq_33.paid_at__extract_month
-                  , subq_33.paid_at__extract_day
-                  , subq_33.paid_at__extract_dow
-                  , subq_33.paid_at__extract_doy
-                  , subq_33.booking__ds__day
-                  , subq_33.booking__ds__week
-                  , subq_33.booking__ds__month
-                  , subq_33.booking__ds__quarter
-                  , subq_33.booking__ds__year
-                  , subq_33.booking__ds__extract_year
-                  , subq_33.booking__ds__extract_quarter
-                  , subq_33.booking__ds__extract_month
-                  , subq_33.booking__ds__extract_day
-                  , subq_33.booking__ds__extract_dow
-                  , subq_33.booking__ds__extract_doy
-                  , subq_33.booking__ds_partitioned__day
-                  , subq_33.booking__ds_partitioned__week
-                  , subq_33.booking__ds_partitioned__month
-                  , subq_33.booking__ds_partitioned__quarter
-                  , subq_33.booking__ds_partitioned__year
-                  , subq_33.booking__ds_partitioned__extract_year
-                  , subq_33.booking__ds_partitioned__extract_quarter
-                  , subq_33.booking__ds_partitioned__extract_month
-                  , subq_33.booking__ds_partitioned__extract_day
-                  , subq_33.booking__ds_partitioned__extract_dow
-                  , subq_33.booking__ds_partitioned__extract_doy
-                  , subq_33.booking__paid_at__day
-                  , subq_33.booking__paid_at__week
-                  , subq_33.booking__paid_at__month
-                  , subq_33.booking__paid_at__quarter
-                  , subq_33.booking__paid_at__year
-                  , subq_33.booking__paid_at__extract_year
-                  , subq_33.booking__paid_at__extract_quarter
-                  , subq_33.booking__paid_at__extract_month
-                  , subq_33.booking__paid_at__extract_day
-                  , subq_33.booking__paid_at__extract_dow
-                  , subq_33.booking__paid_at__extract_doy
-                  , subq_33.metric_time__day
-                  , subq_33.metric_time__week
-                  , subq_33.metric_time__month
-                  , subq_33.metric_time__quarter
-                  , subq_33.metric_time__year
-                  , subq_33.metric_time__extract_year
-                  , subq_33.metric_time__extract_quarter
-                  , subq_33.metric_time__extract_month
-                  , subq_33.metric_time__extract_day
-                  , subq_33.metric_time__extract_dow
-                  , subq_33.metric_time__extract_doy
-                  , subq_33.listing
-                  , subq_33.guest
-                  , subq_33.host
-                  , subq_33.booking__listing
-                  , subq_33.booking__guest
-                  , subq_33.booking__host
-                  , subq_33.is_instant
-                  , subq_33.booking__is_instant
-                  , subq_33.bookings
-                  , subq_33.instant_bookings
-                  , subq_33.booking_value
-                  , subq_33.max_booking_value
-                  , subq_33.min_booking_value
-                  , subq_33.bookers
-                  , subq_33.average_booking_value
-                  , subq_33.referred_bookings
-                  , subq_33.median_booking_value
-                  , subq_33.booking_value_p99
-                  , subq_33.discrete_booking_value_p99
-                  , subq_33.approximate_continuous_booking_value_p99
-                  , subq_33.approximate_discrete_booking_value_p99
+                  subq_27.ds__day
+                  , subq_27.ds__week
+                  , subq_27.ds__month
+                  , subq_27.ds__quarter
+                  , subq_27.ds__year
+                  , subq_27.ds__extract_year
+                  , subq_27.ds__extract_quarter
+                  , subq_27.ds__extract_month
+                  , subq_27.ds__extract_day
+                  , subq_27.ds__extract_dow
+                  , subq_27.ds__extract_doy
+                  , subq_27.ds_partitioned__day
+                  , subq_27.ds_partitioned__week
+                  , subq_27.ds_partitioned__month
+                  , subq_27.ds_partitioned__quarter
+                  , subq_27.ds_partitioned__year
+                  , subq_27.ds_partitioned__extract_year
+                  , subq_27.ds_partitioned__extract_quarter
+                  , subq_27.ds_partitioned__extract_month
+                  , subq_27.ds_partitioned__extract_day
+                  , subq_27.ds_partitioned__extract_dow
+                  , subq_27.ds_partitioned__extract_doy
+                  , subq_27.paid_at__day
+                  , subq_27.paid_at__week
+                  , subq_27.paid_at__month
+                  , subq_27.paid_at__quarter
+                  , subq_27.paid_at__year
+                  , subq_27.paid_at__extract_year
+                  , subq_27.paid_at__extract_quarter
+                  , subq_27.paid_at__extract_month
+                  , subq_27.paid_at__extract_day
+                  , subq_27.paid_at__extract_dow
+                  , subq_27.paid_at__extract_doy
+                  , subq_27.booking__ds__day
+                  , subq_27.booking__ds__week
+                  , subq_27.booking__ds__month
+                  , subq_27.booking__ds__quarter
+                  , subq_27.booking__ds__year
+                  , subq_27.booking__ds__extract_year
+                  , subq_27.booking__ds__extract_quarter
+                  , subq_27.booking__ds__extract_month
+                  , subq_27.booking__ds__extract_day
+                  , subq_27.booking__ds__extract_dow
+                  , subq_27.booking__ds__extract_doy
+                  , subq_27.booking__ds_partitioned__day
+                  , subq_27.booking__ds_partitioned__week
+                  , subq_27.booking__ds_partitioned__month
+                  , subq_27.booking__ds_partitioned__quarter
+                  , subq_27.booking__ds_partitioned__year
+                  , subq_27.booking__ds_partitioned__extract_year
+                  , subq_27.booking__ds_partitioned__extract_quarter
+                  , subq_27.booking__ds_partitioned__extract_month
+                  , subq_27.booking__ds_partitioned__extract_day
+                  , subq_27.booking__ds_partitioned__extract_dow
+                  , subq_27.booking__ds_partitioned__extract_doy
+                  , subq_27.booking__paid_at__day
+                  , subq_27.booking__paid_at__week
+                  , subq_27.booking__paid_at__month
+                  , subq_27.booking__paid_at__quarter
+                  , subq_27.booking__paid_at__year
+                  , subq_27.booking__paid_at__extract_year
+                  , subq_27.booking__paid_at__extract_quarter
+                  , subq_27.booking__paid_at__extract_month
+                  , subq_27.booking__paid_at__extract_day
+                  , subq_27.booking__paid_at__extract_dow
+                  , subq_27.booking__paid_at__extract_doy
+                  , subq_27.metric_time__day
+                  , subq_27.metric_time__week
+                  , subq_27.metric_time__month
+                  , subq_27.metric_time__quarter
+                  , subq_27.metric_time__year
+                  , subq_27.metric_time__extract_year
+                  , subq_27.metric_time__extract_quarter
+                  , subq_27.metric_time__extract_month
+                  , subq_27.metric_time__extract_day
+                  , subq_27.metric_time__extract_dow
+                  , subq_27.metric_time__extract_doy
+                  , subq_27.listing
+                  , subq_27.guest
+                  , subq_27.host
+                  , subq_27.booking__listing
+                  , subq_27.booking__guest
+                  , subq_27.booking__host
+                  , subq_27.is_instant
+                  , subq_27.booking__is_instant
+                  , subq_27.bookings
+                  , subq_27.instant_bookings
+                  , subq_27.booking_value
+                  , subq_27.max_booking_value
+                  , subq_27.min_booking_value
+                  , subq_27.bookers
+                  , subq_27.average_booking_value
+                  , subq_27.referred_bookings
+                  , subq_27.median_booking_value
+                  , subq_27.booking_value_p99
+                  , subq_27.discrete_booking_value_p99
+                  , subq_27.approximate_continuous_booking_value_p99
+                  , subq_27.approximate_discrete_booking_value_p99
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_32.ds__day
-                    , subq_32.ds__week
-                    , subq_32.ds__month
-                    , subq_32.ds__quarter
-                    , subq_32.ds__year
-                    , subq_32.ds__extract_year
-                    , subq_32.ds__extract_quarter
-                    , subq_32.ds__extract_month
-                    , subq_32.ds__extract_day
-                    , subq_32.ds__extract_dow
-                    , subq_32.ds__extract_doy
-                    , subq_32.ds_partitioned__day
-                    , subq_32.ds_partitioned__week
-                    , subq_32.ds_partitioned__month
-                    , subq_32.ds_partitioned__quarter
-                    , subq_32.ds_partitioned__year
-                    , subq_32.ds_partitioned__extract_year
-                    , subq_32.ds_partitioned__extract_quarter
-                    , subq_32.ds_partitioned__extract_month
-                    , subq_32.ds_partitioned__extract_day
-                    , subq_32.ds_partitioned__extract_dow
-                    , subq_32.ds_partitioned__extract_doy
-                    , subq_32.paid_at__day
-                    , subq_32.paid_at__week
-                    , subq_32.paid_at__month
-                    , subq_32.paid_at__quarter
-                    , subq_32.paid_at__year
-                    , subq_32.paid_at__extract_year
-                    , subq_32.paid_at__extract_quarter
-                    , subq_32.paid_at__extract_month
-                    , subq_32.paid_at__extract_day
-                    , subq_32.paid_at__extract_dow
-                    , subq_32.paid_at__extract_doy
-                    , subq_32.booking__ds__day
-                    , subq_32.booking__ds__week
-                    , subq_32.booking__ds__month
-                    , subq_32.booking__ds__quarter
-                    , subq_32.booking__ds__year
-                    , subq_32.booking__ds__extract_year
-                    , subq_32.booking__ds__extract_quarter
-                    , subq_32.booking__ds__extract_month
-                    , subq_32.booking__ds__extract_day
-                    , subq_32.booking__ds__extract_dow
-                    , subq_32.booking__ds__extract_doy
-                    , subq_32.booking__ds_partitioned__day
-                    , subq_32.booking__ds_partitioned__week
-                    , subq_32.booking__ds_partitioned__month
-                    , subq_32.booking__ds_partitioned__quarter
-                    , subq_32.booking__ds_partitioned__year
-                    , subq_32.booking__ds_partitioned__extract_year
-                    , subq_32.booking__ds_partitioned__extract_quarter
-                    , subq_32.booking__ds_partitioned__extract_month
-                    , subq_32.booking__ds_partitioned__extract_day
-                    , subq_32.booking__ds_partitioned__extract_dow
-                    , subq_32.booking__ds_partitioned__extract_doy
-                    , subq_32.booking__paid_at__day
-                    , subq_32.booking__paid_at__week
-                    , subq_32.booking__paid_at__month
-                    , subq_32.booking__paid_at__quarter
-                    , subq_32.booking__paid_at__year
-                    , subq_32.booking__paid_at__extract_year
-                    , subq_32.booking__paid_at__extract_quarter
-                    , subq_32.booking__paid_at__extract_month
-                    , subq_32.booking__paid_at__extract_day
-                    , subq_32.booking__paid_at__extract_dow
-                    , subq_32.booking__paid_at__extract_doy
-                    , subq_32.ds__day AS metric_time__day
-                    , subq_32.ds__week AS metric_time__week
-                    , subq_32.ds__month AS metric_time__month
-                    , subq_32.ds__quarter AS metric_time__quarter
-                    , subq_32.ds__year AS metric_time__year
-                    , subq_32.ds__extract_year AS metric_time__extract_year
-                    , subq_32.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_32.ds__extract_month AS metric_time__extract_month
-                    , subq_32.ds__extract_day AS metric_time__extract_day
-                    , subq_32.ds__extract_dow AS metric_time__extract_dow
-                    , subq_32.ds__extract_doy AS metric_time__extract_doy
-                    , subq_32.listing
-                    , subq_32.guest
-                    , subq_32.host
-                    , subq_32.booking__listing
-                    , subq_32.booking__guest
-                    , subq_32.booking__host
-                    , subq_32.is_instant
-                    , subq_32.booking__is_instant
-                    , subq_32.bookings
-                    , subq_32.instant_bookings
-                    , subq_32.booking_value
-                    , subq_32.max_booking_value
-                    , subq_32.min_booking_value
-                    , subq_32.bookers
-                    , subq_32.average_booking_value
-                    , subq_32.referred_bookings
-                    , subq_32.median_booking_value
-                    , subq_32.booking_value_p99
-                    , subq_32.discrete_booking_value_p99
-                    , subq_32.approximate_continuous_booking_value_p99
-                    , subq_32.approximate_discrete_booking_value_p99
+                    subq_26.ds__day
+                    , subq_26.ds__week
+                    , subq_26.ds__month
+                    , subq_26.ds__quarter
+                    , subq_26.ds__year
+                    , subq_26.ds__extract_year
+                    , subq_26.ds__extract_quarter
+                    , subq_26.ds__extract_month
+                    , subq_26.ds__extract_day
+                    , subq_26.ds__extract_dow
+                    , subq_26.ds__extract_doy
+                    , subq_26.ds_partitioned__day
+                    , subq_26.ds_partitioned__week
+                    , subq_26.ds_partitioned__month
+                    , subq_26.ds_partitioned__quarter
+                    , subq_26.ds_partitioned__year
+                    , subq_26.ds_partitioned__extract_year
+                    , subq_26.ds_partitioned__extract_quarter
+                    , subq_26.ds_partitioned__extract_month
+                    , subq_26.ds_partitioned__extract_day
+                    , subq_26.ds_partitioned__extract_dow
+                    , subq_26.ds_partitioned__extract_doy
+                    , subq_26.paid_at__day
+                    , subq_26.paid_at__week
+                    , subq_26.paid_at__month
+                    , subq_26.paid_at__quarter
+                    , subq_26.paid_at__year
+                    , subq_26.paid_at__extract_year
+                    , subq_26.paid_at__extract_quarter
+                    , subq_26.paid_at__extract_month
+                    , subq_26.paid_at__extract_day
+                    , subq_26.paid_at__extract_dow
+                    , subq_26.paid_at__extract_doy
+                    , subq_26.booking__ds__day
+                    , subq_26.booking__ds__week
+                    , subq_26.booking__ds__month
+                    , subq_26.booking__ds__quarter
+                    , subq_26.booking__ds__year
+                    , subq_26.booking__ds__extract_year
+                    , subq_26.booking__ds__extract_quarter
+                    , subq_26.booking__ds__extract_month
+                    , subq_26.booking__ds__extract_day
+                    , subq_26.booking__ds__extract_dow
+                    , subq_26.booking__ds__extract_doy
+                    , subq_26.booking__ds_partitioned__day
+                    , subq_26.booking__ds_partitioned__week
+                    , subq_26.booking__ds_partitioned__month
+                    , subq_26.booking__ds_partitioned__quarter
+                    , subq_26.booking__ds_partitioned__year
+                    , subq_26.booking__ds_partitioned__extract_year
+                    , subq_26.booking__ds_partitioned__extract_quarter
+                    , subq_26.booking__ds_partitioned__extract_month
+                    , subq_26.booking__ds_partitioned__extract_day
+                    , subq_26.booking__ds_partitioned__extract_dow
+                    , subq_26.booking__ds_partitioned__extract_doy
+                    , subq_26.booking__paid_at__day
+                    , subq_26.booking__paid_at__week
+                    , subq_26.booking__paid_at__month
+                    , subq_26.booking__paid_at__quarter
+                    , subq_26.booking__paid_at__year
+                    , subq_26.booking__paid_at__extract_year
+                    , subq_26.booking__paid_at__extract_quarter
+                    , subq_26.booking__paid_at__extract_month
+                    , subq_26.booking__paid_at__extract_day
+                    , subq_26.booking__paid_at__extract_dow
+                    , subq_26.booking__paid_at__extract_doy
+                    , subq_26.ds__day AS metric_time__day
+                    , subq_26.ds__week AS metric_time__week
+                    , subq_26.ds__month AS metric_time__month
+                    , subq_26.ds__quarter AS metric_time__quarter
+                    , subq_26.ds__year AS metric_time__year
+                    , subq_26.ds__extract_year AS metric_time__extract_year
+                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_26.ds__extract_month AS metric_time__extract_month
+                    , subq_26.ds__extract_day AS metric_time__extract_day
+                    , subq_26.ds__extract_dow AS metric_time__extract_dow
+                    , subq_26.ds__extract_doy AS metric_time__extract_doy
+                    , subq_26.listing
+                    , subq_26.guest
+                    , subq_26.host
+                    , subq_26.booking__listing
+                    , subq_26.booking__guest
+                    , subq_26.booking__host
+                    , subq_26.is_instant
+                    , subq_26.booking__is_instant
+                    , subq_26.bookings
+                    , subq_26.instant_bookings
+                    , subq_26.booking_value
+                    , subq_26.max_booking_value
+                    , subq_26.min_booking_value
+                    , subq_26.bookers
+                    , subq_26.average_booking_value
+                    , subq_26.referred_bookings
+                    , subq_26.median_booking_value
+                    , subq_26.booking_value_p99
+                    , subq_26.discrete_booking_value_p99
+                    , subq_26.approximate_continuous_booking_value_p99
+                    , subq_26.approximate_discrete_booking_value_p99
                   FROM (
                     -- Read Elements From Semantic Model 'bookings_source'
                     SELECT
@@ -1293,15 +1293,15 @@ FROM (
                       , bookings_source_src_28000.guest_id AS booking__guest
                       , bookings_source_src_28000.host_id AS booking__host
                     FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_32
-                ) subq_33
+                  ) subq_26
+                ) subq_27
                 WHERE booking__is_instant
-              ) subq_34
-            ) subq_35
+              ) subq_28
+            ) subq_29
             WHERE booking__is_instant
-          ) subq_36
-        ) subq_37
-      ) subq_38
-    ) subq_39
-  ) subq_40
-) subq_41
+          ) subq_30
+        ) subq_31
+      ) subq_32
+    ) subq_33
+  ) subq_34
+) subq_35

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_60.average_booking_value) AS average_booking_value
-      , MAX(subq_73.bookings) AS bookings
-      , MAX(subq_81.booking_value) AS booking_value
+      MAX(subq_48.average_booking_value) AS average_booking_value
+      , MAX(subq_61.bookings) AS bookings
+      , MAX(subq_69.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_51.booking__is_instant AS booking__is_instant
+          subq_39.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_51.average_booking_value AS average_booking_value
+          , subq_39.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_49
+          ) subq_37
           WHERE booking__is_instant
-        ) subq_51
+        ) subq_39
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_51.listing = listings_latest_src_28000.listing_id
-      ) subq_56
+          subq_39.listing = listings_latest_src_28000.listing_id
+      ) subq_44
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_60
+    ) subq_48
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_64.booking__is_instant AS booking__is_instant
+          subq_52.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_64.bookings AS bookings
+          , subq_52.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_62
+          ) subq_50
           WHERE booking__is_instant
-        ) subq_64
+        ) subq_52
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_64.listing = listings_latest_src_28000.listing_id
-      ) subq_69
+          subq_52.listing = listings_latest_src_28000.listing_id
+      ) subq_57
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_73
+    ) subq_61
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_75
+        ) subq_63
         WHERE booking__is_instant
-      ) subq_77
+      ) subq_65
       WHERE booking__is_instant
-    ) subq_81
-  ) subq_82
-) subq_83
+    ) subq_69
+  ) subq_70
+) subq_71

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0.sql
@@ -8,248 +8,248 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_18.average_booking_value) AS average_booking_value
-      , MAX(subq_31.bookings) AS bookings
-      , MAX(subq_39.booking_value) AS booking_value
+      MAX(subq_12.average_booking_value) AS average_booking_value
+      , MAX(subq_25.bookings) AS bookings
+      , MAX(subq_33.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.average_booking_value
+        subq_11.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_16.average_booking_value) AS average_booking_value
+          AVG(subq_10.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_15.average_booking_value
+            subq_9.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.booking__is_instant
-              , subq_14.listing__is_lux_latest
-              , subq_14.average_booking_value
+              subq_8.booking__is_instant
+              , subq_8.listing__is_lux_latest
+              , subq_8.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_13.booking__is_instant
-                , subq_13.listing__is_lux_latest
-                , subq_13.average_booking_value
+                subq_7.booking__is_instant
+                , subq_7.listing__is_lux_latest
+                , subq_7.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_9.listing AS listing
-                  , subq_9.booking__is_instant AS booking__is_instant
-                  , subq_12.is_lux_latest AS listing__is_lux_latest
-                  , subq_9.average_booking_value AS average_booking_value
+                  subq_3.listing AS listing
+                  , subq_3.booking__is_instant AS booking__is_instant
+                  , subq_6.is_lux_latest AS listing__is_lux_latest
+                  , subq_3.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.booking__is_instant
-                    , subq_8.average_booking_value
+                    subq_2.listing
+                    , subq_2.booking__is_instant
+                    , subq_2.average_booking_value
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.metric_time__day
-                      , subq_7.metric_time__week
-                      , subq_7.metric_time__month
-                      , subq_7.metric_time__quarter
-                      , subq_7.metric_time__year
-                      , subq_7.metric_time__extract_year
-                      , subq_7.metric_time__extract_quarter
-                      , subq_7.metric_time__extract_month
-                      , subq_7.metric_time__extract_day
-                      , subq_7.metric_time__extract_dow
-                      , subq_7.metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_1.ds__day
+                      , subq_1.ds__week
+                      , subq_1.ds__month
+                      , subq_1.ds__quarter
+                      , subq_1.ds__year
+                      , subq_1.ds__extract_year
+                      , subq_1.ds__extract_quarter
+                      , subq_1.ds__extract_month
+                      , subq_1.ds__extract_day
+                      , subq_1.ds__extract_dow
+                      , subq_1.ds__extract_doy
+                      , subq_1.ds_partitioned__day
+                      , subq_1.ds_partitioned__week
+                      , subq_1.ds_partitioned__month
+                      , subq_1.ds_partitioned__quarter
+                      , subq_1.ds_partitioned__year
+                      , subq_1.ds_partitioned__extract_year
+                      , subq_1.ds_partitioned__extract_quarter
+                      , subq_1.ds_partitioned__extract_month
+                      , subq_1.ds_partitioned__extract_day
+                      , subq_1.ds_partitioned__extract_dow
+                      , subq_1.ds_partitioned__extract_doy
+                      , subq_1.paid_at__day
+                      , subq_1.paid_at__week
+                      , subq_1.paid_at__month
+                      , subq_1.paid_at__quarter
+                      , subq_1.paid_at__year
+                      , subq_1.paid_at__extract_year
+                      , subq_1.paid_at__extract_quarter
+                      , subq_1.paid_at__extract_month
+                      , subq_1.paid_at__extract_day
+                      , subq_1.paid_at__extract_dow
+                      , subq_1.paid_at__extract_doy
+                      , subq_1.booking__ds__day
+                      , subq_1.booking__ds__week
+                      , subq_1.booking__ds__month
+                      , subq_1.booking__ds__quarter
+                      , subq_1.booking__ds__year
+                      , subq_1.booking__ds__extract_year
+                      , subq_1.booking__ds__extract_quarter
+                      , subq_1.booking__ds__extract_month
+                      , subq_1.booking__ds__extract_day
+                      , subq_1.booking__ds__extract_dow
+                      , subq_1.booking__ds__extract_doy
+                      , subq_1.booking__ds_partitioned__day
+                      , subq_1.booking__ds_partitioned__week
+                      , subq_1.booking__ds_partitioned__month
+                      , subq_1.booking__ds_partitioned__quarter
+                      , subq_1.booking__ds_partitioned__year
+                      , subq_1.booking__ds_partitioned__extract_year
+                      , subq_1.booking__ds_partitioned__extract_quarter
+                      , subq_1.booking__ds_partitioned__extract_month
+                      , subq_1.booking__ds_partitioned__extract_day
+                      , subq_1.booking__ds_partitioned__extract_dow
+                      , subq_1.booking__ds_partitioned__extract_doy
+                      , subq_1.booking__paid_at__day
+                      , subq_1.booking__paid_at__week
+                      , subq_1.booking__paid_at__month
+                      , subq_1.booking__paid_at__quarter
+                      , subq_1.booking__paid_at__year
+                      , subq_1.booking__paid_at__extract_year
+                      , subq_1.booking__paid_at__extract_quarter
+                      , subq_1.booking__paid_at__extract_month
+                      , subq_1.booking__paid_at__extract_day
+                      , subq_1.booking__paid_at__extract_dow
+                      , subq_1.booking__paid_at__extract_doy
+                      , subq_1.metric_time__day
+                      , subq_1.metric_time__week
+                      , subq_1.metric_time__month
+                      , subq_1.metric_time__quarter
+                      , subq_1.metric_time__year
+                      , subq_1.metric_time__extract_year
+                      , subq_1.metric_time__extract_quarter
+                      , subq_1.metric_time__extract_month
+                      , subq_1.metric_time__extract_day
+                      , subq_1.metric_time__extract_dow
+                      , subq_1.metric_time__extract_doy
+                      , subq_1.listing
+                      , subq_1.guest
+                      , subq_1.host
+                      , subq_1.booking__listing
+                      , subq_1.booking__guest
+                      , subq_1.booking__host
+                      , subq_1.is_instant
+                      , subq_1.booking__is_instant
+                      , subq_1.bookings
+                      , subq_1.instant_bookings
+                      , subq_1.booking_value
+                      , subq_1.max_booking_value
+                      , subq_1.min_booking_value
+                      , subq_1.bookers
+                      , subq_1.average_booking_value
+                      , subq_1.referred_bookings
+                      , subq_1.median_booking_value
+                      , subq_1.booking_value_p99
+                      , subq_1.discrete_booking_value_p99
+                      , subq_1.approximate_continuous_booking_value_p99
+                      , subq_1.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_6.ds__day
-                        , subq_6.ds__week
-                        , subq_6.ds__month
-                        , subq_6.ds__quarter
-                        , subq_6.ds__year
-                        , subq_6.ds__extract_year
-                        , subq_6.ds__extract_quarter
-                        , subq_6.ds__extract_month
-                        , subq_6.ds__extract_day
-                        , subq_6.ds__extract_dow
-                        , subq_6.ds__extract_doy
-                        , subq_6.ds_partitioned__day
-                        , subq_6.ds_partitioned__week
-                        , subq_6.ds_partitioned__month
-                        , subq_6.ds_partitioned__quarter
-                        , subq_6.ds_partitioned__year
-                        , subq_6.ds_partitioned__extract_year
-                        , subq_6.ds_partitioned__extract_quarter
-                        , subq_6.ds_partitioned__extract_month
-                        , subq_6.ds_partitioned__extract_day
-                        , subq_6.ds_partitioned__extract_dow
-                        , subq_6.ds_partitioned__extract_doy
-                        , subq_6.paid_at__day
-                        , subq_6.paid_at__week
-                        , subq_6.paid_at__month
-                        , subq_6.paid_at__quarter
-                        , subq_6.paid_at__year
-                        , subq_6.paid_at__extract_year
-                        , subq_6.paid_at__extract_quarter
-                        , subq_6.paid_at__extract_month
-                        , subq_6.paid_at__extract_day
-                        , subq_6.paid_at__extract_dow
-                        , subq_6.paid_at__extract_doy
-                        , subq_6.booking__ds__day
-                        , subq_6.booking__ds__week
-                        , subq_6.booking__ds__month
-                        , subq_6.booking__ds__quarter
-                        , subq_6.booking__ds__year
-                        , subq_6.booking__ds__extract_year
-                        , subq_6.booking__ds__extract_quarter
-                        , subq_6.booking__ds__extract_month
-                        , subq_6.booking__ds__extract_day
-                        , subq_6.booking__ds__extract_dow
-                        , subq_6.booking__ds__extract_doy
-                        , subq_6.booking__ds_partitioned__day
-                        , subq_6.booking__ds_partitioned__week
-                        , subq_6.booking__ds_partitioned__month
-                        , subq_6.booking__ds_partitioned__quarter
-                        , subq_6.booking__ds_partitioned__year
-                        , subq_6.booking__ds_partitioned__extract_year
-                        , subq_6.booking__ds_partitioned__extract_quarter
-                        , subq_6.booking__ds_partitioned__extract_month
-                        , subq_6.booking__ds_partitioned__extract_day
-                        , subq_6.booking__ds_partitioned__extract_dow
-                        , subq_6.booking__ds_partitioned__extract_doy
-                        , subq_6.booking__paid_at__day
-                        , subq_6.booking__paid_at__week
-                        , subq_6.booking__paid_at__month
-                        , subq_6.booking__paid_at__quarter
-                        , subq_6.booking__paid_at__year
-                        , subq_6.booking__paid_at__extract_year
-                        , subq_6.booking__paid_at__extract_quarter
-                        , subq_6.booking__paid_at__extract_month
-                        , subq_6.booking__paid_at__extract_day
-                        , subq_6.booking__paid_at__extract_dow
-                        , subq_6.booking__paid_at__extract_doy
-                        , subq_6.ds__day AS metric_time__day
-                        , subq_6.ds__week AS metric_time__week
-                        , subq_6.ds__month AS metric_time__month
-                        , subq_6.ds__quarter AS metric_time__quarter
-                        , subq_6.ds__year AS metric_time__year
-                        , subq_6.ds__extract_year AS metric_time__extract_year
-                        , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_6.ds__extract_month AS metric_time__extract_month
-                        , subq_6.ds__extract_day AS metric_time__extract_day
-                        , subq_6.ds__extract_dow AS metric_time__extract_dow
-                        , subq_6.ds__extract_doy AS metric_time__extract_doy
-                        , subq_6.listing
-                        , subq_6.guest
-                        , subq_6.host
-                        , subq_6.booking__listing
-                        , subq_6.booking__guest
-                        , subq_6.booking__host
-                        , subq_6.is_instant
-                        , subq_6.booking__is_instant
-                        , subq_6.bookings
-                        , subq_6.instant_bookings
-                        , subq_6.booking_value
-                        , subq_6.max_booking_value
-                        , subq_6.min_booking_value
-                        , subq_6.bookers
-                        , subq_6.average_booking_value
-                        , subq_6.referred_bookings
-                        , subq_6.median_booking_value
-                        , subq_6.booking_value_p99
-                        , subq_6.discrete_booking_value_p99
-                        , subq_6.approximate_continuous_booking_value_p99
-                        , subq_6.approximate_discrete_booking_value_p99
+                        subq_0.ds__day
+                        , subq_0.ds__week
+                        , subq_0.ds__month
+                        , subq_0.ds__quarter
+                        , subq_0.ds__year
+                        , subq_0.ds__extract_year
+                        , subq_0.ds__extract_quarter
+                        , subq_0.ds__extract_month
+                        , subq_0.ds__extract_day
+                        , subq_0.ds__extract_dow
+                        , subq_0.ds__extract_doy
+                        , subq_0.ds_partitioned__day
+                        , subq_0.ds_partitioned__week
+                        , subq_0.ds_partitioned__month
+                        , subq_0.ds_partitioned__quarter
+                        , subq_0.ds_partitioned__year
+                        , subq_0.ds_partitioned__extract_year
+                        , subq_0.ds_partitioned__extract_quarter
+                        , subq_0.ds_partitioned__extract_month
+                        , subq_0.ds_partitioned__extract_day
+                        , subq_0.ds_partitioned__extract_dow
+                        , subq_0.ds_partitioned__extract_doy
+                        , subq_0.paid_at__day
+                        , subq_0.paid_at__week
+                        , subq_0.paid_at__month
+                        , subq_0.paid_at__quarter
+                        , subq_0.paid_at__year
+                        , subq_0.paid_at__extract_year
+                        , subq_0.paid_at__extract_quarter
+                        , subq_0.paid_at__extract_month
+                        , subq_0.paid_at__extract_day
+                        , subq_0.paid_at__extract_dow
+                        , subq_0.paid_at__extract_doy
+                        , subq_0.booking__ds__day
+                        , subq_0.booking__ds__week
+                        , subq_0.booking__ds__month
+                        , subq_0.booking__ds__quarter
+                        , subq_0.booking__ds__year
+                        , subq_0.booking__ds__extract_year
+                        , subq_0.booking__ds__extract_quarter
+                        , subq_0.booking__ds__extract_month
+                        , subq_0.booking__ds__extract_day
+                        , subq_0.booking__ds__extract_dow
+                        , subq_0.booking__ds__extract_doy
+                        , subq_0.booking__ds_partitioned__day
+                        , subq_0.booking__ds_partitioned__week
+                        , subq_0.booking__ds_partitioned__month
+                        , subq_0.booking__ds_partitioned__quarter
+                        , subq_0.booking__ds_partitioned__year
+                        , subq_0.booking__ds_partitioned__extract_year
+                        , subq_0.booking__ds_partitioned__extract_quarter
+                        , subq_0.booking__ds_partitioned__extract_month
+                        , subq_0.booking__ds_partitioned__extract_day
+                        , subq_0.booking__ds_partitioned__extract_dow
+                        , subq_0.booking__ds_partitioned__extract_doy
+                        , subq_0.booking__paid_at__day
+                        , subq_0.booking__paid_at__week
+                        , subq_0.booking__paid_at__month
+                        , subq_0.booking__paid_at__quarter
+                        , subq_0.booking__paid_at__year
+                        , subq_0.booking__paid_at__extract_year
+                        , subq_0.booking__paid_at__extract_quarter
+                        , subq_0.booking__paid_at__extract_month
+                        , subq_0.booking__paid_at__extract_day
+                        , subq_0.booking__paid_at__extract_dow
+                        , subq_0.booking__paid_at__extract_doy
+                        , subq_0.ds__day AS metric_time__day
+                        , subq_0.ds__week AS metric_time__week
+                        , subq_0.ds__month AS metric_time__month
+                        , subq_0.ds__quarter AS metric_time__quarter
+                        , subq_0.ds__year AS metric_time__year
+                        , subq_0.ds__extract_year AS metric_time__extract_year
+                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_0.ds__extract_month AS metric_time__extract_month
+                        , subq_0.ds__extract_day AS metric_time__extract_day
+                        , subq_0.ds__extract_dow AS metric_time__extract_dow
+                        , subq_0.ds__extract_doy AS metric_time__extract_doy
+                        , subq_0.listing
+                        , subq_0.guest
+                        , subq_0.host
+                        , subq_0.booking__listing
+                        , subq_0.booking__guest
+                        , subq_0.booking__host
+                        , subq_0.is_instant
+                        , subq_0.booking__is_instant
+                        , subq_0.bookings
+                        , subq_0.instant_bookings
+                        , subq_0.booking_value
+                        , subq_0.max_booking_value
+                        , subq_0.min_booking_value
+                        , subq_0.bookers
+                        , subq_0.average_booking_value
+                        , subq_0.referred_bookings
+                        , subq_0.median_booking_value
+                        , subq_0.booking_value_p99
+                        , subq_0.discrete_booking_value_p99
+                        , subq_0.approximate_continuous_booking_value_p99
+                        , subq_0.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -342,86 +342,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_6
-                    ) subq_7
+                      ) subq_0
+                    ) subq_1
                     WHERE booking__is_instant
-                  ) subq_8
-                ) subq_9
+                  ) subq_2
+                ) subq_3
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_11.listing
-                    , subq_11.is_lux_latest
+                    subq_5.listing
+                    , subq_5.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_10.ds__day
-                      , subq_10.ds__week
-                      , subq_10.ds__month
-                      , subq_10.ds__quarter
-                      , subq_10.ds__year
-                      , subq_10.ds__extract_year
-                      , subq_10.ds__extract_quarter
-                      , subq_10.ds__extract_month
-                      , subq_10.ds__extract_day
-                      , subq_10.ds__extract_dow
-                      , subq_10.ds__extract_doy
-                      , subq_10.created_at__day
-                      , subq_10.created_at__week
-                      , subq_10.created_at__month
-                      , subq_10.created_at__quarter
-                      , subq_10.created_at__year
-                      , subq_10.created_at__extract_year
-                      , subq_10.created_at__extract_quarter
-                      , subq_10.created_at__extract_month
-                      , subq_10.created_at__extract_day
-                      , subq_10.created_at__extract_dow
-                      , subq_10.created_at__extract_doy
-                      , subq_10.listing__ds__day
-                      , subq_10.listing__ds__week
-                      , subq_10.listing__ds__month
-                      , subq_10.listing__ds__quarter
-                      , subq_10.listing__ds__year
-                      , subq_10.listing__ds__extract_year
-                      , subq_10.listing__ds__extract_quarter
-                      , subq_10.listing__ds__extract_month
-                      , subq_10.listing__ds__extract_day
-                      , subq_10.listing__ds__extract_dow
-                      , subq_10.listing__ds__extract_doy
-                      , subq_10.listing__created_at__day
-                      , subq_10.listing__created_at__week
-                      , subq_10.listing__created_at__month
-                      , subq_10.listing__created_at__quarter
-                      , subq_10.listing__created_at__year
-                      , subq_10.listing__created_at__extract_year
-                      , subq_10.listing__created_at__extract_quarter
-                      , subq_10.listing__created_at__extract_month
-                      , subq_10.listing__created_at__extract_day
-                      , subq_10.listing__created_at__extract_dow
-                      , subq_10.listing__created_at__extract_doy
-                      , subq_10.ds__day AS metric_time__day
-                      , subq_10.ds__week AS metric_time__week
-                      , subq_10.ds__month AS metric_time__month
-                      , subq_10.ds__quarter AS metric_time__quarter
-                      , subq_10.ds__year AS metric_time__year
-                      , subq_10.ds__extract_year AS metric_time__extract_year
-                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_10.ds__extract_month AS metric_time__extract_month
-                      , subq_10.ds__extract_day AS metric_time__extract_day
-                      , subq_10.ds__extract_dow AS metric_time__extract_dow
-                      , subq_10.ds__extract_doy AS metric_time__extract_doy
-                      , subq_10.listing
-                      , subq_10.user
-                      , subq_10.listing__user
-                      , subq_10.country_latest
-                      , subq_10.is_lux_latest
-                      , subq_10.capacity_latest
-                      , subq_10.listing__country_latest
-                      , subq_10.listing__is_lux_latest
-                      , subq_10.listing__capacity_latest
-                      , subq_10.listings
-                      , subq_10.largest_listing
-                      , subq_10.smallest_listing
+                      subq_4.ds__day
+                      , subq_4.ds__week
+                      , subq_4.ds__month
+                      , subq_4.ds__quarter
+                      , subq_4.ds__year
+                      , subq_4.ds__extract_year
+                      , subq_4.ds__extract_quarter
+                      , subq_4.ds__extract_month
+                      , subq_4.ds__extract_day
+                      , subq_4.ds__extract_dow
+                      , subq_4.ds__extract_doy
+                      , subq_4.created_at__day
+                      , subq_4.created_at__week
+                      , subq_4.created_at__month
+                      , subq_4.created_at__quarter
+                      , subq_4.created_at__year
+                      , subq_4.created_at__extract_year
+                      , subq_4.created_at__extract_quarter
+                      , subq_4.created_at__extract_month
+                      , subq_4.created_at__extract_day
+                      , subq_4.created_at__extract_dow
+                      , subq_4.created_at__extract_doy
+                      , subq_4.listing__ds__day
+                      , subq_4.listing__ds__week
+                      , subq_4.listing__ds__month
+                      , subq_4.listing__ds__quarter
+                      , subq_4.listing__ds__year
+                      , subq_4.listing__ds__extract_year
+                      , subq_4.listing__ds__extract_quarter
+                      , subq_4.listing__ds__extract_month
+                      , subq_4.listing__ds__extract_day
+                      , subq_4.listing__ds__extract_dow
+                      , subq_4.listing__ds__extract_doy
+                      , subq_4.listing__created_at__day
+                      , subq_4.listing__created_at__week
+                      , subq_4.listing__created_at__month
+                      , subq_4.listing__created_at__quarter
+                      , subq_4.listing__created_at__year
+                      , subq_4.listing__created_at__extract_year
+                      , subq_4.listing__created_at__extract_quarter
+                      , subq_4.listing__created_at__extract_month
+                      , subq_4.listing__created_at__extract_day
+                      , subq_4.listing__created_at__extract_dow
+                      , subq_4.listing__created_at__extract_doy
+                      , subq_4.ds__day AS metric_time__day
+                      , subq_4.ds__week AS metric_time__week
+                      , subq_4.ds__month AS metric_time__month
+                      , subq_4.ds__quarter AS metric_time__quarter
+                      , subq_4.ds__year AS metric_time__year
+                      , subq_4.ds__extract_year AS metric_time__extract_year
+                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_4.ds__extract_month AS metric_time__extract_month
+                      , subq_4.ds__extract_day AS metric_time__extract_day
+                      , subq_4.ds__extract_dow AS metric_time__extract_dow
+                      , subq_4.ds__extract_doy AS metric_time__extract_doy
+                      , subq_4.listing
+                      , subq_4.user
+                      , subq_4.listing__user
+                      , subq_4.country_latest
+                      , subq_4.is_lux_latest
+                      , subq_4.capacity_latest
+                      , subq_4.listing__country_latest
+                      , subq_4.listing__is_lux_latest
+                      , subq_4.listing__capacity_latest
+                      , subq_4.listings
+                      , subq_4.largest_listing
+                      , subq_4.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,257 +482,257 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_10
-                  ) subq_11
-                ) subq_12
+                    ) subq_4
+                  ) subq_5
+                ) subq_6
                 ON
-                  subq_9.listing = subq_12.listing
-              ) subq_13
-            ) subq_14
+                  subq_3.listing = subq_6.listing
+              ) subq_7
+            ) subq_8
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_15
-        ) subq_16
-      ) subq_17
-    ) subq_18
+          ) subq_9
+        ) subq_10
+      ) subq_11
+    ) subq_12
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_30.bookings
+        subq_24.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_29.bookings) AS bookings
+          SUM(subq_23.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_28.bookings
+            subq_22.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_27.booking__is_instant
-              , subq_27.listing__is_lux_latest
-              , subq_27.bookings
+              subq_21.booking__is_instant
+              , subq_21.listing__is_lux_latest
+              , subq_21.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_26.booking__is_instant
-                , subq_26.listing__is_lux_latest
-                , subq_26.bookings
+                subq_20.booking__is_instant
+                , subq_20.listing__is_lux_latest
+                , subq_20.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_22.listing AS listing
-                  , subq_22.booking__is_instant AS booking__is_instant
-                  , subq_25.is_lux_latest AS listing__is_lux_latest
-                  , subq_22.bookings AS bookings
+                  subq_16.listing AS listing
+                  , subq_16.booking__is_instant AS booking__is_instant
+                  , subq_19.is_lux_latest AS listing__is_lux_latest
+                  , subq_16.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_21.listing
-                    , subq_21.booking__is_instant
-                    , subq_21.bookings
+                    subq_15.listing
+                    , subq_15.booking__is_instant
+                    , subq_15.bookings
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_20.ds__day
-                      , subq_20.ds__week
-                      , subq_20.ds__month
-                      , subq_20.ds__quarter
-                      , subq_20.ds__year
-                      , subq_20.ds__extract_year
-                      , subq_20.ds__extract_quarter
-                      , subq_20.ds__extract_month
-                      , subq_20.ds__extract_day
-                      , subq_20.ds__extract_dow
-                      , subq_20.ds__extract_doy
-                      , subq_20.ds_partitioned__day
-                      , subq_20.ds_partitioned__week
-                      , subq_20.ds_partitioned__month
-                      , subq_20.ds_partitioned__quarter
-                      , subq_20.ds_partitioned__year
-                      , subq_20.ds_partitioned__extract_year
-                      , subq_20.ds_partitioned__extract_quarter
-                      , subq_20.ds_partitioned__extract_month
-                      , subq_20.ds_partitioned__extract_day
-                      , subq_20.ds_partitioned__extract_dow
-                      , subq_20.ds_partitioned__extract_doy
-                      , subq_20.paid_at__day
-                      , subq_20.paid_at__week
-                      , subq_20.paid_at__month
-                      , subq_20.paid_at__quarter
-                      , subq_20.paid_at__year
-                      , subq_20.paid_at__extract_year
-                      , subq_20.paid_at__extract_quarter
-                      , subq_20.paid_at__extract_month
-                      , subq_20.paid_at__extract_day
-                      , subq_20.paid_at__extract_dow
-                      , subq_20.paid_at__extract_doy
-                      , subq_20.booking__ds__day
-                      , subq_20.booking__ds__week
-                      , subq_20.booking__ds__month
-                      , subq_20.booking__ds__quarter
-                      , subq_20.booking__ds__year
-                      , subq_20.booking__ds__extract_year
-                      , subq_20.booking__ds__extract_quarter
-                      , subq_20.booking__ds__extract_month
-                      , subq_20.booking__ds__extract_day
-                      , subq_20.booking__ds__extract_dow
-                      , subq_20.booking__ds__extract_doy
-                      , subq_20.booking__ds_partitioned__day
-                      , subq_20.booking__ds_partitioned__week
-                      , subq_20.booking__ds_partitioned__month
-                      , subq_20.booking__ds_partitioned__quarter
-                      , subq_20.booking__ds_partitioned__year
-                      , subq_20.booking__ds_partitioned__extract_year
-                      , subq_20.booking__ds_partitioned__extract_quarter
-                      , subq_20.booking__ds_partitioned__extract_month
-                      , subq_20.booking__ds_partitioned__extract_day
-                      , subq_20.booking__ds_partitioned__extract_dow
-                      , subq_20.booking__ds_partitioned__extract_doy
-                      , subq_20.booking__paid_at__day
-                      , subq_20.booking__paid_at__week
-                      , subq_20.booking__paid_at__month
-                      , subq_20.booking__paid_at__quarter
-                      , subq_20.booking__paid_at__year
-                      , subq_20.booking__paid_at__extract_year
-                      , subq_20.booking__paid_at__extract_quarter
-                      , subq_20.booking__paid_at__extract_month
-                      , subq_20.booking__paid_at__extract_day
-                      , subq_20.booking__paid_at__extract_dow
-                      , subq_20.booking__paid_at__extract_doy
-                      , subq_20.metric_time__day
-                      , subq_20.metric_time__week
-                      , subq_20.metric_time__month
-                      , subq_20.metric_time__quarter
-                      , subq_20.metric_time__year
-                      , subq_20.metric_time__extract_year
-                      , subq_20.metric_time__extract_quarter
-                      , subq_20.metric_time__extract_month
-                      , subq_20.metric_time__extract_day
-                      , subq_20.metric_time__extract_dow
-                      , subq_20.metric_time__extract_doy
-                      , subq_20.listing
-                      , subq_20.guest
-                      , subq_20.host
-                      , subq_20.booking__listing
-                      , subq_20.booking__guest
-                      , subq_20.booking__host
-                      , subq_20.is_instant
-                      , subq_20.booking__is_instant
-                      , subq_20.bookings
-                      , subq_20.instant_bookings
-                      , subq_20.booking_value
-                      , subq_20.max_booking_value
-                      , subq_20.min_booking_value
-                      , subq_20.bookers
-                      , subq_20.average_booking_value
-                      , subq_20.referred_bookings
-                      , subq_20.median_booking_value
-                      , subq_20.booking_value_p99
-                      , subq_20.discrete_booking_value_p99
-                      , subq_20.approximate_continuous_booking_value_p99
-                      , subq_20.approximate_discrete_booking_value_p99
+                      subq_14.ds__day
+                      , subq_14.ds__week
+                      , subq_14.ds__month
+                      , subq_14.ds__quarter
+                      , subq_14.ds__year
+                      , subq_14.ds__extract_year
+                      , subq_14.ds__extract_quarter
+                      , subq_14.ds__extract_month
+                      , subq_14.ds__extract_day
+                      , subq_14.ds__extract_dow
+                      , subq_14.ds__extract_doy
+                      , subq_14.ds_partitioned__day
+                      , subq_14.ds_partitioned__week
+                      , subq_14.ds_partitioned__month
+                      , subq_14.ds_partitioned__quarter
+                      , subq_14.ds_partitioned__year
+                      , subq_14.ds_partitioned__extract_year
+                      , subq_14.ds_partitioned__extract_quarter
+                      , subq_14.ds_partitioned__extract_month
+                      , subq_14.ds_partitioned__extract_day
+                      , subq_14.ds_partitioned__extract_dow
+                      , subq_14.ds_partitioned__extract_doy
+                      , subq_14.paid_at__day
+                      , subq_14.paid_at__week
+                      , subq_14.paid_at__month
+                      , subq_14.paid_at__quarter
+                      , subq_14.paid_at__year
+                      , subq_14.paid_at__extract_year
+                      , subq_14.paid_at__extract_quarter
+                      , subq_14.paid_at__extract_month
+                      , subq_14.paid_at__extract_day
+                      , subq_14.paid_at__extract_dow
+                      , subq_14.paid_at__extract_doy
+                      , subq_14.booking__ds__day
+                      , subq_14.booking__ds__week
+                      , subq_14.booking__ds__month
+                      , subq_14.booking__ds__quarter
+                      , subq_14.booking__ds__year
+                      , subq_14.booking__ds__extract_year
+                      , subq_14.booking__ds__extract_quarter
+                      , subq_14.booking__ds__extract_month
+                      , subq_14.booking__ds__extract_day
+                      , subq_14.booking__ds__extract_dow
+                      , subq_14.booking__ds__extract_doy
+                      , subq_14.booking__ds_partitioned__day
+                      , subq_14.booking__ds_partitioned__week
+                      , subq_14.booking__ds_partitioned__month
+                      , subq_14.booking__ds_partitioned__quarter
+                      , subq_14.booking__ds_partitioned__year
+                      , subq_14.booking__ds_partitioned__extract_year
+                      , subq_14.booking__ds_partitioned__extract_quarter
+                      , subq_14.booking__ds_partitioned__extract_month
+                      , subq_14.booking__ds_partitioned__extract_day
+                      , subq_14.booking__ds_partitioned__extract_dow
+                      , subq_14.booking__ds_partitioned__extract_doy
+                      , subq_14.booking__paid_at__day
+                      , subq_14.booking__paid_at__week
+                      , subq_14.booking__paid_at__month
+                      , subq_14.booking__paid_at__quarter
+                      , subq_14.booking__paid_at__year
+                      , subq_14.booking__paid_at__extract_year
+                      , subq_14.booking__paid_at__extract_quarter
+                      , subq_14.booking__paid_at__extract_month
+                      , subq_14.booking__paid_at__extract_day
+                      , subq_14.booking__paid_at__extract_dow
+                      , subq_14.booking__paid_at__extract_doy
+                      , subq_14.metric_time__day
+                      , subq_14.metric_time__week
+                      , subq_14.metric_time__month
+                      , subq_14.metric_time__quarter
+                      , subq_14.metric_time__year
+                      , subq_14.metric_time__extract_year
+                      , subq_14.metric_time__extract_quarter
+                      , subq_14.metric_time__extract_month
+                      , subq_14.metric_time__extract_day
+                      , subq_14.metric_time__extract_dow
+                      , subq_14.metric_time__extract_doy
+                      , subq_14.listing
+                      , subq_14.guest
+                      , subq_14.host
+                      , subq_14.booking__listing
+                      , subq_14.booking__guest
+                      , subq_14.booking__host
+                      , subq_14.is_instant
+                      , subq_14.booking__is_instant
+                      , subq_14.bookings
+                      , subq_14.instant_bookings
+                      , subq_14.booking_value
+                      , subq_14.max_booking_value
+                      , subq_14.min_booking_value
+                      , subq_14.bookers
+                      , subq_14.average_booking_value
+                      , subq_14.referred_bookings
+                      , subq_14.median_booking_value
+                      , subq_14.booking_value_p99
+                      , subq_14.discrete_booking_value_p99
+                      , subq_14.approximate_continuous_booking_value_p99
+                      , subq_14.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_19.ds__day
-                        , subq_19.ds__week
-                        , subq_19.ds__month
-                        , subq_19.ds__quarter
-                        , subq_19.ds__year
-                        , subq_19.ds__extract_year
-                        , subq_19.ds__extract_quarter
-                        , subq_19.ds__extract_month
-                        , subq_19.ds__extract_day
-                        , subq_19.ds__extract_dow
-                        , subq_19.ds__extract_doy
-                        , subq_19.ds_partitioned__day
-                        , subq_19.ds_partitioned__week
-                        , subq_19.ds_partitioned__month
-                        , subq_19.ds_partitioned__quarter
-                        , subq_19.ds_partitioned__year
-                        , subq_19.ds_partitioned__extract_year
-                        , subq_19.ds_partitioned__extract_quarter
-                        , subq_19.ds_partitioned__extract_month
-                        , subq_19.ds_partitioned__extract_day
-                        , subq_19.ds_partitioned__extract_dow
-                        , subq_19.ds_partitioned__extract_doy
-                        , subq_19.paid_at__day
-                        , subq_19.paid_at__week
-                        , subq_19.paid_at__month
-                        , subq_19.paid_at__quarter
-                        , subq_19.paid_at__year
-                        , subq_19.paid_at__extract_year
-                        , subq_19.paid_at__extract_quarter
-                        , subq_19.paid_at__extract_month
-                        , subq_19.paid_at__extract_day
-                        , subq_19.paid_at__extract_dow
-                        , subq_19.paid_at__extract_doy
-                        , subq_19.booking__ds__day
-                        , subq_19.booking__ds__week
-                        , subq_19.booking__ds__month
-                        , subq_19.booking__ds__quarter
-                        , subq_19.booking__ds__year
-                        , subq_19.booking__ds__extract_year
-                        , subq_19.booking__ds__extract_quarter
-                        , subq_19.booking__ds__extract_month
-                        , subq_19.booking__ds__extract_day
-                        , subq_19.booking__ds__extract_dow
-                        , subq_19.booking__ds__extract_doy
-                        , subq_19.booking__ds_partitioned__day
-                        , subq_19.booking__ds_partitioned__week
-                        , subq_19.booking__ds_partitioned__month
-                        , subq_19.booking__ds_partitioned__quarter
-                        , subq_19.booking__ds_partitioned__year
-                        , subq_19.booking__ds_partitioned__extract_year
-                        , subq_19.booking__ds_partitioned__extract_quarter
-                        , subq_19.booking__ds_partitioned__extract_month
-                        , subq_19.booking__ds_partitioned__extract_day
-                        , subq_19.booking__ds_partitioned__extract_dow
-                        , subq_19.booking__ds_partitioned__extract_doy
-                        , subq_19.booking__paid_at__day
-                        , subq_19.booking__paid_at__week
-                        , subq_19.booking__paid_at__month
-                        , subq_19.booking__paid_at__quarter
-                        , subq_19.booking__paid_at__year
-                        , subq_19.booking__paid_at__extract_year
-                        , subq_19.booking__paid_at__extract_quarter
-                        , subq_19.booking__paid_at__extract_month
-                        , subq_19.booking__paid_at__extract_day
-                        , subq_19.booking__paid_at__extract_dow
-                        , subq_19.booking__paid_at__extract_doy
-                        , subq_19.ds__day AS metric_time__day
-                        , subq_19.ds__week AS metric_time__week
-                        , subq_19.ds__month AS metric_time__month
-                        , subq_19.ds__quarter AS metric_time__quarter
-                        , subq_19.ds__year AS metric_time__year
-                        , subq_19.ds__extract_year AS metric_time__extract_year
-                        , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_19.ds__extract_month AS metric_time__extract_month
-                        , subq_19.ds__extract_day AS metric_time__extract_day
-                        , subq_19.ds__extract_dow AS metric_time__extract_dow
-                        , subq_19.ds__extract_doy AS metric_time__extract_doy
-                        , subq_19.listing
-                        , subq_19.guest
-                        , subq_19.host
-                        , subq_19.booking__listing
-                        , subq_19.booking__guest
-                        , subq_19.booking__host
-                        , subq_19.is_instant
-                        , subq_19.booking__is_instant
-                        , subq_19.bookings
-                        , subq_19.instant_bookings
-                        , subq_19.booking_value
-                        , subq_19.max_booking_value
-                        , subq_19.min_booking_value
-                        , subq_19.bookers
-                        , subq_19.average_booking_value
-                        , subq_19.referred_bookings
-                        , subq_19.median_booking_value
-                        , subq_19.booking_value_p99
-                        , subq_19.discrete_booking_value_p99
-                        , subq_19.approximate_continuous_booking_value_p99
-                        , subq_19.approximate_discrete_booking_value_p99
+                        subq_13.ds__day
+                        , subq_13.ds__week
+                        , subq_13.ds__month
+                        , subq_13.ds__quarter
+                        , subq_13.ds__year
+                        , subq_13.ds__extract_year
+                        , subq_13.ds__extract_quarter
+                        , subq_13.ds__extract_month
+                        , subq_13.ds__extract_day
+                        , subq_13.ds__extract_dow
+                        , subq_13.ds__extract_doy
+                        , subq_13.ds_partitioned__day
+                        , subq_13.ds_partitioned__week
+                        , subq_13.ds_partitioned__month
+                        , subq_13.ds_partitioned__quarter
+                        , subq_13.ds_partitioned__year
+                        , subq_13.ds_partitioned__extract_year
+                        , subq_13.ds_partitioned__extract_quarter
+                        , subq_13.ds_partitioned__extract_month
+                        , subq_13.ds_partitioned__extract_day
+                        , subq_13.ds_partitioned__extract_dow
+                        , subq_13.ds_partitioned__extract_doy
+                        , subq_13.paid_at__day
+                        , subq_13.paid_at__week
+                        , subq_13.paid_at__month
+                        , subq_13.paid_at__quarter
+                        , subq_13.paid_at__year
+                        , subq_13.paid_at__extract_year
+                        , subq_13.paid_at__extract_quarter
+                        , subq_13.paid_at__extract_month
+                        , subq_13.paid_at__extract_day
+                        , subq_13.paid_at__extract_dow
+                        , subq_13.paid_at__extract_doy
+                        , subq_13.booking__ds__day
+                        , subq_13.booking__ds__week
+                        , subq_13.booking__ds__month
+                        , subq_13.booking__ds__quarter
+                        , subq_13.booking__ds__year
+                        , subq_13.booking__ds__extract_year
+                        , subq_13.booking__ds__extract_quarter
+                        , subq_13.booking__ds__extract_month
+                        , subq_13.booking__ds__extract_day
+                        , subq_13.booking__ds__extract_dow
+                        , subq_13.booking__ds__extract_doy
+                        , subq_13.booking__ds_partitioned__day
+                        , subq_13.booking__ds_partitioned__week
+                        , subq_13.booking__ds_partitioned__month
+                        , subq_13.booking__ds_partitioned__quarter
+                        , subq_13.booking__ds_partitioned__year
+                        , subq_13.booking__ds_partitioned__extract_year
+                        , subq_13.booking__ds_partitioned__extract_quarter
+                        , subq_13.booking__ds_partitioned__extract_month
+                        , subq_13.booking__ds_partitioned__extract_day
+                        , subq_13.booking__ds_partitioned__extract_dow
+                        , subq_13.booking__ds_partitioned__extract_doy
+                        , subq_13.booking__paid_at__day
+                        , subq_13.booking__paid_at__week
+                        , subq_13.booking__paid_at__month
+                        , subq_13.booking__paid_at__quarter
+                        , subq_13.booking__paid_at__year
+                        , subq_13.booking__paid_at__extract_year
+                        , subq_13.booking__paid_at__extract_quarter
+                        , subq_13.booking__paid_at__extract_month
+                        , subq_13.booking__paid_at__extract_day
+                        , subq_13.booking__paid_at__extract_dow
+                        , subq_13.booking__paid_at__extract_doy
+                        , subq_13.ds__day AS metric_time__day
+                        , subq_13.ds__week AS metric_time__week
+                        , subq_13.ds__month AS metric_time__month
+                        , subq_13.ds__quarter AS metric_time__quarter
+                        , subq_13.ds__year AS metric_time__year
+                        , subq_13.ds__extract_year AS metric_time__extract_year
+                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_13.ds__extract_month AS metric_time__extract_month
+                        , subq_13.ds__extract_day AS metric_time__extract_day
+                        , subq_13.ds__extract_dow AS metric_time__extract_dow
+                        , subq_13.ds__extract_doy AS metric_time__extract_doy
+                        , subq_13.listing
+                        , subq_13.guest
+                        , subq_13.host
+                        , subq_13.booking__listing
+                        , subq_13.booking__guest
+                        , subq_13.booking__host
+                        , subq_13.is_instant
+                        , subq_13.booking__is_instant
+                        , subq_13.bookings
+                        , subq_13.instant_bookings
+                        , subq_13.booking_value
+                        , subq_13.max_booking_value
+                        , subq_13.min_booking_value
+                        , subq_13.bookers
+                        , subq_13.average_booking_value
+                        , subq_13.referred_bookings
+                        , subq_13.median_booking_value
+                        , subq_13.booking_value_p99
+                        , subq_13.discrete_booking_value_p99
+                        , subq_13.approximate_continuous_booking_value_p99
+                        , subq_13.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -825,86 +825,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_19
-                    ) subq_20
+                      ) subq_13
+                    ) subq_14
                     WHERE booking__is_instant
-                  ) subq_21
-                ) subq_22
+                  ) subq_15
+                ) subq_16
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_24.listing
-                    , subq_24.is_lux_latest
+                    subq_18.listing
+                    , subq_18.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_23.ds__day
-                      , subq_23.ds__week
-                      , subq_23.ds__month
-                      , subq_23.ds__quarter
-                      , subq_23.ds__year
-                      , subq_23.ds__extract_year
-                      , subq_23.ds__extract_quarter
-                      , subq_23.ds__extract_month
-                      , subq_23.ds__extract_day
-                      , subq_23.ds__extract_dow
-                      , subq_23.ds__extract_doy
-                      , subq_23.created_at__day
-                      , subq_23.created_at__week
-                      , subq_23.created_at__month
-                      , subq_23.created_at__quarter
-                      , subq_23.created_at__year
-                      , subq_23.created_at__extract_year
-                      , subq_23.created_at__extract_quarter
-                      , subq_23.created_at__extract_month
-                      , subq_23.created_at__extract_day
-                      , subq_23.created_at__extract_dow
-                      , subq_23.created_at__extract_doy
-                      , subq_23.listing__ds__day
-                      , subq_23.listing__ds__week
-                      , subq_23.listing__ds__month
-                      , subq_23.listing__ds__quarter
-                      , subq_23.listing__ds__year
-                      , subq_23.listing__ds__extract_year
-                      , subq_23.listing__ds__extract_quarter
-                      , subq_23.listing__ds__extract_month
-                      , subq_23.listing__ds__extract_day
-                      , subq_23.listing__ds__extract_dow
-                      , subq_23.listing__ds__extract_doy
-                      , subq_23.listing__created_at__day
-                      , subq_23.listing__created_at__week
-                      , subq_23.listing__created_at__month
-                      , subq_23.listing__created_at__quarter
-                      , subq_23.listing__created_at__year
-                      , subq_23.listing__created_at__extract_year
-                      , subq_23.listing__created_at__extract_quarter
-                      , subq_23.listing__created_at__extract_month
-                      , subq_23.listing__created_at__extract_day
-                      , subq_23.listing__created_at__extract_dow
-                      , subq_23.listing__created_at__extract_doy
-                      , subq_23.ds__day AS metric_time__day
-                      , subq_23.ds__week AS metric_time__week
-                      , subq_23.ds__month AS metric_time__month
-                      , subq_23.ds__quarter AS metric_time__quarter
-                      , subq_23.ds__year AS metric_time__year
-                      , subq_23.ds__extract_year AS metric_time__extract_year
-                      , subq_23.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_23.ds__extract_month AS metric_time__extract_month
-                      , subq_23.ds__extract_day AS metric_time__extract_day
-                      , subq_23.ds__extract_dow AS metric_time__extract_dow
-                      , subq_23.ds__extract_doy AS metric_time__extract_doy
-                      , subq_23.listing
-                      , subq_23.user
-                      , subq_23.listing__user
-                      , subq_23.country_latest
-                      , subq_23.is_lux_latest
-                      , subq_23.capacity_latest
-                      , subq_23.listing__country_latest
-                      , subq_23.listing__is_lux_latest
-                      , subq_23.listing__capacity_latest
-                      , subq_23.listings
-                      , subq_23.largest_listing
-                      , subq_23.smallest_listing
+                      subq_17.ds__day
+                      , subq_17.ds__week
+                      , subq_17.ds__month
+                      , subq_17.ds__quarter
+                      , subq_17.ds__year
+                      , subq_17.ds__extract_year
+                      , subq_17.ds__extract_quarter
+                      , subq_17.ds__extract_month
+                      , subq_17.ds__extract_day
+                      , subq_17.ds__extract_dow
+                      , subq_17.ds__extract_doy
+                      , subq_17.created_at__day
+                      , subq_17.created_at__week
+                      , subq_17.created_at__month
+                      , subq_17.created_at__quarter
+                      , subq_17.created_at__year
+                      , subq_17.created_at__extract_year
+                      , subq_17.created_at__extract_quarter
+                      , subq_17.created_at__extract_month
+                      , subq_17.created_at__extract_day
+                      , subq_17.created_at__extract_dow
+                      , subq_17.created_at__extract_doy
+                      , subq_17.listing__ds__day
+                      , subq_17.listing__ds__week
+                      , subq_17.listing__ds__month
+                      , subq_17.listing__ds__quarter
+                      , subq_17.listing__ds__year
+                      , subq_17.listing__ds__extract_year
+                      , subq_17.listing__ds__extract_quarter
+                      , subq_17.listing__ds__extract_month
+                      , subq_17.listing__ds__extract_day
+                      , subq_17.listing__ds__extract_dow
+                      , subq_17.listing__ds__extract_doy
+                      , subq_17.listing__created_at__day
+                      , subq_17.listing__created_at__week
+                      , subq_17.listing__created_at__month
+                      , subq_17.listing__created_at__quarter
+                      , subq_17.listing__created_at__year
+                      , subq_17.listing__created_at__extract_year
+                      , subq_17.listing__created_at__extract_quarter
+                      , subq_17.listing__created_at__extract_month
+                      , subq_17.listing__created_at__extract_day
+                      , subq_17.listing__created_at__extract_dow
+                      , subq_17.listing__created_at__extract_doy
+                      , subq_17.ds__day AS metric_time__day
+                      , subq_17.ds__week AS metric_time__week
+                      , subq_17.ds__month AS metric_time__month
+                      , subq_17.ds__quarter AS metric_time__quarter
+                      , subq_17.ds__year AS metric_time__year
+                      , subq_17.ds__extract_year AS metric_time__extract_year
+                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_17.ds__extract_month AS metric_time__extract_month
+                      , subq_17.ds__extract_day AS metric_time__extract_day
+                      , subq_17.ds__extract_dow AS metric_time__extract_dow
+                      , subq_17.ds__extract_doy AS metric_time__extract_doy
+                      , subq_17.listing
+                      , subq_17.user
+                      , subq_17.listing__user
+                      , subq_17.country_latest
+                      , subq_17.is_lux_latest
+                      , subq_17.capacity_latest
+                      , subq_17.listing__country_latest
+                      , subq_17.listing__is_lux_latest
+                      , subq_17.listing__capacity_latest
+                      , subq_17.listings
+                      , subq_17.largest_listing
+                      , subq_17.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,242 +965,242 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_23
-                  ) subq_24
-                ) subq_25
+                    ) subq_17
+                  ) subq_18
+                ) subq_19
                 ON
-                  subq_22.listing = subq_25.listing
-              ) subq_26
-            ) subq_27
+                  subq_16.listing = subq_19.listing
+              ) subq_20
+            ) subq_21
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_28
-        ) subq_29
-      ) subq_30
-    ) subq_31
+          ) subq_22
+        ) subq_23
+      ) subq_24
+    ) subq_25
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_38.booking_value
+        subq_32.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_37.booking_value) AS booking_value
+          SUM(subq_31.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_36.booking_value
+            subq_30.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_35.booking__is_instant
-              , subq_35.booking_value
+              subq_29.booking__is_instant
+              , subq_29.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_34.booking__is_instant
-                , subq_34.booking_value
+                subq_28.booking__is_instant
+                , subq_28.booking_value
               FROM (
                 -- Constrain Output with WHERE
                 SELECT
-                  subq_33.ds__day
-                  , subq_33.ds__week
-                  , subq_33.ds__month
-                  , subq_33.ds__quarter
-                  , subq_33.ds__year
-                  , subq_33.ds__extract_year
-                  , subq_33.ds__extract_quarter
-                  , subq_33.ds__extract_month
-                  , subq_33.ds__extract_day
-                  , subq_33.ds__extract_dow
-                  , subq_33.ds__extract_doy
-                  , subq_33.ds_partitioned__day
-                  , subq_33.ds_partitioned__week
-                  , subq_33.ds_partitioned__month
-                  , subq_33.ds_partitioned__quarter
-                  , subq_33.ds_partitioned__year
-                  , subq_33.ds_partitioned__extract_year
-                  , subq_33.ds_partitioned__extract_quarter
-                  , subq_33.ds_partitioned__extract_month
-                  , subq_33.ds_partitioned__extract_day
-                  , subq_33.ds_partitioned__extract_dow
-                  , subq_33.ds_partitioned__extract_doy
-                  , subq_33.paid_at__day
-                  , subq_33.paid_at__week
-                  , subq_33.paid_at__month
-                  , subq_33.paid_at__quarter
-                  , subq_33.paid_at__year
-                  , subq_33.paid_at__extract_year
-                  , subq_33.paid_at__extract_quarter
-                  , subq_33.paid_at__extract_month
-                  , subq_33.paid_at__extract_day
-                  , subq_33.paid_at__extract_dow
-                  , subq_33.paid_at__extract_doy
-                  , subq_33.booking__ds__day
-                  , subq_33.booking__ds__week
-                  , subq_33.booking__ds__month
-                  , subq_33.booking__ds__quarter
-                  , subq_33.booking__ds__year
-                  , subq_33.booking__ds__extract_year
-                  , subq_33.booking__ds__extract_quarter
-                  , subq_33.booking__ds__extract_month
-                  , subq_33.booking__ds__extract_day
-                  , subq_33.booking__ds__extract_dow
-                  , subq_33.booking__ds__extract_doy
-                  , subq_33.booking__ds_partitioned__day
-                  , subq_33.booking__ds_partitioned__week
-                  , subq_33.booking__ds_partitioned__month
-                  , subq_33.booking__ds_partitioned__quarter
-                  , subq_33.booking__ds_partitioned__year
-                  , subq_33.booking__ds_partitioned__extract_year
-                  , subq_33.booking__ds_partitioned__extract_quarter
-                  , subq_33.booking__ds_partitioned__extract_month
-                  , subq_33.booking__ds_partitioned__extract_day
-                  , subq_33.booking__ds_partitioned__extract_dow
-                  , subq_33.booking__ds_partitioned__extract_doy
-                  , subq_33.booking__paid_at__day
-                  , subq_33.booking__paid_at__week
-                  , subq_33.booking__paid_at__month
-                  , subq_33.booking__paid_at__quarter
-                  , subq_33.booking__paid_at__year
-                  , subq_33.booking__paid_at__extract_year
-                  , subq_33.booking__paid_at__extract_quarter
-                  , subq_33.booking__paid_at__extract_month
-                  , subq_33.booking__paid_at__extract_day
-                  , subq_33.booking__paid_at__extract_dow
-                  , subq_33.booking__paid_at__extract_doy
-                  , subq_33.metric_time__day
-                  , subq_33.metric_time__week
-                  , subq_33.metric_time__month
-                  , subq_33.metric_time__quarter
-                  , subq_33.metric_time__year
-                  , subq_33.metric_time__extract_year
-                  , subq_33.metric_time__extract_quarter
-                  , subq_33.metric_time__extract_month
-                  , subq_33.metric_time__extract_day
-                  , subq_33.metric_time__extract_dow
-                  , subq_33.metric_time__extract_doy
-                  , subq_33.listing
-                  , subq_33.guest
-                  , subq_33.host
-                  , subq_33.booking__listing
-                  , subq_33.booking__guest
-                  , subq_33.booking__host
-                  , subq_33.is_instant
-                  , subq_33.booking__is_instant
-                  , subq_33.bookings
-                  , subq_33.instant_bookings
-                  , subq_33.booking_value
-                  , subq_33.max_booking_value
-                  , subq_33.min_booking_value
-                  , subq_33.bookers
-                  , subq_33.average_booking_value
-                  , subq_33.referred_bookings
-                  , subq_33.median_booking_value
-                  , subq_33.booking_value_p99
-                  , subq_33.discrete_booking_value_p99
-                  , subq_33.approximate_continuous_booking_value_p99
-                  , subq_33.approximate_discrete_booking_value_p99
+                  subq_27.ds__day
+                  , subq_27.ds__week
+                  , subq_27.ds__month
+                  , subq_27.ds__quarter
+                  , subq_27.ds__year
+                  , subq_27.ds__extract_year
+                  , subq_27.ds__extract_quarter
+                  , subq_27.ds__extract_month
+                  , subq_27.ds__extract_day
+                  , subq_27.ds__extract_dow
+                  , subq_27.ds__extract_doy
+                  , subq_27.ds_partitioned__day
+                  , subq_27.ds_partitioned__week
+                  , subq_27.ds_partitioned__month
+                  , subq_27.ds_partitioned__quarter
+                  , subq_27.ds_partitioned__year
+                  , subq_27.ds_partitioned__extract_year
+                  , subq_27.ds_partitioned__extract_quarter
+                  , subq_27.ds_partitioned__extract_month
+                  , subq_27.ds_partitioned__extract_day
+                  , subq_27.ds_partitioned__extract_dow
+                  , subq_27.ds_partitioned__extract_doy
+                  , subq_27.paid_at__day
+                  , subq_27.paid_at__week
+                  , subq_27.paid_at__month
+                  , subq_27.paid_at__quarter
+                  , subq_27.paid_at__year
+                  , subq_27.paid_at__extract_year
+                  , subq_27.paid_at__extract_quarter
+                  , subq_27.paid_at__extract_month
+                  , subq_27.paid_at__extract_day
+                  , subq_27.paid_at__extract_dow
+                  , subq_27.paid_at__extract_doy
+                  , subq_27.booking__ds__day
+                  , subq_27.booking__ds__week
+                  , subq_27.booking__ds__month
+                  , subq_27.booking__ds__quarter
+                  , subq_27.booking__ds__year
+                  , subq_27.booking__ds__extract_year
+                  , subq_27.booking__ds__extract_quarter
+                  , subq_27.booking__ds__extract_month
+                  , subq_27.booking__ds__extract_day
+                  , subq_27.booking__ds__extract_dow
+                  , subq_27.booking__ds__extract_doy
+                  , subq_27.booking__ds_partitioned__day
+                  , subq_27.booking__ds_partitioned__week
+                  , subq_27.booking__ds_partitioned__month
+                  , subq_27.booking__ds_partitioned__quarter
+                  , subq_27.booking__ds_partitioned__year
+                  , subq_27.booking__ds_partitioned__extract_year
+                  , subq_27.booking__ds_partitioned__extract_quarter
+                  , subq_27.booking__ds_partitioned__extract_month
+                  , subq_27.booking__ds_partitioned__extract_day
+                  , subq_27.booking__ds_partitioned__extract_dow
+                  , subq_27.booking__ds_partitioned__extract_doy
+                  , subq_27.booking__paid_at__day
+                  , subq_27.booking__paid_at__week
+                  , subq_27.booking__paid_at__month
+                  , subq_27.booking__paid_at__quarter
+                  , subq_27.booking__paid_at__year
+                  , subq_27.booking__paid_at__extract_year
+                  , subq_27.booking__paid_at__extract_quarter
+                  , subq_27.booking__paid_at__extract_month
+                  , subq_27.booking__paid_at__extract_day
+                  , subq_27.booking__paid_at__extract_dow
+                  , subq_27.booking__paid_at__extract_doy
+                  , subq_27.metric_time__day
+                  , subq_27.metric_time__week
+                  , subq_27.metric_time__month
+                  , subq_27.metric_time__quarter
+                  , subq_27.metric_time__year
+                  , subq_27.metric_time__extract_year
+                  , subq_27.metric_time__extract_quarter
+                  , subq_27.metric_time__extract_month
+                  , subq_27.metric_time__extract_day
+                  , subq_27.metric_time__extract_dow
+                  , subq_27.metric_time__extract_doy
+                  , subq_27.listing
+                  , subq_27.guest
+                  , subq_27.host
+                  , subq_27.booking__listing
+                  , subq_27.booking__guest
+                  , subq_27.booking__host
+                  , subq_27.is_instant
+                  , subq_27.booking__is_instant
+                  , subq_27.bookings
+                  , subq_27.instant_bookings
+                  , subq_27.booking_value
+                  , subq_27.max_booking_value
+                  , subq_27.min_booking_value
+                  , subq_27.bookers
+                  , subq_27.average_booking_value
+                  , subq_27.referred_bookings
+                  , subq_27.median_booking_value
+                  , subq_27.booking_value_p99
+                  , subq_27.discrete_booking_value_p99
+                  , subq_27.approximate_continuous_booking_value_p99
+                  , subq_27.approximate_discrete_booking_value_p99
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_32.ds__day
-                    , subq_32.ds__week
-                    , subq_32.ds__month
-                    , subq_32.ds__quarter
-                    , subq_32.ds__year
-                    , subq_32.ds__extract_year
-                    , subq_32.ds__extract_quarter
-                    , subq_32.ds__extract_month
-                    , subq_32.ds__extract_day
-                    , subq_32.ds__extract_dow
-                    , subq_32.ds__extract_doy
-                    , subq_32.ds_partitioned__day
-                    , subq_32.ds_partitioned__week
-                    , subq_32.ds_partitioned__month
-                    , subq_32.ds_partitioned__quarter
-                    , subq_32.ds_partitioned__year
-                    , subq_32.ds_partitioned__extract_year
-                    , subq_32.ds_partitioned__extract_quarter
-                    , subq_32.ds_partitioned__extract_month
-                    , subq_32.ds_partitioned__extract_day
-                    , subq_32.ds_partitioned__extract_dow
-                    , subq_32.ds_partitioned__extract_doy
-                    , subq_32.paid_at__day
-                    , subq_32.paid_at__week
-                    , subq_32.paid_at__month
-                    , subq_32.paid_at__quarter
-                    , subq_32.paid_at__year
-                    , subq_32.paid_at__extract_year
-                    , subq_32.paid_at__extract_quarter
-                    , subq_32.paid_at__extract_month
-                    , subq_32.paid_at__extract_day
-                    , subq_32.paid_at__extract_dow
-                    , subq_32.paid_at__extract_doy
-                    , subq_32.booking__ds__day
-                    , subq_32.booking__ds__week
-                    , subq_32.booking__ds__month
-                    , subq_32.booking__ds__quarter
-                    , subq_32.booking__ds__year
-                    , subq_32.booking__ds__extract_year
-                    , subq_32.booking__ds__extract_quarter
-                    , subq_32.booking__ds__extract_month
-                    , subq_32.booking__ds__extract_day
-                    , subq_32.booking__ds__extract_dow
-                    , subq_32.booking__ds__extract_doy
-                    , subq_32.booking__ds_partitioned__day
-                    , subq_32.booking__ds_partitioned__week
-                    , subq_32.booking__ds_partitioned__month
-                    , subq_32.booking__ds_partitioned__quarter
-                    , subq_32.booking__ds_partitioned__year
-                    , subq_32.booking__ds_partitioned__extract_year
-                    , subq_32.booking__ds_partitioned__extract_quarter
-                    , subq_32.booking__ds_partitioned__extract_month
-                    , subq_32.booking__ds_partitioned__extract_day
-                    , subq_32.booking__ds_partitioned__extract_dow
-                    , subq_32.booking__ds_partitioned__extract_doy
-                    , subq_32.booking__paid_at__day
-                    , subq_32.booking__paid_at__week
-                    , subq_32.booking__paid_at__month
-                    , subq_32.booking__paid_at__quarter
-                    , subq_32.booking__paid_at__year
-                    , subq_32.booking__paid_at__extract_year
-                    , subq_32.booking__paid_at__extract_quarter
-                    , subq_32.booking__paid_at__extract_month
-                    , subq_32.booking__paid_at__extract_day
-                    , subq_32.booking__paid_at__extract_dow
-                    , subq_32.booking__paid_at__extract_doy
-                    , subq_32.ds__day AS metric_time__day
-                    , subq_32.ds__week AS metric_time__week
-                    , subq_32.ds__month AS metric_time__month
-                    , subq_32.ds__quarter AS metric_time__quarter
-                    , subq_32.ds__year AS metric_time__year
-                    , subq_32.ds__extract_year AS metric_time__extract_year
-                    , subq_32.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_32.ds__extract_month AS metric_time__extract_month
-                    , subq_32.ds__extract_day AS metric_time__extract_day
-                    , subq_32.ds__extract_dow AS metric_time__extract_dow
-                    , subq_32.ds__extract_doy AS metric_time__extract_doy
-                    , subq_32.listing
-                    , subq_32.guest
-                    , subq_32.host
-                    , subq_32.booking__listing
-                    , subq_32.booking__guest
-                    , subq_32.booking__host
-                    , subq_32.is_instant
-                    , subq_32.booking__is_instant
-                    , subq_32.bookings
-                    , subq_32.instant_bookings
-                    , subq_32.booking_value
-                    , subq_32.max_booking_value
-                    , subq_32.min_booking_value
-                    , subq_32.bookers
-                    , subq_32.average_booking_value
-                    , subq_32.referred_bookings
-                    , subq_32.median_booking_value
-                    , subq_32.booking_value_p99
-                    , subq_32.discrete_booking_value_p99
-                    , subq_32.approximate_continuous_booking_value_p99
-                    , subq_32.approximate_discrete_booking_value_p99
+                    subq_26.ds__day
+                    , subq_26.ds__week
+                    , subq_26.ds__month
+                    , subq_26.ds__quarter
+                    , subq_26.ds__year
+                    , subq_26.ds__extract_year
+                    , subq_26.ds__extract_quarter
+                    , subq_26.ds__extract_month
+                    , subq_26.ds__extract_day
+                    , subq_26.ds__extract_dow
+                    , subq_26.ds__extract_doy
+                    , subq_26.ds_partitioned__day
+                    , subq_26.ds_partitioned__week
+                    , subq_26.ds_partitioned__month
+                    , subq_26.ds_partitioned__quarter
+                    , subq_26.ds_partitioned__year
+                    , subq_26.ds_partitioned__extract_year
+                    , subq_26.ds_partitioned__extract_quarter
+                    , subq_26.ds_partitioned__extract_month
+                    , subq_26.ds_partitioned__extract_day
+                    , subq_26.ds_partitioned__extract_dow
+                    , subq_26.ds_partitioned__extract_doy
+                    , subq_26.paid_at__day
+                    , subq_26.paid_at__week
+                    , subq_26.paid_at__month
+                    , subq_26.paid_at__quarter
+                    , subq_26.paid_at__year
+                    , subq_26.paid_at__extract_year
+                    , subq_26.paid_at__extract_quarter
+                    , subq_26.paid_at__extract_month
+                    , subq_26.paid_at__extract_day
+                    , subq_26.paid_at__extract_dow
+                    , subq_26.paid_at__extract_doy
+                    , subq_26.booking__ds__day
+                    , subq_26.booking__ds__week
+                    , subq_26.booking__ds__month
+                    , subq_26.booking__ds__quarter
+                    , subq_26.booking__ds__year
+                    , subq_26.booking__ds__extract_year
+                    , subq_26.booking__ds__extract_quarter
+                    , subq_26.booking__ds__extract_month
+                    , subq_26.booking__ds__extract_day
+                    , subq_26.booking__ds__extract_dow
+                    , subq_26.booking__ds__extract_doy
+                    , subq_26.booking__ds_partitioned__day
+                    , subq_26.booking__ds_partitioned__week
+                    , subq_26.booking__ds_partitioned__month
+                    , subq_26.booking__ds_partitioned__quarter
+                    , subq_26.booking__ds_partitioned__year
+                    , subq_26.booking__ds_partitioned__extract_year
+                    , subq_26.booking__ds_partitioned__extract_quarter
+                    , subq_26.booking__ds_partitioned__extract_month
+                    , subq_26.booking__ds_partitioned__extract_day
+                    , subq_26.booking__ds_partitioned__extract_dow
+                    , subq_26.booking__ds_partitioned__extract_doy
+                    , subq_26.booking__paid_at__day
+                    , subq_26.booking__paid_at__week
+                    , subq_26.booking__paid_at__month
+                    , subq_26.booking__paid_at__quarter
+                    , subq_26.booking__paid_at__year
+                    , subq_26.booking__paid_at__extract_year
+                    , subq_26.booking__paid_at__extract_quarter
+                    , subq_26.booking__paid_at__extract_month
+                    , subq_26.booking__paid_at__extract_day
+                    , subq_26.booking__paid_at__extract_dow
+                    , subq_26.booking__paid_at__extract_doy
+                    , subq_26.ds__day AS metric_time__day
+                    , subq_26.ds__week AS metric_time__week
+                    , subq_26.ds__month AS metric_time__month
+                    , subq_26.ds__quarter AS metric_time__quarter
+                    , subq_26.ds__year AS metric_time__year
+                    , subq_26.ds__extract_year AS metric_time__extract_year
+                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_26.ds__extract_month AS metric_time__extract_month
+                    , subq_26.ds__extract_day AS metric_time__extract_day
+                    , subq_26.ds__extract_dow AS metric_time__extract_dow
+                    , subq_26.ds__extract_doy AS metric_time__extract_doy
+                    , subq_26.listing
+                    , subq_26.guest
+                    , subq_26.host
+                    , subq_26.booking__listing
+                    , subq_26.booking__guest
+                    , subq_26.booking__host
+                    , subq_26.is_instant
+                    , subq_26.booking__is_instant
+                    , subq_26.bookings
+                    , subq_26.instant_bookings
+                    , subq_26.booking_value
+                    , subq_26.max_booking_value
+                    , subq_26.min_booking_value
+                    , subq_26.bookers
+                    , subq_26.average_booking_value
+                    , subq_26.referred_bookings
+                    , subq_26.median_booking_value
+                    , subq_26.booking_value_p99
+                    , subq_26.discrete_booking_value_p99
+                    , subq_26.approximate_continuous_booking_value_p99
+                    , subq_26.approximate_discrete_booking_value_p99
                   FROM (
                     -- Read Elements From Semantic Model 'bookings_source'
                     SELECT
@@ -1293,15 +1293,15 @@ FROM (
                       , bookings_source_src_28000.guest_id AS booking__guest
                       , bookings_source_src_28000.host_id AS booking__host
                     FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_32
-                ) subq_33
+                  ) subq_26
+                ) subq_27
                 WHERE booking__is_instant
-              ) subq_34
-            ) subq_35
+              ) subq_28
+            ) subq_29
             WHERE booking__is_instant
-          ) subq_36
-        ) subq_37
-      ) subq_38
-    ) subq_39
-  ) subq_40
-) subq_41
+          ) subq_30
+        ) subq_31
+      ) subq_32
+    ) subq_33
+  ) subq_34
+) subq_35

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_60.average_booking_value) AS average_booking_value
-      , MAX(subq_73.bookings) AS bookings
-      , MAX(subq_81.booking_value) AS booking_value
+      MAX(subq_48.average_booking_value) AS average_booking_value
+      , MAX(subq_61.bookings) AS bookings
+      , MAX(subq_69.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_51.booking__is_instant AS booking__is_instant
+          subq_39.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_51.average_booking_value AS average_booking_value
+          , subq_39.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_49
+          ) subq_37
           WHERE booking__is_instant
-        ) subq_51
+        ) subq_39
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_51.listing = listings_latest_src_28000.listing_id
-      ) subq_56
+          subq_39.listing = listings_latest_src_28000.listing_id
+      ) subq_44
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_60
+    ) subq_48
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_64.booking__is_instant AS booking__is_instant
+          subq_52.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_64.bookings AS bookings
+          , subq_52.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_62
+          ) subq_50
           WHERE booking__is_instant
-        ) subq_64
+        ) subq_52
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_64.listing = listings_latest_src_28000.listing_id
-      ) subq_69
+          subq_52.listing = listings_latest_src_28000.listing_id
+      ) subq_57
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_73
+    ) subq_61
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_75
+        ) subq_63
         WHERE booking__is_instant
-      ) subq_77
+      ) subq_65
       WHERE booking__is_instant
-    ) subq_81
-  ) subq_82
-) subq_83
+    ) subq_69
+  ) subq_70
+) subq_71

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0.sql
@@ -8,248 +8,248 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_18.average_booking_value) AS average_booking_value
-      , MAX(subq_31.bookings) AS bookings
-      , MAX(subq_39.booking_value) AS booking_value
+      MAX(subq_12.average_booking_value) AS average_booking_value
+      , MAX(subq_25.bookings) AS bookings
+      , MAX(subq_33.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.average_booking_value
+        subq_11.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_16.average_booking_value) AS average_booking_value
+          AVG(subq_10.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_15.average_booking_value
+            subq_9.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.booking__is_instant
-              , subq_14.listing__is_lux_latest
-              , subq_14.average_booking_value
+              subq_8.booking__is_instant
+              , subq_8.listing__is_lux_latest
+              , subq_8.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_13.booking__is_instant
-                , subq_13.listing__is_lux_latest
-                , subq_13.average_booking_value
+                subq_7.booking__is_instant
+                , subq_7.listing__is_lux_latest
+                , subq_7.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_9.listing AS listing
-                  , subq_9.booking__is_instant AS booking__is_instant
-                  , subq_12.is_lux_latest AS listing__is_lux_latest
-                  , subq_9.average_booking_value AS average_booking_value
+                  subq_3.listing AS listing
+                  , subq_3.booking__is_instant AS booking__is_instant
+                  , subq_6.is_lux_latest AS listing__is_lux_latest
+                  , subq_3.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.booking__is_instant
-                    , subq_8.average_booking_value
+                    subq_2.listing
+                    , subq_2.booking__is_instant
+                    , subq_2.average_booking_value
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.metric_time__day
-                      , subq_7.metric_time__week
-                      , subq_7.metric_time__month
-                      , subq_7.metric_time__quarter
-                      , subq_7.metric_time__year
-                      , subq_7.metric_time__extract_year
-                      , subq_7.metric_time__extract_quarter
-                      , subq_7.metric_time__extract_month
-                      , subq_7.metric_time__extract_day
-                      , subq_7.metric_time__extract_dow
-                      , subq_7.metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_1.ds__day
+                      , subq_1.ds__week
+                      , subq_1.ds__month
+                      , subq_1.ds__quarter
+                      , subq_1.ds__year
+                      , subq_1.ds__extract_year
+                      , subq_1.ds__extract_quarter
+                      , subq_1.ds__extract_month
+                      , subq_1.ds__extract_day
+                      , subq_1.ds__extract_dow
+                      , subq_1.ds__extract_doy
+                      , subq_1.ds_partitioned__day
+                      , subq_1.ds_partitioned__week
+                      , subq_1.ds_partitioned__month
+                      , subq_1.ds_partitioned__quarter
+                      , subq_1.ds_partitioned__year
+                      , subq_1.ds_partitioned__extract_year
+                      , subq_1.ds_partitioned__extract_quarter
+                      , subq_1.ds_partitioned__extract_month
+                      , subq_1.ds_partitioned__extract_day
+                      , subq_1.ds_partitioned__extract_dow
+                      , subq_1.ds_partitioned__extract_doy
+                      , subq_1.paid_at__day
+                      , subq_1.paid_at__week
+                      , subq_1.paid_at__month
+                      , subq_1.paid_at__quarter
+                      , subq_1.paid_at__year
+                      , subq_1.paid_at__extract_year
+                      , subq_1.paid_at__extract_quarter
+                      , subq_1.paid_at__extract_month
+                      , subq_1.paid_at__extract_day
+                      , subq_1.paid_at__extract_dow
+                      , subq_1.paid_at__extract_doy
+                      , subq_1.booking__ds__day
+                      , subq_1.booking__ds__week
+                      , subq_1.booking__ds__month
+                      , subq_1.booking__ds__quarter
+                      , subq_1.booking__ds__year
+                      , subq_1.booking__ds__extract_year
+                      , subq_1.booking__ds__extract_quarter
+                      , subq_1.booking__ds__extract_month
+                      , subq_1.booking__ds__extract_day
+                      , subq_1.booking__ds__extract_dow
+                      , subq_1.booking__ds__extract_doy
+                      , subq_1.booking__ds_partitioned__day
+                      , subq_1.booking__ds_partitioned__week
+                      , subq_1.booking__ds_partitioned__month
+                      , subq_1.booking__ds_partitioned__quarter
+                      , subq_1.booking__ds_partitioned__year
+                      , subq_1.booking__ds_partitioned__extract_year
+                      , subq_1.booking__ds_partitioned__extract_quarter
+                      , subq_1.booking__ds_partitioned__extract_month
+                      , subq_1.booking__ds_partitioned__extract_day
+                      , subq_1.booking__ds_partitioned__extract_dow
+                      , subq_1.booking__ds_partitioned__extract_doy
+                      , subq_1.booking__paid_at__day
+                      , subq_1.booking__paid_at__week
+                      , subq_1.booking__paid_at__month
+                      , subq_1.booking__paid_at__quarter
+                      , subq_1.booking__paid_at__year
+                      , subq_1.booking__paid_at__extract_year
+                      , subq_1.booking__paid_at__extract_quarter
+                      , subq_1.booking__paid_at__extract_month
+                      , subq_1.booking__paid_at__extract_day
+                      , subq_1.booking__paid_at__extract_dow
+                      , subq_1.booking__paid_at__extract_doy
+                      , subq_1.metric_time__day
+                      , subq_1.metric_time__week
+                      , subq_1.metric_time__month
+                      , subq_1.metric_time__quarter
+                      , subq_1.metric_time__year
+                      , subq_1.metric_time__extract_year
+                      , subq_1.metric_time__extract_quarter
+                      , subq_1.metric_time__extract_month
+                      , subq_1.metric_time__extract_day
+                      , subq_1.metric_time__extract_dow
+                      , subq_1.metric_time__extract_doy
+                      , subq_1.listing
+                      , subq_1.guest
+                      , subq_1.host
+                      , subq_1.booking__listing
+                      , subq_1.booking__guest
+                      , subq_1.booking__host
+                      , subq_1.is_instant
+                      , subq_1.booking__is_instant
+                      , subq_1.bookings
+                      , subq_1.instant_bookings
+                      , subq_1.booking_value
+                      , subq_1.max_booking_value
+                      , subq_1.min_booking_value
+                      , subq_1.bookers
+                      , subq_1.average_booking_value
+                      , subq_1.referred_bookings
+                      , subq_1.median_booking_value
+                      , subq_1.booking_value_p99
+                      , subq_1.discrete_booking_value_p99
+                      , subq_1.approximate_continuous_booking_value_p99
+                      , subq_1.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_6.ds__day
-                        , subq_6.ds__week
-                        , subq_6.ds__month
-                        , subq_6.ds__quarter
-                        , subq_6.ds__year
-                        , subq_6.ds__extract_year
-                        , subq_6.ds__extract_quarter
-                        , subq_6.ds__extract_month
-                        , subq_6.ds__extract_day
-                        , subq_6.ds__extract_dow
-                        , subq_6.ds__extract_doy
-                        , subq_6.ds_partitioned__day
-                        , subq_6.ds_partitioned__week
-                        , subq_6.ds_partitioned__month
-                        , subq_6.ds_partitioned__quarter
-                        , subq_6.ds_partitioned__year
-                        , subq_6.ds_partitioned__extract_year
-                        , subq_6.ds_partitioned__extract_quarter
-                        , subq_6.ds_partitioned__extract_month
-                        , subq_6.ds_partitioned__extract_day
-                        , subq_6.ds_partitioned__extract_dow
-                        , subq_6.ds_partitioned__extract_doy
-                        , subq_6.paid_at__day
-                        , subq_6.paid_at__week
-                        , subq_6.paid_at__month
-                        , subq_6.paid_at__quarter
-                        , subq_6.paid_at__year
-                        , subq_6.paid_at__extract_year
-                        , subq_6.paid_at__extract_quarter
-                        , subq_6.paid_at__extract_month
-                        , subq_6.paid_at__extract_day
-                        , subq_6.paid_at__extract_dow
-                        , subq_6.paid_at__extract_doy
-                        , subq_6.booking__ds__day
-                        , subq_6.booking__ds__week
-                        , subq_6.booking__ds__month
-                        , subq_6.booking__ds__quarter
-                        , subq_6.booking__ds__year
-                        , subq_6.booking__ds__extract_year
-                        , subq_6.booking__ds__extract_quarter
-                        , subq_6.booking__ds__extract_month
-                        , subq_6.booking__ds__extract_day
-                        , subq_6.booking__ds__extract_dow
-                        , subq_6.booking__ds__extract_doy
-                        , subq_6.booking__ds_partitioned__day
-                        , subq_6.booking__ds_partitioned__week
-                        , subq_6.booking__ds_partitioned__month
-                        , subq_6.booking__ds_partitioned__quarter
-                        , subq_6.booking__ds_partitioned__year
-                        , subq_6.booking__ds_partitioned__extract_year
-                        , subq_6.booking__ds_partitioned__extract_quarter
-                        , subq_6.booking__ds_partitioned__extract_month
-                        , subq_6.booking__ds_partitioned__extract_day
-                        , subq_6.booking__ds_partitioned__extract_dow
-                        , subq_6.booking__ds_partitioned__extract_doy
-                        , subq_6.booking__paid_at__day
-                        , subq_6.booking__paid_at__week
-                        , subq_6.booking__paid_at__month
-                        , subq_6.booking__paid_at__quarter
-                        , subq_6.booking__paid_at__year
-                        , subq_6.booking__paid_at__extract_year
-                        , subq_6.booking__paid_at__extract_quarter
-                        , subq_6.booking__paid_at__extract_month
-                        , subq_6.booking__paid_at__extract_day
-                        , subq_6.booking__paid_at__extract_dow
-                        , subq_6.booking__paid_at__extract_doy
-                        , subq_6.ds__day AS metric_time__day
-                        , subq_6.ds__week AS metric_time__week
-                        , subq_6.ds__month AS metric_time__month
-                        , subq_6.ds__quarter AS metric_time__quarter
-                        , subq_6.ds__year AS metric_time__year
-                        , subq_6.ds__extract_year AS metric_time__extract_year
-                        , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_6.ds__extract_month AS metric_time__extract_month
-                        , subq_6.ds__extract_day AS metric_time__extract_day
-                        , subq_6.ds__extract_dow AS metric_time__extract_dow
-                        , subq_6.ds__extract_doy AS metric_time__extract_doy
-                        , subq_6.listing
-                        , subq_6.guest
-                        , subq_6.host
-                        , subq_6.booking__listing
-                        , subq_6.booking__guest
-                        , subq_6.booking__host
-                        , subq_6.is_instant
-                        , subq_6.booking__is_instant
-                        , subq_6.bookings
-                        , subq_6.instant_bookings
-                        , subq_6.booking_value
-                        , subq_6.max_booking_value
-                        , subq_6.min_booking_value
-                        , subq_6.bookers
-                        , subq_6.average_booking_value
-                        , subq_6.referred_bookings
-                        , subq_6.median_booking_value
-                        , subq_6.booking_value_p99
-                        , subq_6.discrete_booking_value_p99
-                        , subq_6.approximate_continuous_booking_value_p99
-                        , subq_6.approximate_discrete_booking_value_p99
+                        subq_0.ds__day
+                        , subq_0.ds__week
+                        , subq_0.ds__month
+                        , subq_0.ds__quarter
+                        , subq_0.ds__year
+                        , subq_0.ds__extract_year
+                        , subq_0.ds__extract_quarter
+                        , subq_0.ds__extract_month
+                        , subq_0.ds__extract_day
+                        , subq_0.ds__extract_dow
+                        , subq_0.ds__extract_doy
+                        , subq_0.ds_partitioned__day
+                        , subq_0.ds_partitioned__week
+                        , subq_0.ds_partitioned__month
+                        , subq_0.ds_partitioned__quarter
+                        , subq_0.ds_partitioned__year
+                        , subq_0.ds_partitioned__extract_year
+                        , subq_0.ds_partitioned__extract_quarter
+                        , subq_0.ds_partitioned__extract_month
+                        , subq_0.ds_partitioned__extract_day
+                        , subq_0.ds_partitioned__extract_dow
+                        , subq_0.ds_partitioned__extract_doy
+                        , subq_0.paid_at__day
+                        , subq_0.paid_at__week
+                        , subq_0.paid_at__month
+                        , subq_0.paid_at__quarter
+                        , subq_0.paid_at__year
+                        , subq_0.paid_at__extract_year
+                        , subq_0.paid_at__extract_quarter
+                        , subq_0.paid_at__extract_month
+                        , subq_0.paid_at__extract_day
+                        , subq_0.paid_at__extract_dow
+                        , subq_0.paid_at__extract_doy
+                        , subq_0.booking__ds__day
+                        , subq_0.booking__ds__week
+                        , subq_0.booking__ds__month
+                        , subq_0.booking__ds__quarter
+                        , subq_0.booking__ds__year
+                        , subq_0.booking__ds__extract_year
+                        , subq_0.booking__ds__extract_quarter
+                        , subq_0.booking__ds__extract_month
+                        , subq_0.booking__ds__extract_day
+                        , subq_0.booking__ds__extract_dow
+                        , subq_0.booking__ds__extract_doy
+                        , subq_0.booking__ds_partitioned__day
+                        , subq_0.booking__ds_partitioned__week
+                        , subq_0.booking__ds_partitioned__month
+                        , subq_0.booking__ds_partitioned__quarter
+                        , subq_0.booking__ds_partitioned__year
+                        , subq_0.booking__ds_partitioned__extract_year
+                        , subq_0.booking__ds_partitioned__extract_quarter
+                        , subq_0.booking__ds_partitioned__extract_month
+                        , subq_0.booking__ds_partitioned__extract_day
+                        , subq_0.booking__ds_partitioned__extract_dow
+                        , subq_0.booking__ds_partitioned__extract_doy
+                        , subq_0.booking__paid_at__day
+                        , subq_0.booking__paid_at__week
+                        , subq_0.booking__paid_at__month
+                        , subq_0.booking__paid_at__quarter
+                        , subq_0.booking__paid_at__year
+                        , subq_0.booking__paid_at__extract_year
+                        , subq_0.booking__paid_at__extract_quarter
+                        , subq_0.booking__paid_at__extract_month
+                        , subq_0.booking__paid_at__extract_day
+                        , subq_0.booking__paid_at__extract_dow
+                        , subq_0.booking__paid_at__extract_doy
+                        , subq_0.ds__day AS metric_time__day
+                        , subq_0.ds__week AS metric_time__week
+                        , subq_0.ds__month AS metric_time__month
+                        , subq_0.ds__quarter AS metric_time__quarter
+                        , subq_0.ds__year AS metric_time__year
+                        , subq_0.ds__extract_year AS metric_time__extract_year
+                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_0.ds__extract_month AS metric_time__extract_month
+                        , subq_0.ds__extract_day AS metric_time__extract_day
+                        , subq_0.ds__extract_dow AS metric_time__extract_dow
+                        , subq_0.ds__extract_doy AS metric_time__extract_doy
+                        , subq_0.listing
+                        , subq_0.guest
+                        , subq_0.host
+                        , subq_0.booking__listing
+                        , subq_0.booking__guest
+                        , subq_0.booking__host
+                        , subq_0.is_instant
+                        , subq_0.booking__is_instant
+                        , subq_0.bookings
+                        , subq_0.instant_bookings
+                        , subq_0.booking_value
+                        , subq_0.max_booking_value
+                        , subq_0.min_booking_value
+                        , subq_0.bookers
+                        , subq_0.average_booking_value
+                        , subq_0.referred_bookings
+                        , subq_0.median_booking_value
+                        , subq_0.booking_value_p99
+                        , subq_0.discrete_booking_value_p99
+                        , subq_0.approximate_continuous_booking_value_p99
+                        , subq_0.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -342,86 +342,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_6
-                    ) subq_7
+                      ) subq_0
+                    ) subq_1
                     WHERE booking__is_instant
-                  ) subq_8
-                ) subq_9
+                  ) subq_2
+                ) subq_3
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_11.listing
-                    , subq_11.is_lux_latest
+                    subq_5.listing
+                    , subq_5.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_10.ds__day
-                      , subq_10.ds__week
-                      , subq_10.ds__month
-                      , subq_10.ds__quarter
-                      , subq_10.ds__year
-                      , subq_10.ds__extract_year
-                      , subq_10.ds__extract_quarter
-                      , subq_10.ds__extract_month
-                      , subq_10.ds__extract_day
-                      , subq_10.ds__extract_dow
-                      , subq_10.ds__extract_doy
-                      , subq_10.created_at__day
-                      , subq_10.created_at__week
-                      , subq_10.created_at__month
-                      , subq_10.created_at__quarter
-                      , subq_10.created_at__year
-                      , subq_10.created_at__extract_year
-                      , subq_10.created_at__extract_quarter
-                      , subq_10.created_at__extract_month
-                      , subq_10.created_at__extract_day
-                      , subq_10.created_at__extract_dow
-                      , subq_10.created_at__extract_doy
-                      , subq_10.listing__ds__day
-                      , subq_10.listing__ds__week
-                      , subq_10.listing__ds__month
-                      , subq_10.listing__ds__quarter
-                      , subq_10.listing__ds__year
-                      , subq_10.listing__ds__extract_year
-                      , subq_10.listing__ds__extract_quarter
-                      , subq_10.listing__ds__extract_month
-                      , subq_10.listing__ds__extract_day
-                      , subq_10.listing__ds__extract_dow
-                      , subq_10.listing__ds__extract_doy
-                      , subq_10.listing__created_at__day
-                      , subq_10.listing__created_at__week
-                      , subq_10.listing__created_at__month
-                      , subq_10.listing__created_at__quarter
-                      , subq_10.listing__created_at__year
-                      , subq_10.listing__created_at__extract_year
-                      , subq_10.listing__created_at__extract_quarter
-                      , subq_10.listing__created_at__extract_month
-                      , subq_10.listing__created_at__extract_day
-                      , subq_10.listing__created_at__extract_dow
-                      , subq_10.listing__created_at__extract_doy
-                      , subq_10.ds__day AS metric_time__day
-                      , subq_10.ds__week AS metric_time__week
-                      , subq_10.ds__month AS metric_time__month
-                      , subq_10.ds__quarter AS metric_time__quarter
-                      , subq_10.ds__year AS metric_time__year
-                      , subq_10.ds__extract_year AS metric_time__extract_year
-                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_10.ds__extract_month AS metric_time__extract_month
-                      , subq_10.ds__extract_day AS metric_time__extract_day
-                      , subq_10.ds__extract_dow AS metric_time__extract_dow
-                      , subq_10.ds__extract_doy AS metric_time__extract_doy
-                      , subq_10.listing
-                      , subq_10.user
-                      , subq_10.listing__user
-                      , subq_10.country_latest
-                      , subq_10.is_lux_latest
-                      , subq_10.capacity_latest
-                      , subq_10.listing__country_latest
-                      , subq_10.listing__is_lux_latest
-                      , subq_10.listing__capacity_latest
-                      , subq_10.listings
-                      , subq_10.largest_listing
-                      , subq_10.smallest_listing
+                      subq_4.ds__day
+                      , subq_4.ds__week
+                      , subq_4.ds__month
+                      , subq_4.ds__quarter
+                      , subq_4.ds__year
+                      , subq_4.ds__extract_year
+                      , subq_4.ds__extract_quarter
+                      , subq_4.ds__extract_month
+                      , subq_4.ds__extract_day
+                      , subq_4.ds__extract_dow
+                      , subq_4.ds__extract_doy
+                      , subq_4.created_at__day
+                      , subq_4.created_at__week
+                      , subq_4.created_at__month
+                      , subq_4.created_at__quarter
+                      , subq_4.created_at__year
+                      , subq_4.created_at__extract_year
+                      , subq_4.created_at__extract_quarter
+                      , subq_4.created_at__extract_month
+                      , subq_4.created_at__extract_day
+                      , subq_4.created_at__extract_dow
+                      , subq_4.created_at__extract_doy
+                      , subq_4.listing__ds__day
+                      , subq_4.listing__ds__week
+                      , subq_4.listing__ds__month
+                      , subq_4.listing__ds__quarter
+                      , subq_4.listing__ds__year
+                      , subq_4.listing__ds__extract_year
+                      , subq_4.listing__ds__extract_quarter
+                      , subq_4.listing__ds__extract_month
+                      , subq_4.listing__ds__extract_day
+                      , subq_4.listing__ds__extract_dow
+                      , subq_4.listing__ds__extract_doy
+                      , subq_4.listing__created_at__day
+                      , subq_4.listing__created_at__week
+                      , subq_4.listing__created_at__month
+                      , subq_4.listing__created_at__quarter
+                      , subq_4.listing__created_at__year
+                      , subq_4.listing__created_at__extract_year
+                      , subq_4.listing__created_at__extract_quarter
+                      , subq_4.listing__created_at__extract_month
+                      , subq_4.listing__created_at__extract_day
+                      , subq_4.listing__created_at__extract_dow
+                      , subq_4.listing__created_at__extract_doy
+                      , subq_4.ds__day AS metric_time__day
+                      , subq_4.ds__week AS metric_time__week
+                      , subq_4.ds__month AS metric_time__month
+                      , subq_4.ds__quarter AS metric_time__quarter
+                      , subq_4.ds__year AS metric_time__year
+                      , subq_4.ds__extract_year AS metric_time__extract_year
+                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_4.ds__extract_month AS metric_time__extract_month
+                      , subq_4.ds__extract_day AS metric_time__extract_day
+                      , subq_4.ds__extract_dow AS metric_time__extract_dow
+                      , subq_4.ds__extract_doy AS metric_time__extract_doy
+                      , subq_4.listing
+                      , subq_4.user
+                      , subq_4.listing__user
+                      , subq_4.country_latest
+                      , subq_4.is_lux_latest
+                      , subq_4.capacity_latest
+                      , subq_4.listing__country_latest
+                      , subq_4.listing__is_lux_latest
+                      , subq_4.listing__capacity_latest
+                      , subq_4.listings
+                      , subq_4.largest_listing
+                      , subq_4.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,257 +482,257 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_10
-                  ) subq_11
-                ) subq_12
+                    ) subq_4
+                  ) subq_5
+                ) subq_6
                 ON
-                  subq_9.listing = subq_12.listing
-              ) subq_13
-            ) subq_14
+                  subq_3.listing = subq_6.listing
+              ) subq_7
+            ) subq_8
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_15
-        ) subq_16
-      ) subq_17
-    ) subq_18
+          ) subq_9
+        ) subq_10
+      ) subq_11
+    ) subq_12
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_30.bookings
+        subq_24.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_29.bookings) AS bookings
+          SUM(subq_23.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_28.bookings
+            subq_22.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_27.booking__is_instant
-              , subq_27.listing__is_lux_latest
-              , subq_27.bookings
+              subq_21.booking__is_instant
+              , subq_21.listing__is_lux_latest
+              , subq_21.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_26.booking__is_instant
-                , subq_26.listing__is_lux_latest
-                , subq_26.bookings
+                subq_20.booking__is_instant
+                , subq_20.listing__is_lux_latest
+                , subq_20.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_22.listing AS listing
-                  , subq_22.booking__is_instant AS booking__is_instant
-                  , subq_25.is_lux_latest AS listing__is_lux_latest
-                  , subq_22.bookings AS bookings
+                  subq_16.listing AS listing
+                  , subq_16.booking__is_instant AS booking__is_instant
+                  , subq_19.is_lux_latest AS listing__is_lux_latest
+                  , subq_16.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_21.listing
-                    , subq_21.booking__is_instant
-                    , subq_21.bookings
+                    subq_15.listing
+                    , subq_15.booking__is_instant
+                    , subq_15.bookings
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_20.ds__day
-                      , subq_20.ds__week
-                      , subq_20.ds__month
-                      , subq_20.ds__quarter
-                      , subq_20.ds__year
-                      , subq_20.ds__extract_year
-                      , subq_20.ds__extract_quarter
-                      , subq_20.ds__extract_month
-                      , subq_20.ds__extract_day
-                      , subq_20.ds__extract_dow
-                      , subq_20.ds__extract_doy
-                      , subq_20.ds_partitioned__day
-                      , subq_20.ds_partitioned__week
-                      , subq_20.ds_partitioned__month
-                      , subq_20.ds_partitioned__quarter
-                      , subq_20.ds_partitioned__year
-                      , subq_20.ds_partitioned__extract_year
-                      , subq_20.ds_partitioned__extract_quarter
-                      , subq_20.ds_partitioned__extract_month
-                      , subq_20.ds_partitioned__extract_day
-                      , subq_20.ds_partitioned__extract_dow
-                      , subq_20.ds_partitioned__extract_doy
-                      , subq_20.paid_at__day
-                      , subq_20.paid_at__week
-                      , subq_20.paid_at__month
-                      , subq_20.paid_at__quarter
-                      , subq_20.paid_at__year
-                      , subq_20.paid_at__extract_year
-                      , subq_20.paid_at__extract_quarter
-                      , subq_20.paid_at__extract_month
-                      , subq_20.paid_at__extract_day
-                      , subq_20.paid_at__extract_dow
-                      , subq_20.paid_at__extract_doy
-                      , subq_20.booking__ds__day
-                      , subq_20.booking__ds__week
-                      , subq_20.booking__ds__month
-                      , subq_20.booking__ds__quarter
-                      , subq_20.booking__ds__year
-                      , subq_20.booking__ds__extract_year
-                      , subq_20.booking__ds__extract_quarter
-                      , subq_20.booking__ds__extract_month
-                      , subq_20.booking__ds__extract_day
-                      , subq_20.booking__ds__extract_dow
-                      , subq_20.booking__ds__extract_doy
-                      , subq_20.booking__ds_partitioned__day
-                      , subq_20.booking__ds_partitioned__week
-                      , subq_20.booking__ds_partitioned__month
-                      , subq_20.booking__ds_partitioned__quarter
-                      , subq_20.booking__ds_partitioned__year
-                      , subq_20.booking__ds_partitioned__extract_year
-                      , subq_20.booking__ds_partitioned__extract_quarter
-                      , subq_20.booking__ds_partitioned__extract_month
-                      , subq_20.booking__ds_partitioned__extract_day
-                      , subq_20.booking__ds_partitioned__extract_dow
-                      , subq_20.booking__ds_partitioned__extract_doy
-                      , subq_20.booking__paid_at__day
-                      , subq_20.booking__paid_at__week
-                      , subq_20.booking__paid_at__month
-                      , subq_20.booking__paid_at__quarter
-                      , subq_20.booking__paid_at__year
-                      , subq_20.booking__paid_at__extract_year
-                      , subq_20.booking__paid_at__extract_quarter
-                      , subq_20.booking__paid_at__extract_month
-                      , subq_20.booking__paid_at__extract_day
-                      , subq_20.booking__paid_at__extract_dow
-                      , subq_20.booking__paid_at__extract_doy
-                      , subq_20.metric_time__day
-                      , subq_20.metric_time__week
-                      , subq_20.metric_time__month
-                      , subq_20.metric_time__quarter
-                      , subq_20.metric_time__year
-                      , subq_20.metric_time__extract_year
-                      , subq_20.metric_time__extract_quarter
-                      , subq_20.metric_time__extract_month
-                      , subq_20.metric_time__extract_day
-                      , subq_20.metric_time__extract_dow
-                      , subq_20.metric_time__extract_doy
-                      , subq_20.listing
-                      , subq_20.guest
-                      , subq_20.host
-                      , subq_20.booking__listing
-                      , subq_20.booking__guest
-                      , subq_20.booking__host
-                      , subq_20.is_instant
-                      , subq_20.booking__is_instant
-                      , subq_20.bookings
-                      , subq_20.instant_bookings
-                      , subq_20.booking_value
-                      , subq_20.max_booking_value
-                      , subq_20.min_booking_value
-                      , subq_20.bookers
-                      , subq_20.average_booking_value
-                      , subq_20.referred_bookings
-                      , subq_20.median_booking_value
-                      , subq_20.booking_value_p99
-                      , subq_20.discrete_booking_value_p99
-                      , subq_20.approximate_continuous_booking_value_p99
-                      , subq_20.approximate_discrete_booking_value_p99
+                      subq_14.ds__day
+                      , subq_14.ds__week
+                      , subq_14.ds__month
+                      , subq_14.ds__quarter
+                      , subq_14.ds__year
+                      , subq_14.ds__extract_year
+                      , subq_14.ds__extract_quarter
+                      , subq_14.ds__extract_month
+                      , subq_14.ds__extract_day
+                      , subq_14.ds__extract_dow
+                      , subq_14.ds__extract_doy
+                      , subq_14.ds_partitioned__day
+                      , subq_14.ds_partitioned__week
+                      , subq_14.ds_partitioned__month
+                      , subq_14.ds_partitioned__quarter
+                      , subq_14.ds_partitioned__year
+                      , subq_14.ds_partitioned__extract_year
+                      , subq_14.ds_partitioned__extract_quarter
+                      , subq_14.ds_partitioned__extract_month
+                      , subq_14.ds_partitioned__extract_day
+                      , subq_14.ds_partitioned__extract_dow
+                      , subq_14.ds_partitioned__extract_doy
+                      , subq_14.paid_at__day
+                      , subq_14.paid_at__week
+                      , subq_14.paid_at__month
+                      , subq_14.paid_at__quarter
+                      , subq_14.paid_at__year
+                      , subq_14.paid_at__extract_year
+                      , subq_14.paid_at__extract_quarter
+                      , subq_14.paid_at__extract_month
+                      , subq_14.paid_at__extract_day
+                      , subq_14.paid_at__extract_dow
+                      , subq_14.paid_at__extract_doy
+                      , subq_14.booking__ds__day
+                      , subq_14.booking__ds__week
+                      , subq_14.booking__ds__month
+                      , subq_14.booking__ds__quarter
+                      , subq_14.booking__ds__year
+                      , subq_14.booking__ds__extract_year
+                      , subq_14.booking__ds__extract_quarter
+                      , subq_14.booking__ds__extract_month
+                      , subq_14.booking__ds__extract_day
+                      , subq_14.booking__ds__extract_dow
+                      , subq_14.booking__ds__extract_doy
+                      , subq_14.booking__ds_partitioned__day
+                      , subq_14.booking__ds_partitioned__week
+                      , subq_14.booking__ds_partitioned__month
+                      , subq_14.booking__ds_partitioned__quarter
+                      , subq_14.booking__ds_partitioned__year
+                      , subq_14.booking__ds_partitioned__extract_year
+                      , subq_14.booking__ds_partitioned__extract_quarter
+                      , subq_14.booking__ds_partitioned__extract_month
+                      , subq_14.booking__ds_partitioned__extract_day
+                      , subq_14.booking__ds_partitioned__extract_dow
+                      , subq_14.booking__ds_partitioned__extract_doy
+                      , subq_14.booking__paid_at__day
+                      , subq_14.booking__paid_at__week
+                      , subq_14.booking__paid_at__month
+                      , subq_14.booking__paid_at__quarter
+                      , subq_14.booking__paid_at__year
+                      , subq_14.booking__paid_at__extract_year
+                      , subq_14.booking__paid_at__extract_quarter
+                      , subq_14.booking__paid_at__extract_month
+                      , subq_14.booking__paid_at__extract_day
+                      , subq_14.booking__paid_at__extract_dow
+                      , subq_14.booking__paid_at__extract_doy
+                      , subq_14.metric_time__day
+                      , subq_14.metric_time__week
+                      , subq_14.metric_time__month
+                      , subq_14.metric_time__quarter
+                      , subq_14.metric_time__year
+                      , subq_14.metric_time__extract_year
+                      , subq_14.metric_time__extract_quarter
+                      , subq_14.metric_time__extract_month
+                      , subq_14.metric_time__extract_day
+                      , subq_14.metric_time__extract_dow
+                      , subq_14.metric_time__extract_doy
+                      , subq_14.listing
+                      , subq_14.guest
+                      , subq_14.host
+                      , subq_14.booking__listing
+                      , subq_14.booking__guest
+                      , subq_14.booking__host
+                      , subq_14.is_instant
+                      , subq_14.booking__is_instant
+                      , subq_14.bookings
+                      , subq_14.instant_bookings
+                      , subq_14.booking_value
+                      , subq_14.max_booking_value
+                      , subq_14.min_booking_value
+                      , subq_14.bookers
+                      , subq_14.average_booking_value
+                      , subq_14.referred_bookings
+                      , subq_14.median_booking_value
+                      , subq_14.booking_value_p99
+                      , subq_14.discrete_booking_value_p99
+                      , subq_14.approximate_continuous_booking_value_p99
+                      , subq_14.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_19.ds__day
-                        , subq_19.ds__week
-                        , subq_19.ds__month
-                        , subq_19.ds__quarter
-                        , subq_19.ds__year
-                        , subq_19.ds__extract_year
-                        , subq_19.ds__extract_quarter
-                        , subq_19.ds__extract_month
-                        , subq_19.ds__extract_day
-                        , subq_19.ds__extract_dow
-                        , subq_19.ds__extract_doy
-                        , subq_19.ds_partitioned__day
-                        , subq_19.ds_partitioned__week
-                        , subq_19.ds_partitioned__month
-                        , subq_19.ds_partitioned__quarter
-                        , subq_19.ds_partitioned__year
-                        , subq_19.ds_partitioned__extract_year
-                        , subq_19.ds_partitioned__extract_quarter
-                        , subq_19.ds_partitioned__extract_month
-                        , subq_19.ds_partitioned__extract_day
-                        , subq_19.ds_partitioned__extract_dow
-                        , subq_19.ds_partitioned__extract_doy
-                        , subq_19.paid_at__day
-                        , subq_19.paid_at__week
-                        , subq_19.paid_at__month
-                        , subq_19.paid_at__quarter
-                        , subq_19.paid_at__year
-                        , subq_19.paid_at__extract_year
-                        , subq_19.paid_at__extract_quarter
-                        , subq_19.paid_at__extract_month
-                        , subq_19.paid_at__extract_day
-                        , subq_19.paid_at__extract_dow
-                        , subq_19.paid_at__extract_doy
-                        , subq_19.booking__ds__day
-                        , subq_19.booking__ds__week
-                        , subq_19.booking__ds__month
-                        , subq_19.booking__ds__quarter
-                        , subq_19.booking__ds__year
-                        , subq_19.booking__ds__extract_year
-                        , subq_19.booking__ds__extract_quarter
-                        , subq_19.booking__ds__extract_month
-                        , subq_19.booking__ds__extract_day
-                        , subq_19.booking__ds__extract_dow
-                        , subq_19.booking__ds__extract_doy
-                        , subq_19.booking__ds_partitioned__day
-                        , subq_19.booking__ds_partitioned__week
-                        , subq_19.booking__ds_partitioned__month
-                        , subq_19.booking__ds_partitioned__quarter
-                        , subq_19.booking__ds_partitioned__year
-                        , subq_19.booking__ds_partitioned__extract_year
-                        , subq_19.booking__ds_partitioned__extract_quarter
-                        , subq_19.booking__ds_partitioned__extract_month
-                        , subq_19.booking__ds_partitioned__extract_day
-                        , subq_19.booking__ds_partitioned__extract_dow
-                        , subq_19.booking__ds_partitioned__extract_doy
-                        , subq_19.booking__paid_at__day
-                        , subq_19.booking__paid_at__week
-                        , subq_19.booking__paid_at__month
-                        , subq_19.booking__paid_at__quarter
-                        , subq_19.booking__paid_at__year
-                        , subq_19.booking__paid_at__extract_year
-                        , subq_19.booking__paid_at__extract_quarter
-                        , subq_19.booking__paid_at__extract_month
-                        , subq_19.booking__paid_at__extract_day
-                        , subq_19.booking__paid_at__extract_dow
-                        , subq_19.booking__paid_at__extract_doy
-                        , subq_19.ds__day AS metric_time__day
-                        , subq_19.ds__week AS metric_time__week
-                        , subq_19.ds__month AS metric_time__month
-                        , subq_19.ds__quarter AS metric_time__quarter
-                        , subq_19.ds__year AS metric_time__year
-                        , subq_19.ds__extract_year AS metric_time__extract_year
-                        , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_19.ds__extract_month AS metric_time__extract_month
-                        , subq_19.ds__extract_day AS metric_time__extract_day
-                        , subq_19.ds__extract_dow AS metric_time__extract_dow
-                        , subq_19.ds__extract_doy AS metric_time__extract_doy
-                        , subq_19.listing
-                        , subq_19.guest
-                        , subq_19.host
-                        , subq_19.booking__listing
-                        , subq_19.booking__guest
-                        , subq_19.booking__host
-                        , subq_19.is_instant
-                        , subq_19.booking__is_instant
-                        , subq_19.bookings
-                        , subq_19.instant_bookings
-                        , subq_19.booking_value
-                        , subq_19.max_booking_value
-                        , subq_19.min_booking_value
-                        , subq_19.bookers
-                        , subq_19.average_booking_value
-                        , subq_19.referred_bookings
-                        , subq_19.median_booking_value
-                        , subq_19.booking_value_p99
-                        , subq_19.discrete_booking_value_p99
-                        , subq_19.approximate_continuous_booking_value_p99
-                        , subq_19.approximate_discrete_booking_value_p99
+                        subq_13.ds__day
+                        , subq_13.ds__week
+                        , subq_13.ds__month
+                        , subq_13.ds__quarter
+                        , subq_13.ds__year
+                        , subq_13.ds__extract_year
+                        , subq_13.ds__extract_quarter
+                        , subq_13.ds__extract_month
+                        , subq_13.ds__extract_day
+                        , subq_13.ds__extract_dow
+                        , subq_13.ds__extract_doy
+                        , subq_13.ds_partitioned__day
+                        , subq_13.ds_partitioned__week
+                        , subq_13.ds_partitioned__month
+                        , subq_13.ds_partitioned__quarter
+                        , subq_13.ds_partitioned__year
+                        , subq_13.ds_partitioned__extract_year
+                        , subq_13.ds_partitioned__extract_quarter
+                        , subq_13.ds_partitioned__extract_month
+                        , subq_13.ds_partitioned__extract_day
+                        , subq_13.ds_partitioned__extract_dow
+                        , subq_13.ds_partitioned__extract_doy
+                        , subq_13.paid_at__day
+                        , subq_13.paid_at__week
+                        , subq_13.paid_at__month
+                        , subq_13.paid_at__quarter
+                        , subq_13.paid_at__year
+                        , subq_13.paid_at__extract_year
+                        , subq_13.paid_at__extract_quarter
+                        , subq_13.paid_at__extract_month
+                        , subq_13.paid_at__extract_day
+                        , subq_13.paid_at__extract_dow
+                        , subq_13.paid_at__extract_doy
+                        , subq_13.booking__ds__day
+                        , subq_13.booking__ds__week
+                        , subq_13.booking__ds__month
+                        , subq_13.booking__ds__quarter
+                        , subq_13.booking__ds__year
+                        , subq_13.booking__ds__extract_year
+                        , subq_13.booking__ds__extract_quarter
+                        , subq_13.booking__ds__extract_month
+                        , subq_13.booking__ds__extract_day
+                        , subq_13.booking__ds__extract_dow
+                        , subq_13.booking__ds__extract_doy
+                        , subq_13.booking__ds_partitioned__day
+                        , subq_13.booking__ds_partitioned__week
+                        , subq_13.booking__ds_partitioned__month
+                        , subq_13.booking__ds_partitioned__quarter
+                        , subq_13.booking__ds_partitioned__year
+                        , subq_13.booking__ds_partitioned__extract_year
+                        , subq_13.booking__ds_partitioned__extract_quarter
+                        , subq_13.booking__ds_partitioned__extract_month
+                        , subq_13.booking__ds_partitioned__extract_day
+                        , subq_13.booking__ds_partitioned__extract_dow
+                        , subq_13.booking__ds_partitioned__extract_doy
+                        , subq_13.booking__paid_at__day
+                        , subq_13.booking__paid_at__week
+                        , subq_13.booking__paid_at__month
+                        , subq_13.booking__paid_at__quarter
+                        , subq_13.booking__paid_at__year
+                        , subq_13.booking__paid_at__extract_year
+                        , subq_13.booking__paid_at__extract_quarter
+                        , subq_13.booking__paid_at__extract_month
+                        , subq_13.booking__paid_at__extract_day
+                        , subq_13.booking__paid_at__extract_dow
+                        , subq_13.booking__paid_at__extract_doy
+                        , subq_13.ds__day AS metric_time__day
+                        , subq_13.ds__week AS metric_time__week
+                        , subq_13.ds__month AS metric_time__month
+                        , subq_13.ds__quarter AS metric_time__quarter
+                        , subq_13.ds__year AS metric_time__year
+                        , subq_13.ds__extract_year AS metric_time__extract_year
+                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_13.ds__extract_month AS metric_time__extract_month
+                        , subq_13.ds__extract_day AS metric_time__extract_day
+                        , subq_13.ds__extract_dow AS metric_time__extract_dow
+                        , subq_13.ds__extract_doy AS metric_time__extract_doy
+                        , subq_13.listing
+                        , subq_13.guest
+                        , subq_13.host
+                        , subq_13.booking__listing
+                        , subq_13.booking__guest
+                        , subq_13.booking__host
+                        , subq_13.is_instant
+                        , subq_13.booking__is_instant
+                        , subq_13.bookings
+                        , subq_13.instant_bookings
+                        , subq_13.booking_value
+                        , subq_13.max_booking_value
+                        , subq_13.min_booking_value
+                        , subq_13.bookers
+                        , subq_13.average_booking_value
+                        , subq_13.referred_bookings
+                        , subq_13.median_booking_value
+                        , subq_13.booking_value_p99
+                        , subq_13.discrete_booking_value_p99
+                        , subq_13.approximate_continuous_booking_value_p99
+                        , subq_13.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -825,86 +825,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_19
-                    ) subq_20
+                      ) subq_13
+                    ) subq_14
                     WHERE booking__is_instant
-                  ) subq_21
-                ) subq_22
+                  ) subq_15
+                ) subq_16
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_24.listing
-                    , subq_24.is_lux_latest
+                    subq_18.listing
+                    , subq_18.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_23.ds__day
-                      , subq_23.ds__week
-                      , subq_23.ds__month
-                      , subq_23.ds__quarter
-                      , subq_23.ds__year
-                      , subq_23.ds__extract_year
-                      , subq_23.ds__extract_quarter
-                      , subq_23.ds__extract_month
-                      , subq_23.ds__extract_day
-                      , subq_23.ds__extract_dow
-                      , subq_23.ds__extract_doy
-                      , subq_23.created_at__day
-                      , subq_23.created_at__week
-                      , subq_23.created_at__month
-                      , subq_23.created_at__quarter
-                      , subq_23.created_at__year
-                      , subq_23.created_at__extract_year
-                      , subq_23.created_at__extract_quarter
-                      , subq_23.created_at__extract_month
-                      , subq_23.created_at__extract_day
-                      , subq_23.created_at__extract_dow
-                      , subq_23.created_at__extract_doy
-                      , subq_23.listing__ds__day
-                      , subq_23.listing__ds__week
-                      , subq_23.listing__ds__month
-                      , subq_23.listing__ds__quarter
-                      , subq_23.listing__ds__year
-                      , subq_23.listing__ds__extract_year
-                      , subq_23.listing__ds__extract_quarter
-                      , subq_23.listing__ds__extract_month
-                      , subq_23.listing__ds__extract_day
-                      , subq_23.listing__ds__extract_dow
-                      , subq_23.listing__ds__extract_doy
-                      , subq_23.listing__created_at__day
-                      , subq_23.listing__created_at__week
-                      , subq_23.listing__created_at__month
-                      , subq_23.listing__created_at__quarter
-                      , subq_23.listing__created_at__year
-                      , subq_23.listing__created_at__extract_year
-                      , subq_23.listing__created_at__extract_quarter
-                      , subq_23.listing__created_at__extract_month
-                      , subq_23.listing__created_at__extract_day
-                      , subq_23.listing__created_at__extract_dow
-                      , subq_23.listing__created_at__extract_doy
-                      , subq_23.ds__day AS metric_time__day
-                      , subq_23.ds__week AS metric_time__week
-                      , subq_23.ds__month AS metric_time__month
-                      , subq_23.ds__quarter AS metric_time__quarter
-                      , subq_23.ds__year AS metric_time__year
-                      , subq_23.ds__extract_year AS metric_time__extract_year
-                      , subq_23.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_23.ds__extract_month AS metric_time__extract_month
-                      , subq_23.ds__extract_day AS metric_time__extract_day
-                      , subq_23.ds__extract_dow AS metric_time__extract_dow
-                      , subq_23.ds__extract_doy AS metric_time__extract_doy
-                      , subq_23.listing
-                      , subq_23.user
-                      , subq_23.listing__user
-                      , subq_23.country_latest
-                      , subq_23.is_lux_latest
-                      , subq_23.capacity_latest
-                      , subq_23.listing__country_latest
-                      , subq_23.listing__is_lux_latest
-                      , subq_23.listing__capacity_latest
-                      , subq_23.listings
-                      , subq_23.largest_listing
-                      , subq_23.smallest_listing
+                      subq_17.ds__day
+                      , subq_17.ds__week
+                      , subq_17.ds__month
+                      , subq_17.ds__quarter
+                      , subq_17.ds__year
+                      , subq_17.ds__extract_year
+                      , subq_17.ds__extract_quarter
+                      , subq_17.ds__extract_month
+                      , subq_17.ds__extract_day
+                      , subq_17.ds__extract_dow
+                      , subq_17.ds__extract_doy
+                      , subq_17.created_at__day
+                      , subq_17.created_at__week
+                      , subq_17.created_at__month
+                      , subq_17.created_at__quarter
+                      , subq_17.created_at__year
+                      , subq_17.created_at__extract_year
+                      , subq_17.created_at__extract_quarter
+                      , subq_17.created_at__extract_month
+                      , subq_17.created_at__extract_day
+                      , subq_17.created_at__extract_dow
+                      , subq_17.created_at__extract_doy
+                      , subq_17.listing__ds__day
+                      , subq_17.listing__ds__week
+                      , subq_17.listing__ds__month
+                      , subq_17.listing__ds__quarter
+                      , subq_17.listing__ds__year
+                      , subq_17.listing__ds__extract_year
+                      , subq_17.listing__ds__extract_quarter
+                      , subq_17.listing__ds__extract_month
+                      , subq_17.listing__ds__extract_day
+                      , subq_17.listing__ds__extract_dow
+                      , subq_17.listing__ds__extract_doy
+                      , subq_17.listing__created_at__day
+                      , subq_17.listing__created_at__week
+                      , subq_17.listing__created_at__month
+                      , subq_17.listing__created_at__quarter
+                      , subq_17.listing__created_at__year
+                      , subq_17.listing__created_at__extract_year
+                      , subq_17.listing__created_at__extract_quarter
+                      , subq_17.listing__created_at__extract_month
+                      , subq_17.listing__created_at__extract_day
+                      , subq_17.listing__created_at__extract_dow
+                      , subq_17.listing__created_at__extract_doy
+                      , subq_17.ds__day AS metric_time__day
+                      , subq_17.ds__week AS metric_time__week
+                      , subq_17.ds__month AS metric_time__month
+                      , subq_17.ds__quarter AS metric_time__quarter
+                      , subq_17.ds__year AS metric_time__year
+                      , subq_17.ds__extract_year AS metric_time__extract_year
+                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_17.ds__extract_month AS metric_time__extract_month
+                      , subq_17.ds__extract_day AS metric_time__extract_day
+                      , subq_17.ds__extract_dow AS metric_time__extract_dow
+                      , subq_17.ds__extract_doy AS metric_time__extract_doy
+                      , subq_17.listing
+                      , subq_17.user
+                      , subq_17.listing__user
+                      , subq_17.country_latest
+                      , subq_17.is_lux_latest
+                      , subq_17.capacity_latest
+                      , subq_17.listing__country_latest
+                      , subq_17.listing__is_lux_latest
+                      , subq_17.listing__capacity_latest
+                      , subq_17.listings
+                      , subq_17.largest_listing
+                      , subq_17.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,242 +965,242 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_23
-                  ) subq_24
-                ) subq_25
+                    ) subq_17
+                  ) subq_18
+                ) subq_19
                 ON
-                  subq_22.listing = subq_25.listing
-              ) subq_26
-            ) subq_27
+                  subq_16.listing = subq_19.listing
+              ) subq_20
+            ) subq_21
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_28
-        ) subq_29
-      ) subq_30
-    ) subq_31
+          ) subq_22
+        ) subq_23
+      ) subq_24
+    ) subq_25
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_38.booking_value
+        subq_32.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_37.booking_value) AS booking_value
+          SUM(subq_31.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_36.booking_value
+            subq_30.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_35.booking__is_instant
-              , subq_35.booking_value
+              subq_29.booking__is_instant
+              , subq_29.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_34.booking__is_instant
-                , subq_34.booking_value
+                subq_28.booking__is_instant
+                , subq_28.booking_value
               FROM (
                 -- Constrain Output with WHERE
                 SELECT
-                  subq_33.ds__day
-                  , subq_33.ds__week
-                  , subq_33.ds__month
-                  , subq_33.ds__quarter
-                  , subq_33.ds__year
-                  , subq_33.ds__extract_year
-                  , subq_33.ds__extract_quarter
-                  , subq_33.ds__extract_month
-                  , subq_33.ds__extract_day
-                  , subq_33.ds__extract_dow
-                  , subq_33.ds__extract_doy
-                  , subq_33.ds_partitioned__day
-                  , subq_33.ds_partitioned__week
-                  , subq_33.ds_partitioned__month
-                  , subq_33.ds_partitioned__quarter
-                  , subq_33.ds_partitioned__year
-                  , subq_33.ds_partitioned__extract_year
-                  , subq_33.ds_partitioned__extract_quarter
-                  , subq_33.ds_partitioned__extract_month
-                  , subq_33.ds_partitioned__extract_day
-                  , subq_33.ds_partitioned__extract_dow
-                  , subq_33.ds_partitioned__extract_doy
-                  , subq_33.paid_at__day
-                  , subq_33.paid_at__week
-                  , subq_33.paid_at__month
-                  , subq_33.paid_at__quarter
-                  , subq_33.paid_at__year
-                  , subq_33.paid_at__extract_year
-                  , subq_33.paid_at__extract_quarter
-                  , subq_33.paid_at__extract_month
-                  , subq_33.paid_at__extract_day
-                  , subq_33.paid_at__extract_dow
-                  , subq_33.paid_at__extract_doy
-                  , subq_33.booking__ds__day
-                  , subq_33.booking__ds__week
-                  , subq_33.booking__ds__month
-                  , subq_33.booking__ds__quarter
-                  , subq_33.booking__ds__year
-                  , subq_33.booking__ds__extract_year
-                  , subq_33.booking__ds__extract_quarter
-                  , subq_33.booking__ds__extract_month
-                  , subq_33.booking__ds__extract_day
-                  , subq_33.booking__ds__extract_dow
-                  , subq_33.booking__ds__extract_doy
-                  , subq_33.booking__ds_partitioned__day
-                  , subq_33.booking__ds_partitioned__week
-                  , subq_33.booking__ds_partitioned__month
-                  , subq_33.booking__ds_partitioned__quarter
-                  , subq_33.booking__ds_partitioned__year
-                  , subq_33.booking__ds_partitioned__extract_year
-                  , subq_33.booking__ds_partitioned__extract_quarter
-                  , subq_33.booking__ds_partitioned__extract_month
-                  , subq_33.booking__ds_partitioned__extract_day
-                  , subq_33.booking__ds_partitioned__extract_dow
-                  , subq_33.booking__ds_partitioned__extract_doy
-                  , subq_33.booking__paid_at__day
-                  , subq_33.booking__paid_at__week
-                  , subq_33.booking__paid_at__month
-                  , subq_33.booking__paid_at__quarter
-                  , subq_33.booking__paid_at__year
-                  , subq_33.booking__paid_at__extract_year
-                  , subq_33.booking__paid_at__extract_quarter
-                  , subq_33.booking__paid_at__extract_month
-                  , subq_33.booking__paid_at__extract_day
-                  , subq_33.booking__paid_at__extract_dow
-                  , subq_33.booking__paid_at__extract_doy
-                  , subq_33.metric_time__day
-                  , subq_33.metric_time__week
-                  , subq_33.metric_time__month
-                  , subq_33.metric_time__quarter
-                  , subq_33.metric_time__year
-                  , subq_33.metric_time__extract_year
-                  , subq_33.metric_time__extract_quarter
-                  , subq_33.metric_time__extract_month
-                  , subq_33.metric_time__extract_day
-                  , subq_33.metric_time__extract_dow
-                  , subq_33.metric_time__extract_doy
-                  , subq_33.listing
-                  , subq_33.guest
-                  , subq_33.host
-                  , subq_33.booking__listing
-                  , subq_33.booking__guest
-                  , subq_33.booking__host
-                  , subq_33.is_instant
-                  , subq_33.booking__is_instant
-                  , subq_33.bookings
-                  , subq_33.instant_bookings
-                  , subq_33.booking_value
-                  , subq_33.max_booking_value
-                  , subq_33.min_booking_value
-                  , subq_33.bookers
-                  , subq_33.average_booking_value
-                  , subq_33.referred_bookings
-                  , subq_33.median_booking_value
-                  , subq_33.booking_value_p99
-                  , subq_33.discrete_booking_value_p99
-                  , subq_33.approximate_continuous_booking_value_p99
-                  , subq_33.approximate_discrete_booking_value_p99
+                  subq_27.ds__day
+                  , subq_27.ds__week
+                  , subq_27.ds__month
+                  , subq_27.ds__quarter
+                  , subq_27.ds__year
+                  , subq_27.ds__extract_year
+                  , subq_27.ds__extract_quarter
+                  , subq_27.ds__extract_month
+                  , subq_27.ds__extract_day
+                  , subq_27.ds__extract_dow
+                  , subq_27.ds__extract_doy
+                  , subq_27.ds_partitioned__day
+                  , subq_27.ds_partitioned__week
+                  , subq_27.ds_partitioned__month
+                  , subq_27.ds_partitioned__quarter
+                  , subq_27.ds_partitioned__year
+                  , subq_27.ds_partitioned__extract_year
+                  , subq_27.ds_partitioned__extract_quarter
+                  , subq_27.ds_partitioned__extract_month
+                  , subq_27.ds_partitioned__extract_day
+                  , subq_27.ds_partitioned__extract_dow
+                  , subq_27.ds_partitioned__extract_doy
+                  , subq_27.paid_at__day
+                  , subq_27.paid_at__week
+                  , subq_27.paid_at__month
+                  , subq_27.paid_at__quarter
+                  , subq_27.paid_at__year
+                  , subq_27.paid_at__extract_year
+                  , subq_27.paid_at__extract_quarter
+                  , subq_27.paid_at__extract_month
+                  , subq_27.paid_at__extract_day
+                  , subq_27.paid_at__extract_dow
+                  , subq_27.paid_at__extract_doy
+                  , subq_27.booking__ds__day
+                  , subq_27.booking__ds__week
+                  , subq_27.booking__ds__month
+                  , subq_27.booking__ds__quarter
+                  , subq_27.booking__ds__year
+                  , subq_27.booking__ds__extract_year
+                  , subq_27.booking__ds__extract_quarter
+                  , subq_27.booking__ds__extract_month
+                  , subq_27.booking__ds__extract_day
+                  , subq_27.booking__ds__extract_dow
+                  , subq_27.booking__ds__extract_doy
+                  , subq_27.booking__ds_partitioned__day
+                  , subq_27.booking__ds_partitioned__week
+                  , subq_27.booking__ds_partitioned__month
+                  , subq_27.booking__ds_partitioned__quarter
+                  , subq_27.booking__ds_partitioned__year
+                  , subq_27.booking__ds_partitioned__extract_year
+                  , subq_27.booking__ds_partitioned__extract_quarter
+                  , subq_27.booking__ds_partitioned__extract_month
+                  , subq_27.booking__ds_partitioned__extract_day
+                  , subq_27.booking__ds_partitioned__extract_dow
+                  , subq_27.booking__ds_partitioned__extract_doy
+                  , subq_27.booking__paid_at__day
+                  , subq_27.booking__paid_at__week
+                  , subq_27.booking__paid_at__month
+                  , subq_27.booking__paid_at__quarter
+                  , subq_27.booking__paid_at__year
+                  , subq_27.booking__paid_at__extract_year
+                  , subq_27.booking__paid_at__extract_quarter
+                  , subq_27.booking__paid_at__extract_month
+                  , subq_27.booking__paid_at__extract_day
+                  , subq_27.booking__paid_at__extract_dow
+                  , subq_27.booking__paid_at__extract_doy
+                  , subq_27.metric_time__day
+                  , subq_27.metric_time__week
+                  , subq_27.metric_time__month
+                  , subq_27.metric_time__quarter
+                  , subq_27.metric_time__year
+                  , subq_27.metric_time__extract_year
+                  , subq_27.metric_time__extract_quarter
+                  , subq_27.metric_time__extract_month
+                  , subq_27.metric_time__extract_day
+                  , subq_27.metric_time__extract_dow
+                  , subq_27.metric_time__extract_doy
+                  , subq_27.listing
+                  , subq_27.guest
+                  , subq_27.host
+                  , subq_27.booking__listing
+                  , subq_27.booking__guest
+                  , subq_27.booking__host
+                  , subq_27.is_instant
+                  , subq_27.booking__is_instant
+                  , subq_27.bookings
+                  , subq_27.instant_bookings
+                  , subq_27.booking_value
+                  , subq_27.max_booking_value
+                  , subq_27.min_booking_value
+                  , subq_27.bookers
+                  , subq_27.average_booking_value
+                  , subq_27.referred_bookings
+                  , subq_27.median_booking_value
+                  , subq_27.booking_value_p99
+                  , subq_27.discrete_booking_value_p99
+                  , subq_27.approximate_continuous_booking_value_p99
+                  , subq_27.approximate_discrete_booking_value_p99
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_32.ds__day
-                    , subq_32.ds__week
-                    , subq_32.ds__month
-                    , subq_32.ds__quarter
-                    , subq_32.ds__year
-                    , subq_32.ds__extract_year
-                    , subq_32.ds__extract_quarter
-                    , subq_32.ds__extract_month
-                    , subq_32.ds__extract_day
-                    , subq_32.ds__extract_dow
-                    , subq_32.ds__extract_doy
-                    , subq_32.ds_partitioned__day
-                    , subq_32.ds_partitioned__week
-                    , subq_32.ds_partitioned__month
-                    , subq_32.ds_partitioned__quarter
-                    , subq_32.ds_partitioned__year
-                    , subq_32.ds_partitioned__extract_year
-                    , subq_32.ds_partitioned__extract_quarter
-                    , subq_32.ds_partitioned__extract_month
-                    , subq_32.ds_partitioned__extract_day
-                    , subq_32.ds_partitioned__extract_dow
-                    , subq_32.ds_partitioned__extract_doy
-                    , subq_32.paid_at__day
-                    , subq_32.paid_at__week
-                    , subq_32.paid_at__month
-                    , subq_32.paid_at__quarter
-                    , subq_32.paid_at__year
-                    , subq_32.paid_at__extract_year
-                    , subq_32.paid_at__extract_quarter
-                    , subq_32.paid_at__extract_month
-                    , subq_32.paid_at__extract_day
-                    , subq_32.paid_at__extract_dow
-                    , subq_32.paid_at__extract_doy
-                    , subq_32.booking__ds__day
-                    , subq_32.booking__ds__week
-                    , subq_32.booking__ds__month
-                    , subq_32.booking__ds__quarter
-                    , subq_32.booking__ds__year
-                    , subq_32.booking__ds__extract_year
-                    , subq_32.booking__ds__extract_quarter
-                    , subq_32.booking__ds__extract_month
-                    , subq_32.booking__ds__extract_day
-                    , subq_32.booking__ds__extract_dow
-                    , subq_32.booking__ds__extract_doy
-                    , subq_32.booking__ds_partitioned__day
-                    , subq_32.booking__ds_partitioned__week
-                    , subq_32.booking__ds_partitioned__month
-                    , subq_32.booking__ds_partitioned__quarter
-                    , subq_32.booking__ds_partitioned__year
-                    , subq_32.booking__ds_partitioned__extract_year
-                    , subq_32.booking__ds_partitioned__extract_quarter
-                    , subq_32.booking__ds_partitioned__extract_month
-                    , subq_32.booking__ds_partitioned__extract_day
-                    , subq_32.booking__ds_partitioned__extract_dow
-                    , subq_32.booking__ds_partitioned__extract_doy
-                    , subq_32.booking__paid_at__day
-                    , subq_32.booking__paid_at__week
-                    , subq_32.booking__paid_at__month
-                    , subq_32.booking__paid_at__quarter
-                    , subq_32.booking__paid_at__year
-                    , subq_32.booking__paid_at__extract_year
-                    , subq_32.booking__paid_at__extract_quarter
-                    , subq_32.booking__paid_at__extract_month
-                    , subq_32.booking__paid_at__extract_day
-                    , subq_32.booking__paid_at__extract_dow
-                    , subq_32.booking__paid_at__extract_doy
-                    , subq_32.ds__day AS metric_time__day
-                    , subq_32.ds__week AS metric_time__week
-                    , subq_32.ds__month AS metric_time__month
-                    , subq_32.ds__quarter AS metric_time__quarter
-                    , subq_32.ds__year AS metric_time__year
-                    , subq_32.ds__extract_year AS metric_time__extract_year
-                    , subq_32.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_32.ds__extract_month AS metric_time__extract_month
-                    , subq_32.ds__extract_day AS metric_time__extract_day
-                    , subq_32.ds__extract_dow AS metric_time__extract_dow
-                    , subq_32.ds__extract_doy AS metric_time__extract_doy
-                    , subq_32.listing
-                    , subq_32.guest
-                    , subq_32.host
-                    , subq_32.booking__listing
-                    , subq_32.booking__guest
-                    , subq_32.booking__host
-                    , subq_32.is_instant
-                    , subq_32.booking__is_instant
-                    , subq_32.bookings
-                    , subq_32.instant_bookings
-                    , subq_32.booking_value
-                    , subq_32.max_booking_value
-                    , subq_32.min_booking_value
-                    , subq_32.bookers
-                    , subq_32.average_booking_value
-                    , subq_32.referred_bookings
-                    , subq_32.median_booking_value
-                    , subq_32.booking_value_p99
-                    , subq_32.discrete_booking_value_p99
-                    , subq_32.approximate_continuous_booking_value_p99
-                    , subq_32.approximate_discrete_booking_value_p99
+                    subq_26.ds__day
+                    , subq_26.ds__week
+                    , subq_26.ds__month
+                    , subq_26.ds__quarter
+                    , subq_26.ds__year
+                    , subq_26.ds__extract_year
+                    , subq_26.ds__extract_quarter
+                    , subq_26.ds__extract_month
+                    , subq_26.ds__extract_day
+                    , subq_26.ds__extract_dow
+                    , subq_26.ds__extract_doy
+                    , subq_26.ds_partitioned__day
+                    , subq_26.ds_partitioned__week
+                    , subq_26.ds_partitioned__month
+                    , subq_26.ds_partitioned__quarter
+                    , subq_26.ds_partitioned__year
+                    , subq_26.ds_partitioned__extract_year
+                    , subq_26.ds_partitioned__extract_quarter
+                    , subq_26.ds_partitioned__extract_month
+                    , subq_26.ds_partitioned__extract_day
+                    , subq_26.ds_partitioned__extract_dow
+                    , subq_26.ds_partitioned__extract_doy
+                    , subq_26.paid_at__day
+                    , subq_26.paid_at__week
+                    , subq_26.paid_at__month
+                    , subq_26.paid_at__quarter
+                    , subq_26.paid_at__year
+                    , subq_26.paid_at__extract_year
+                    , subq_26.paid_at__extract_quarter
+                    , subq_26.paid_at__extract_month
+                    , subq_26.paid_at__extract_day
+                    , subq_26.paid_at__extract_dow
+                    , subq_26.paid_at__extract_doy
+                    , subq_26.booking__ds__day
+                    , subq_26.booking__ds__week
+                    , subq_26.booking__ds__month
+                    , subq_26.booking__ds__quarter
+                    , subq_26.booking__ds__year
+                    , subq_26.booking__ds__extract_year
+                    , subq_26.booking__ds__extract_quarter
+                    , subq_26.booking__ds__extract_month
+                    , subq_26.booking__ds__extract_day
+                    , subq_26.booking__ds__extract_dow
+                    , subq_26.booking__ds__extract_doy
+                    , subq_26.booking__ds_partitioned__day
+                    , subq_26.booking__ds_partitioned__week
+                    , subq_26.booking__ds_partitioned__month
+                    , subq_26.booking__ds_partitioned__quarter
+                    , subq_26.booking__ds_partitioned__year
+                    , subq_26.booking__ds_partitioned__extract_year
+                    , subq_26.booking__ds_partitioned__extract_quarter
+                    , subq_26.booking__ds_partitioned__extract_month
+                    , subq_26.booking__ds_partitioned__extract_day
+                    , subq_26.booking__ds_partitioned__extract_dow
+                    , subq_26.booking__ds_partitioned__extract_doy
+                    , subq_26.booking__paid_at__day
+                    , subq_26.booking__paid_at__week
+                    , subq_26.booking__paid_at__month
+                    , subq_26.booking__paid_at__quarter
+                    , subq_26.booking__paid_at__year
+                    , subq_26.booking__paid_at__extract_year
+                    , subq_26.booking__paid_at__extract_quarter
+                    , subq_26.booking__paid_at__extract_month
+                    , subq_26.booking__paid_at__extract_day
+                    , subq_26.booking__paid_at__extract_dow
+                    , subq_26.booking__paid_at__extract_doy
+                    , subq_26.ds__day AS metric_time__day
+                    , subq_26.ds__week AS metric_time__week
+                    , subq_26.ds__month AS metric_time__month
+                    , subq_26.ds__quarter AS metric_time__quarter
+                    , subq_26.ds__year AS metric_time__year
+                    , subq_26.ds__extract_year AS metric_time__extract_year
+                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_26.ds__extract_month AS metric_time__extract_month
+                    , subq_26.ds__extract_day AS metric_time__extract_day
+                    , subq_26.ds__extract_dow AS metric_time__extract_dow
+                    , subq_26.ds__extract_doy AS metric_time__extract_doy
+                    , subq_26.listing
+                    , subq_26.guest
+                    , subq_26.host
+                    , subq_26.booking__listing
+                    , subq_26.booking__guest
+                    , subq_26.booking__host
+                    , subq_26.is_instant
+                    , subq_26.booking__is_instant
+                    , subq_26.bookings
+                    , subq_26.instant_bookings
+                    , subq_26.booking_value
+                    , subq_26.max_booking_value
+                    , subq_26.min_booking_value
+                    , subq_26.bookers
+                    , subq_26.average_booking_value
+                    , subq_26.referred_bookings
+                    , subq_26.median_booking_value
+                    , subq_26.booking_value_p99
+                    , subq_26.discrete_booking_value_p99
+                    , subq_26.approximate_continuous_booking_value_p99
+                    , subq_26.approximate_discrete_booking_value_p99
                   FROM (
                     -- Read Elements From Semantic Model 'bookings_source'
                     SELECT
@@ -1293,15 +1293,15 @@ FROM (
                       , bookings_source_src_28000.guest_id AS booking__guest
                       , bookings_source_src_28000.host_id AS booking__host
                     FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_32
-                ) subq_33
+                  ) subq_26
+                ) subq_27
                 WHERE booking__is_instant
-              ) subq_34
-            ) subq_35
+              ) subq_28
+            ) subq_29
             WHERE booking__is_instant
-          ) subq_36
-        ) subq_37
-      ) subq_38
-    ) subq_39
-  ) subq_40
-) subq_41
+          ) subq_30
+        ) subq_31
+      ) subq_32
+    ) subq_33
+  ) subq_34
+) subq_35

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_60.average_booking_value) AS average_booking_value
-      , MAX(subq_73.bookings) AS bookings
-      , MAX(subq_81.booking_value) AS booking_value
+      MAX(subq_48.average_booking_value) AS average_booking_value
+      , MAX(subq_61.bookings) AS bookings
+      , MAX(subq_69.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_51.booking__is_instant AS booking__is_instant
+          subq_39.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_51.average_booking_value AS average_booking_value
+          , subq_39.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_49
+          ) subq_37
           WHERE booking__is_instant
-        ) subq_51
+        ) subq_39
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_51.listing = listings_latest_src_28000.listing_id
-      ) subq_56
+          subq_39.listing = listings_latest_src_28000.listing_id
+      ) subq_44
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_60
+    ) subq_48
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_64.booking__is_instant AS booking__is_instant
+          subq_52.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_64.bookings AS bookings
+          , subq_52.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_62
+          ) subq_50
           WHERE booking__is_instant
-        ) subq_64
+        ) subq_52
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_64.listing = listings_latest_src_28000.listing_id
-      ) subq_69
+          subq_52.listing = listings_latest_src_28000.listing_id
+      ) subq_57
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_73
+    ) subq_61
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_75
+        ) subq_63
         WHERE booking__is_instant
-      ) subq_77
+      ) subq_65
       WHERE booking__is_instant
-    ) subq_81
-  ) subq_82
-) subq_83
+    ) subq_69
+  ) subq_70
+) subq_71

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0.sql
@@ -8,248 +8,248 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_18.average_booking_value) AS average_booking_value
-      , MAX(subq_31.bookings) AS bookings
-      , MAX(subq_39.booking_value) AS booking_value
+      MAX(subq_12.average_booking_value) AS average_booking_value
+      , MAX(subq_25.bookings) AS bookings
+      , MAX(subq_33.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.average_booking_value
+        subq_11.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_16.average_booking_value) AS average_booking_value
+          AVG(subq_10.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_15.average_booking_value
+            subq_9.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.booking__is_instant
-              , subq_14.listing__is_lux_latest
-              , subq_14.average_booking_value
+              subq_8.booking__is_instant
+              , subq_8.listing__is_lux_latest
+              , subq_8.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_13.booking__is_instant
-                , subq_13.listing__is_lux_latest
-                , subq_13.average_booking_value
+                subq_7.booking__is_instant
+                , subq_7.listing__is_lux_latest
+                , subq_7.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_9.listing AS listing
-                  , subq_9.booking__is_instant AS booking__is_instant
-                  , subq_12.is_lux_latest AS listing__is_lux_latest
-                  , subq_9.average_booking_value AS average_booking_value
+                  subq_3.listing AS listing
+                  , subq_3.booking__is_instant AS booking__is_instant
+                  , subq_6.is_lux_latest AS listing__is_lux_latest
+                  , subq_3.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.booking__is_instant
-                    , subq_8.average_booking_value
+                    subq_2.listing
+                    , subq_2.booking__is_instant
+                    , subq_2.average_booking_value
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.metric_time__day
-                      , subq_7.metric_time__week
-                      , subq_7.metric_time__month
-                      , subq_7.metric_time__quarter
-                      , subq_7.metric_time__year
-                      , subq_7.metric_time__extract_year
-                      , subq_7.metric_time__extract_quarter
-                      , subq_7.metric_time__extract_month
-                      , subq_7.metric_time__extract_day
-                      , subq_7.metric_time__extract_dow
-                      , subq_7.metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_1.ds__day
+                      , subq_1.ds__week
+                      , subq_1.ds__month
+                      , subq_1.ds__quarter
+                      , subq_1.ds__year
+                      , subq_1.ds__extract_year
+                      , subq_1.ds__extract_quarter
+                      , subq_1.ds__extract_month
+                      , subq_1.ds__extract_day
+                      , subq_1.ds__extract_dow
+                      , subq_1.ds__extract_doy
+                      , subq_1.ds_partitioned__day
+                      , subq_1.ds_partitioned__week
+                      , subq_1.ds_partitioned__month
+                      , subq_1.ds_partitioned__quarter
+                      , subq_1.ds_partitioned__year
+                      , subq_1.ds_partitioned__extract_year
+                      , subq_1.ds_partitioned__extract_quarter
+                      , subq_1.ds_partitioned__extract_month
+                      , subq_1.ds_partitioned__extract_day
+                      , subq_1.ds_partitioned__extract_dow
+                      , subq_1.ds_partitioned__extract_doy
+                      , subq_1.paid_at__day
+                      , subq_1.paid_at__week
+                      , subq_1.paid_at__month
+                      , subq_1.paid_at__quarter
+                      , subq_1.paid_at__year
+                      , subq_1.paid_at__extract_year
+                      , subq_1.paid_at__extract_quarter
+                      , subq_1.paid_at__extract_month
+                      , subq_1.paid_at__extract_day
+                      , subq_1.paid_at__extract_dow
+                      , subq_1.paid_at__extract_doy
+                      , subq_1.booking__ds__day
+                      , subq_1.booking__ds__week
+                      , subq_1.booking__ds__month
+                      , subq_1.booking__ds__quarter
+                      , subq_1.booking__ds__year
+                      , subq_1.booking__ds__extract_year
+                      , subq_1.booking__ds__extract_quarter
+                      , subq_1.booking__ds__extract_month
+                      , subq_1.booking__ds__extract_day
+                      , subq_1.booking__ds__extract_dow
+                      , subq_1.booking__ds__extract_doy
+                      , subq_1.booking__ds_partitioned__day
+                      , subq_1.booking__ds_partitioned__week
+                      , subq_1.booking__ds_partitioned__month
+                      , subq_1.booking__ds_partitioned__quarter
+                      , subq_1.booking__ds_partitioned__year
+                      , subq_1.booking__ds_partitioned__extract_year
+                      , subq_1.booking__ds_partitioned__extract_quarter
+                      , subq_1.booking__ds_partitioned__extract_month
+                      , subq_1.booking__ds_partitioned__extract_day
+                      , subq_1.booking__ds_partitioned__extract_dow
+                      , subq_1.booking__ds_partitioned__extract_doy
+                      , subq_1.booking__paid_at__day
+                      , subq_1.booking__paid_at__week
+                      , subq_1.booking__paid_at__month
+                      , subq_1.booking__paid_at__quarter
+                      , subq_1.booking__paid_at__year
+                      , subq_1.booking__paid_at__extract_year
+                      , subq_1.booking__paid_at__extract_quarter
+                      , subq_1.booking__paid_at__extract_month
+                      , subq_1.booking__paid_at__extract_day
+                      , subq_1.booking__paid_at__extract_dow
+                      , subq_1.booking__paid_at__extract_doy
+                      , subq_1.metric_time__day
+                      , subq_1.metric_time__week
+                      , subq_1.metric_time__month
+                      , subq_1.metric_time__quarter
+                      , subq_1.metric_time__year
+                      , subq_1.metric_time__extract_year
+                      , subq_1.metric_time__extract_quarter
+                      , subq_1.metric_time__extract_month
+                      , subq_1.metric_time__extract_day
+                      , subq_1.metric_time__extract_dow
+                      , subq_1.metric_time__extract_doy
+                      , subq_1.listing
+                      , subq_1.guest
+                      , subq_1.host
+                      , subq_1.booking__listing
+                      , subq_1.booking__guest
+                      , subq_1.booking__host
+                      , subq_1.is_instant
+                      , subq_1.booking__is_instant
+                      , subq_1.bookings
+                      , subq_1.instant_bookings
+                      , subq_1.booking_value
+                      , subq_1.max_booking_value
+                      , subq_1.min_booking_value
+                      , subq_1.bookers
+                      , subq_1.average_booking_value
+                      , subq_1.referred_bookings
+                      , subq_1.median_booking_value
+                      , subq_1.booking_value_p99
+                      , subq_1.discrete_booking_value_p99
+                      , subq_1.approximate_continuous_booking_value_p99
+                      , subq_1.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_6.ds__day
-                        , subq_6.ds__week
-                        , subq_6.ds__month
-                        , subq_6.ds__quarter
-                        , subq_6.ds__year
-                        , subq_6.ds__extract_year
-                        , subq_6.ds__extract_quarter
-                        , subq_6.ds__extract_month
-                        , subq_6.ds__extract_day
-                        , subq_6.ds__extract_dow
-                        , subq_6.ds__extract_doy
-                        , subq_6.ds_partitioned__day
-                        , subq_6.ds_partitioned__week
-                        , subq_6.ds_partitioned__month
-                        , subq_6.ds_partitioned__quarter
-                        , subq_6.ds_partitioned__year
-                        , subq_6.ds_partitioned__extract_year
-                        , subq_6.ds_partitioned__extract_quarter
-                        , subq_6.ds_partitioned__extract_month
-                        , subq_6.ds_partitioned__extract_day
-                        , subq_6.ds_partitioned__extract_dow
-                        , subq_6.ds_partitioned__extract_doy
-                        , subq_6.paid_at__day
-                        , subq_6.paid_at__week
-                        , subq_6.paid_at__month
-                        , subq_6.paid_at__quarter
-                        , subq_6.paid_at__year
-                        , subq_6.paid_at__extract_year
-                        , subq_6.paid_at__extract_quarter
-                        , subq_6.paid_at__extract_month
-                        , subq_6.paid_at__extract_day
-                        , subq_6.paid_at__extract_dow
-                        , subq_6.paid_at__extract_doy
-                        , subq_6.booking__ds__day
-                        , subq_6.booking__ds__week
-                        , subq_6.booking__ds__month
-                        , subq_6.booking__ds__quarter
-                        , subq_6.booking__ds__year
-                        , subq_6.booking__ds__extract_year
-                        , subq_6.booking__ds__extract_quarter
-                        , subq_6.booking__ds__extract_month
-                        , subq_6.booking__ds__extract_day
-                        , subq_6.booking__ds__extract_dow
-                        , subq_6.booking__ds__extract_doy
-                        , subq_6.booking__ds_partitioned__day
-                        , subq_6.booking__ds_partitioned__week
-                        , subq_6.booking__ds_partitioned__month
-                        , subq_6.booking__ds_partitioned__quarter
-                        , subq_6.booking__ds_partitioned__year
-                        , subq_6.booking__ds_partitioned__extract_year
-                        , subq_6.booking__ds_partitioned__extract_quarter
-                        , subq_6.booking__ds_partitioned__extract_month
-                        , subq_6.booking__ds_partitioned__extract_day
-                        , subq_6.booking__ds_partitioned__extract_dow
-                        , subq_6.booking__ds_partitioned__extract_doy
-                        , subq_6.booking__paid_at__day
-                        , subq_6.booking__paid_at__week
-                        , subq_6.booking__paid_at__month
-                        , subq_6.booking__paid_at__quarter
-                        , subq_6.booking__paid_at__year
-                        , subq_6.booking__paid_at__extract_year
-                        , subq_6.booking__paid_at__extract_quarter
-                        , subq_6.booking__paid_at__extract_month
-                        , subq_6.booking__paid_at__extract_day
-                        , subq_6.booking__paid_at__extract_dow
-                        , subq_6.booking__paid_at__extract_doy
-                        , subq_6.ds__day AS metric_time__day
-                        , subq_6.ds__week AS metric_time__week
-                        , subq_6.ds__month AS metric_time__month
-                        , subq_6.ds__quarter AS metric_time__quarter
-                        , subq_6.ds__year AS metric_time__year
-                        , subq_6.ds__extract_year AS metric_time__extract_year
-                        , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_6.ds__extract_month AS metric_time__extract_month
-                        , subq_6.ds__extract_day AS metric_time__extract_day
-                        , subq_6.ds__extract_dow AS metric_time__extract_dow
-                        , subq_6.ds__extract_doy AS metric_time__extract_doy
-                        , subq_6.listing
-                        , subq_6.guest
-                        , subq_6.host
-                        , subq_6.booking__listing
-                        , subq_6.booking__guest
-                        , subq_6.booking__host
-                        , subq_6.is_instant
-                        , subq_6.booking__is_instant
-                        , subq_6.bookings
-                        , subq_6.instant_bookings
-                        , subq_6.booking_value
-                        , subq_6.max_booking_value
-                        , subq_6.min_booking_value
-                        , subq_6.bookers
-                        , subq_6.average_booking_value
-                        , subq_6.referred_bookings
-                        , subq_6.median_booking_value
-                        , subq_6.booking_value_p99
-                        , subq_6.discrete_booking_value_p99
-                        , subq_6.approximate_continuous_booking_value_p99
-                        , subq_6.approximate_discrete_booking_value_p99
+                        subq_0.ds__day
+                        , subq_0.ds__week
+                        , subq_0.ds__month
+                        , subq_0.ds__quarter
+                        , subq_0.ds__year
+                        , subq_0.ds__extract_year
+                        , subq_0.ds__extract_quarter
+                        , subq_0.ds__extract_month
+                        , subq_0.ds__extract_day
+                        , subq_0.ds__extract_dow
+                        , subq_0.ds__extract_doy
+                        , subq_0.ds_partitioned__day
+                        , subq_0.ds_partitioned__week
+                        , subq_0.ds_partitioned__month
+                        , subq_0.ds_partitioned__quarter
+                        , subq_0.ds_partitioned__year
+                        , subq_0.ds_partitioned__extract_year
+                        , subq_0.ds_partitioned__extract_quarter
+                        , subq_0.ds_partitioned__extract_month
+                        , subq_0.ds_partitioned__extract_day
+                        , subq_0.ds_partitioned__extract_dow
+                        , subq_0.ds_partitioned__extract_doy
+                        , subq_0.paid_at__day
+                        , subq_0.paid_at__week
+                        , subq_0.paid_at__month
+                        , subq_0.paid_at__quarter
+                        , subq_0.paid_at__year
+                        , subq_0.paid_at__extract_year
+                        , subq_0.paid_at__extract_quarter
+                        , subq_0.paid_at__extract_month
+                        , subq_0.paid_at__extract_day
+                        , subq_0.paid_at__extract_dow
+                        , subq_0.paid_at__extract_doy
+                        , subq_0.booking__ds__day
+                        , subq_0.booking__ds__week
+                        , subq_0.booking__ds__month
+                        , subq_0.booking__ds__quarter
+                        , subq_0.booking__ds__year
+                        , subq_0.booking__ds__extract_year
+                        , subq_0.booking__ds__extract_quarter
+                        , subq_0.booking__ds__extract_month
+                        , subq_0.booking__ds__extract_day
+                        , subq_0.booking__ds__extract_dow
+                        , subq_0.booking__ds__extract_doy
+                        , subq_0.booking__ds_partitioned__day
+                        , subq_0.booking__ds_partitioned__week
+                        , subq_0.booking__ds_partitioned__month
+                        , subq_0.booking__ds_partitioned__quarter
+                        , subq_0.booking__ds_partitioned__year
+                        , subq_0.booking__ds_partitioned__extract_year
+                        , subq_0.booking__ds_partitioned__extract_quarter
+                        , subq_0.booking__ds_partitioned__extract_month
+                        , subq_0.booking__ds_partitioned__extract_day
+                        , subq_0.booking__ds_partitioned__extract_dow
+                        , subq_0.booking__ds_partitioned__extract_doy
+                        , subq_0.booking__paid_at__day
+                        , subq_0.booking__paid_at__week
+                        , subq_0.booking__paid_at__month
+                        , subq_0.booking__paid_at__quarter
+                        , subq_0.booking__paid_at__year
+                        , subq_0.booking__paid_at__extract_year
+                        , subq_0.booking__paid_at__extract_quarter
+                        , subq_0.booking__paid_at__extract_month
+                        , subq_0.booking__paid_at__extract_day
+                        , subq_0.booking__paid_at__extract_dow
+                        , subq_0.booking__paid_at__extract_doy
+                        , subq_0.ds__day AS metric_time__day
+                        , subq_0.ds__week AS metric_time__week
+                        , subq_0.ds__month AS metric_time__month
+                        , subq_0.ds__quarter AS metric_time__quarter
+                        , subq_0.ds__year AS metric_time__year
+                        , subq_0.ds__extract_year AS metric_time__extract_year
+                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_0.ds__extract_month AS metric_time__extract_month
+                        , subq_0.ds__extract_day AS metric_time__extract_day
+                        , subq_0.ds__extract_dow AS metric_time__extract_dow
+                        , subq_0.ds__extract_doy AS metric_time__extract_doy
+                        , subq_0.listing
+                        , subq_0.guest
+                        , subq_0.host
+                        , subq_0.booking__listing
+                        , subq_0.booking__guest
+                        , subq_0.booking__host
+                        , subq_0.is_instant
+                        , subq_0.booking__is_instant
+                        , subq_0.bookings
+                        , subq_0.instant_bookings
+                        , subq_0.booking_value
+                        , subq_0.max_booking_value
+                        , subq_0.min_booking_value
+                        , subq_0.bookers
+                        , subq_0.average_booking_value
+                        , subq_0.referred_bookings
+                        , subq_0.median_booking_value
+                        , subq_0.booking_value_p99
+                        , subq_0.discrete_booking_value_p99
+                        , subq_0.approximate_continuous_booking_value_p99
+                        , subq_0.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -342,86 +342,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_6
-                    ) subq_7
+                      ) subq_0
+                    ) subq_1
                     WHERE booking__is_instant
-                  ) subq_8
-                ) subq_9
+                  ) subq_2
+                ) subq_3
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_11.listing
-                    , subq_11.is_lux_latest
+                    subq_5.listing
+                    , subq_5.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_10.ds__day
-                      , subq_10.ds__week
-                      , subq_10.ds__month
-                      , subq_10.ds__quarter
-                      , subq_10.ds__year
-                      , subq_10.ds__extract_year
-                      , subq_10.ds__extract_quarter
-                      , subq_10.ds__extract_month
-                      , subq_10.ds__extract_day
-                      , subq_10.ds__extract_dow
-                      , subq_10.ds__extract_doy
-                      , subq_10.created_at__day
-                      , subq_10.created_at__week
-                      , subq_10.created_at__month
-                      , subq_10.created_at__quarter
-                      , subq_10.created_at__year
-                      , subq_10.created_at__extract_year
-                      , subq_10.created_at__extract_quarter
-                      , subq_10.created_at__extract_month
-                      , subq_10.created_at__extract_day
-                      , subq_10.created_at__extract_dow
-                      , subq_10.created_at__extract_doy
-                      , subq_10.listing__ds__day
-                      , subq_10.listing__ds__week
-                      , subq_10.listing__ds__month
-                      , subq_10.listing__ds__quarter
-                      , subq_10.listing__ds__year
-                      , subq_10.listing__ds__extract_year
-                      , subq_10.listing__ds__extract_quarter
-                      , subq_10.listing__ds__extract_month
-                      , subq_10.listing__ds__extract_day
-                      , subq_10.listing__ds__extract_dow
-                      , subq_10.listing__ds__extract_doy
-                      , subq_10.listing__created_at__day
-                      , subq_10.listing__created_at__week
-                      , subq_10.listing__created_at__month
-                      , subq_10.listing__created_at__quarter
-                      , subq_10.listing__created_at__year
-                      , subq_10.listing__created_at__extract_year
-                      , subq_10.listing__created_at__extract_quarter
-                      , subq_10.listing__created_at__extract_month
-                      , subq_10.listing__created_at__extract_day
-                      , subq_10.listing__created_at__extract_dow
-                      , subq_10.listing__created_at__extract_doy
-                      , subq_10.ds__day AS metric_time__day
-                      , subq_10.ds__week AS metric_time__week
-                      , subq_10.ds__month AS metric_time__month
-                      , subq_10.ds__quarter AS metric_time__quarter
-                      , subq_10.ds__year AS metric_time__year
-                      , subq_10.ds__extract_year AS metric_time__extract_year
-                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_10.ds__extract_month AS metric_time__extract_month
-                      , subq_10.ds__extract_day AS metric_time__extract_day
-                      , subq_10.ds__extract_dow AS metric_time__extract_dow
-                      , subq_10.ds__extract_doy AS metric_time__extract_doy
-                      , subq_10.listing
-                      , subq_10.user
-                      , subq_10.listing__user
-                      , subq_10.country_latest
-                      , subq_10.is_lux_latest
-                      , subq_10.capacity_latest
-                      , subq_10.listing__country_latest
-                      , subq_10.listing__is_lux_latest
-                      , subq_10.listing__capacity_latest
-                      , subq_10.listings
-                      , subq_10.largest_listing
-                      , subq_10.smallest_listing
+                      subq_4.ds__day
+                      , subq_4.ds__week
+                      , subq_4.ds__month
+                      , subq_4.ds__quarter
+                      , subq_4.ds__year
+                      , subq_4.ds__extract_year
+                      , subq_4.ds__extract_quarter
+                      , subq_4.ds__extract_month
+                      , subq_4.ds__extract_day
+                      , subq_4.ds__extract_dow
+                      , subq_4.ds__extract_doy
+                      , subq_4.created_at__day
+                      , subq_4.created_at__week
+                      , subq_4.created_at__month
+                      , subq_4.created_at__quarter
+                      , subq_4.created_at__year
+                      , subq_4.created_at__extract_year
+                      , subq_4.created_at__extract_quarter
+                      , subq_4.created_at__extract_month
+                      , subq_4.created_at__extract_day
+                      , subq_4.created_at__extract_dow
+                      , subq_4.created_at__extract_doy
+                      , subq_4.listing__ds__day
+                      , subq_4.listing__ds__week
+                      , subq_4.listing__ds__month
+                      , subq_4.listing__ds__quarter
+                      , subq_4.listing__ds__year
+                      , subq_4.listing__ds__extract_year
+                      , subq_4.listing__ds__extract_quarter
+                      , subq_4.listing__ds__extract_month
+                      , subq_4.listing__ds__extract_day
+                      , subq_4.listing__ds__extract_dow
+                      , subq_4.listing__ds__extract_doy
+                      , subq_4.listing__created_at__day
+                      , subq_4.listing__created_at__week
+                      , subq_4.listing__created_at__month
+                      , subq_4.listing__created_at__quarter
+                      , subq_4.listing__created_at__year
+                      , subq_4.listing__created_at__extract_year
+                      , subq_4.listing__created_at__extract_quarter
+                      , subq_4.listing__created_at__extract_month
+                      , subq_4.listing__created_at__extract_day
+                      , subq_4.listing__created_at__extract_dow
+                      , subq_4.listing__created_at__extract_doy
+                      , subq_4.ds__day AS metric_time__day
+                      , subq_4.ds__week AS metric_time__week
+                      , subq_4.ds__month AS metric_time__month
+                      , subq_4.ds__quarter AS metric_time__quarter
+                      , subq_4.ds__year AS metric_time__year
+                      , subq_4.ds__extract_year AS metric_time__extract_year
+                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_4.ds__extract_month AS metric_time__extract_month
+                      , subq_4.ds__extract_day AS metric_time__extract_day
+                      , subq_4.ds__extract_dow AS metric_time__extract_dow
+                      , subq_4.ds__extract_doy AS metric_time__extract_doy
+                      , subq_4.listing
+                      , subq_4.user
+                      , subq_4.listing__user
+                      , subq_4.country_latest
+                      , subq_4.is_lux_latest
+                      , subq_4.capacity_latest
+                      , subq_4.listing__country_latest
+                      , subq_4.listing__is_lux_latest
+                      , subq_4.listing__capacity_latest
+                      , subq_4.listings
+                      , subq_4.largest_listing
+                      , subq_4.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,257 +482,257 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_10
-                  ) subq_11
-                ) subq_12
+                    ) subq_4
+                  ) subq_5
+                ) subq_6
                 ON
-                  subq_9.listing = subq_12.listing
-              ) subq_13
-            ) subq_14
+                  subq_3.listing = subq_6.listing
+              ) subq_7
+            ) subq_8
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_15
-        ) subq_16
-      ) subq_17
-    ) subq_18
+          ) subq_9
+        ) subq_10
+      ) subq_11
+    ) subq_12
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_30.bookings
+        subq_24.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_29.bookings) AS bookings
+          SUM(subq_23.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_28.bookings
+            subq_22.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_27.booking__is_instant
-              , subq_27.listing__is_lux_latest
-              , subq_27.bookings
+              subq_21.booking__is_instant
+              , subq_21.listing__is_lux_latest
+              , subq_21.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_26.booking__is_instant
-                , subq_26.listing__is_lux_latest
-                , subq_26.bookings
+                subq_20.booking__is_instant
+                , subq_20.listing__is_lux_latest
+                , subq_20.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_22.listing AS listing
-                  , subq_22.booking__is_instant AS booking__is_instant
-                  , subq_25.is_lux_latest AS listing__is_lux_latest
-                  , subq_22.bookings AS bookings
+                  subq_16.listing AS listing
+                  , subq_16.booking__is_instant AS booking__is_instant
+                  , subq_19.is_lux_latest AS listing__is_lux_latest
+                  , subq_16.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_21.listing
-                    , subq_21.booking__is_instant
-                    , subq_21.bookings
+                    subq_15.listing
+                    , subq_15.booking__is_instant
+                    , subq_15.bookings
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_20.ds__day
-                      , subq_20.ds__week
-                      , subq_20.ds__month
-                      , subq_20.ds__quarter
-                      , subq_20.ds__year
-                      , subq_20.ds__extract_year
-                      , subq_20.ds__extract_quarter
-                      , subq_20.ds__extract_month
-                      , subq_20.ds__extract_day
-                      , subq_20.ds__extract_dow
-                      , subq_20.ds__extract_doy
-                      , subq_20.ds_partitioned__day
-                      , subq_20.ds_partitioned__week
-                      , subq_20.ds_partitioned__month
-                      , subq_20.ds_partitioned__quarter
-                      , subq_20.ds_partitioned__year
-                      , subq_20.ds_partitioned__extract_year
-                      , subq_20.ds_partitioned__extract_quarter
-                      , subq_20.ds_partitioned__extract_month
-                      , subq_20.ds_partitioned__extract_day
-                      , subq_20.ds_partitioned__extract_dow
-                      , subq_20.ds_partitioned__extract_doy
-                      , subq_20.paid_at__day
-                      , subq_20.paid_at__week
-                      , subq_20.paid_at__month
-                      , subq_20.paid_at__quarter
-                      , subq_20.paid_at__year
-                      , subq_20.paid_at__extract_year
-                      , subq_20.paid_at__extract_quarter
-                      , subq_20.paid_at__extract_month
-                      , subq_20.paid_at__extract_day
-                      , subq_20.paid_at__extract_dow
-                      , subq_20.paid_at__extract_doy
-                      , subq_20.booking__ds__day
-                      , subq_20.booking__ds__week
-                      , subq_20.booking__ds__month
-                      , subq_20.booking__ds__quarter
-                      , subq_20.booking__ds__year
-                      , subq_20.booking__ds__extract_year
-                      , subq_20.booking__ds__extract_quarter
-                      , subq_20.booking__ds__extract_month
-                      , subq_20.booking__ds__extract_day
-                      , subq_20.booking__ds__extract_dow
-                      , subq_20.booking__ds__extract_doy
-                      , subq_20.booking__ds_partitioned__day
-                      , subq_20.booking__ds_partitioned__week
-                      , subq_20.booking__ds_partitioned__month
-                      , subq_20.booking__ds_partitioned__quarter
-                      , subq_20.booking__ds_partitioned__year
-                      , subq_20.booking__ds_partitioned__extract_year
-                      , subq_20.booking__ds_partitioned__extract_quarter
-                      , subq_20.booking__ds_partitioned__extract_month
-                      , subq_20.booking__ds_partitioned__extract_day
-                      , subq_20.booking__ds_partitioned__extract_dow
-                      , subq_20.booking__ds_partitioned__extract_doy
-                      , subq_20.booking__paid_at__day
-                      , subq_20.booking__paid_at__week
-                      , subq_20.booking__paid_at__month
-                      , subq_20.booking__paid_at__quarter
-                      , subq_20.booking__paid_at__year
-                      , subq_20.booking__paid_at__extract_year
-                      , subq_20.booking__paid_at__extract_quarter
-                      , subq_20.booking__paid_at__extract_month
-                      , subq_20.booking__paid_at__extract_day
-                      , subq_20.booking__paid_at__extract_dow
-                      , subq_20.booking__paid_at__extract_doy
-                      , subq_20.metric_time__day
-                      , subq_20.metric_time__week
-                      , subq_20.metric_time__month
-                      , subq_20.metric_time__quarter
-                      , subq_20.metric_time__year
-                      , subq_20.metric_time__extract_year
-                      , subq_20.metric_time__extract_quarter
-                      , subq_20.metric_time__extract_month
-                      , subq_20.metric_time__extract_day
-                      , subq_20.metric_time__extract_dow
-                      , subq_20.metric_time__extract_doy
-                      , subq_20.listing
-                      , subq_20.guest
-                      , subq_20.host
-                      , subq_20.booking__listing
-                      , subq_20.booking__guest
-                      , subq_20.booking__host
-                      , subq_20.is_instant
-                      , subq_20.booking__is_instant
-                      , subq_20.bookings
-                      , subq_20.instant_bookings
-                      , subq_20.booking_value
-                      , subq_20.max_booking_value
-                      , subq_20.min_booking_value
-                      , subq_20.bookers
-                      , subq_20.average_booking_value
-                      , subq_20.referred_bookings
-                      , subq_20.median_booking_value
-                      , subq_20.booking_value_p99
-                      , subq_20.discrete_booking_value_p99
-                      , subq_20.approximate_continuous_booking_value_p99
-                      , subq_20.approximate_discrete_booking_value_p99
+                      subq_14.ds__day
+                      , subq_14.ds__week
+                      , subq_14.ds__month
+                      , subq_14.ds__quarter
+                      , subq_14.ds__year
+                      , subq_14.ds__extract_year
+                      , subq_14.ds__extract_quarter
+                      , subq_14.ds__extract_month
+                      , subq_14.ds__extract_day
+                      , subq_14.ds__extract_dow
+                      , subq_14.ds__extract_doy
+                      , subq_14.ds_partitioned__day
+                      , subq_14.ds_partitioned__week
+                      , subq_14.ds_partitioned__month
+                      , subq_14.ds_partitioned__quarter
+                      , subq_14.ds_partitioned__year
+                      , subq_14.ds_partitioned__extract_year
+                      , subq_14.ds_partitioned__extract_quarter
+                      , subq_14.ds_partitioned__extract_month
+                      , subq_14.ds_partitioned__extract_day
+                      , subq_14.ds_partitioned__extract_dow
+                      , subq_14.ds_partitioned__extract_doy
+                      , subq_14.paid_at__day
+                      , subq_14.paid_at__week
+                      , subq_14.paid_at__month
+                      , subq_14.paid_at__quarter
+                      , subq_14.paid_at__year
+                      , subq_14.paid_at__extract_year
+                      , subq_14.paid_at__extract_quarter
+                      , subq_14.paid_at__extract_month
+                      , subq_14.paid_at__extract_day
+                      , subq_14.paid_at__extract_dow
+                      , subq_14.paid_at__extract_doy
+                      , subq_14.booking__ds__day
+                      , subq_14.booking__ds__week
+                      , subq_14.booking__ds__month
+                      , subq_14.booking__ds__quarter
+                      , subq_14.booking__ds__year
+                      , subq_14.booking__ds__extract_year
+                      , subq_14.booking__ds__extract_quarter
+                      , subq_14.booking__ds__extract_month
+                      , subq_14.booking__ds__extract_day
+                      , subq_14.booking__ds__extract_dow
+                      , subq_14.booking__ds__extract_doy
+                      , subq_14.booking__ds_partitioned__day
+                      , subq_14.booking__ds_partitioned__week
+                      , subq_14.booking__ds_partitioned__month
+                      , subq_14.booking__ds_partitioned__quarter
+                      , subq_14.booking__ds_partitioned__year
+                      , subq_14.booking__ds_partitioned__extract_year
+                      , subq_14.booking__ds_partitioned__extract_quarter
+                      , subq_14.booking__ds_partitioned__extract_month
+                      , subq_14.booking__ds_partitioned__extract_day
+                      , subq_14.booking__ds_partitioned__extract_dow
+                      , subq_14.booking__ds_partitioned__extract_doy
+                      , subq_14.booking__paid_at__day
+                      , subq_14.booking__paid_at__week
+                      , subq_14.booking__paid_at__month
+                      , subq_14.booking__paid_at__quarter
+                      , subq_14.booking__paid_at__year
+                      , subq_14.booking__paid_at__extract_year
+                      , subq_14.booking__paid_at__extract_quarter
+                      , subq_14.booking__paid_at__extract_month
+                      , subq_14.booking__paid_at__extract_day
+                      , subq_14.booking__paid_at__extract_dow
+                      , subq_14.booking__paid_at__extract_doy
+                      , subq_14.metric_time__day
+                      , subq_14.metric_time__week
+                      , subq_14.metric_time__month
+                      , subq_14.metric_time__quarter
+                      , subq_14.metric_time__year
+                      , subq_14.metric_time__extract_year
+                      , subq_14.metric_time__extract_quarter
+                      , subq_14.metric_time__extract_month
+                      , subq_14.metric_time__extract_day
+                      , subq_14.metric_time__extract_dow
+                      , subq_14.metric_time__extract_doy
+                      , subq_14.listing
+                      , subq_14.guest
+                      , subq_14.host
+                      , subq_14.booking__listing
+                      , subq_14.booking__guest
+                      , subq_14.booking__host
+                      , subq_14.is_instant
+                      , subq_14.booking__is_instant
+                      , subq_14.bookings
+                      , subq_14.instant_bookings
+                      , subq_14.booking_value
+                      , subq_14.max_booking_value
+                      , subq_14.min_booking_value
+                      , subq_14.bookers
+                      , subq_14.average_booking_value
+                      , subq_14.referred_bookings
+                      , subq_14.median_booking_value
+                      , subq_14.booking_value_p99
+                      , subq_14.discrete_booking_value_p99
+                      , subq_14.approximate_continuous_booking_value_p99
+                      , subq_14.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_19.ds__day
-                        , subq_19.ds__week
-                        , subq_19.ds__month
-                        , subq_19.ds__quarter
-                        , subq_19.ds__year
-                        , subq_19.ds__extract_year
-                        , subq_19.ds__extract_quarter
-                        , subq_19.ds__extract_month
-                        , subq_19.ds__extract_day
-                        , subq_19.ds__extract_dow
-                        , subq_19.ds__extract_doy
-                        , subq_19.ds_partitioned__day
-                        , subq_19.ds_partitioned__week
-                        , subq_19.ds_partitioned__month
-                        , subq_19.ds_partitioned__quarter
-                        , subq_19.ds_partitioned__year
-                        , subq_19.ds_partitioned__extract_year
-                        , subq_19.ds_partitioned__extract_quarter
-                        , subq_19.ds_partitioned__extract_month
-                        , subq_19.ds_partitioned__extract_day
-                        , subq_19.ds_partitioned__extract_dow
-                        , subq_19.ds_partitioned__extract_doy
-                        , subq_19.paid_at__day
-                        , subq_19.paid_at__week
-                        , subq_19.paid_at__month
-                        , subq_19.paid_at__quarter
-                        , subq_19.paid_at__year
-                        , subq_19.paid_at__extract_year
-                        , subq_19.paid_at__extract_quarter
-                        , subq_19.paid_at__extract_month
-                        , subq_19.paid_at__extract_day
-                        , subq_19.paid_at__extract_dow
-                        , subq_19.paid_at__extract_doy
-                        , subq_19.booking__ds__day
-                        , subq_19.booking__ds__week
-                        , subq_19.booking__ds__month
-                        , subq_19.booking__ds__quarter
-                        , subq_19.booking__ds__year
-                        , subq_19.booking__ds__extract_year
-                        , subq_19.booking__ds__extract_quarter
-                        , subq_19.booking__ds__extract_month
-                        , subq_19.booking__ds__extract_day
-                        , subq_19.booking__ds__extract_dow
-                        , subq_19.booking__ds__extract_doy
-                        , subq_19.booking__ds_partitioned__day
-                        , subq_19.booking__ds_partitioned__week
-                        , subq_19.booking__ds_partitioned__month
-                        , subq_19.booking__ds_partitioned__quarter
-                        , subq_19.booking__ds_partitioned__year
-                        , subq_19.booking__ds_partitioned__extract_year
-                        , subq_19.booking__ds_partitioned__extract_quarter
-                        , subq_19.booking__ds_partitioned__extract_month
-                        , subq_19.booking__ds_partitioned__extract_day
-                        , subq_19.booking__ds_partitioned__extract_dow
-                        , subq_19.booking__ds_partitioned__extract_doy
-                        , subq_19.booking__paid_at__day
-                        , subq_19.booking__paid_at__week
-                        , subq_19.booking__paid_at__month
-                        , subq_19.booking__paid_at__quarter
-                        , subq_19.booking__paid_at__year
-                        , subq_19.booking__paid_at__extract_year
-                        , subq_19.booking__paid_at__extract_quarter
-                        , subq_19.booking__paid_at__extract_month
-                        , subq_19.booking__paid_at__extract_day
-                        , subq_19.booking__paid_at__extract_dow
-                        , subq_19.booking__paid_at__extract_doy
-                        , subq_19.ds__day AS metric_time__day
-                        , subq_19.ds__week AS metric_time__week
-                        , subq_19.ds__month AS metric_time__month
-                        , subq_19.ds__quarter AS metric_time__quarter
-                        , subq_19.ds__year AS metric_time__year
-                        , subq_19.ds__extract_year AS metric_time__extract_year
-                        , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_19.ds__extract_month AS metric_time__extract_month
-                        , subq_19.ds__extract_day AS metric_time__extract_day
-                        , subq_19.ds__extract_dow AS metric_time__extract_dow
-                        , subq_19.ds__extract_doy AS metric_time__extract_doy
-                        , subq_19.listing
-                        , subq_19.guest
-                        , subq_19.host
-                        , subq_19.booking__listing
-                        , subq_19.booking__guest
-                        , subq_19.booking__host
-                        , subq_19.is_instant
-                        , subq_19.booking__is_instant
-                        , subq_19.bookings
-                        , subq_19.instant_bookings
-                        , subq_19.booking_value
-                        , subq_19.max_booking_value
-                        , subq_19.min_booking_value
-                        , subq_19.bookers
-                        , subq_19.average_booking_value
-                        , subq_19.referred_bookings
-                        , subq_19.median_booking_value
-                        , subq_19.booking_value_p99
-                        , subq_19.discrete_booking_value_p99
-                        , subq_19.approximate_continuous_booking_value_p99
-                        , subq_19.approximate_discrete_booking_value_p99
+                        subq_13.ds__day
+                        , subq_13.ds__week
+                        , subq_13.ds__month
+                        , subq_13.ds__quarter
+                        , subq_13.ds__year
+                        , subq_13.ds__extract_year
+                        , subq_13.ds__extract_quarter
+                        , subq_13.ds__extract_month
+                        , subq_13.ds__extract_day
+                        , subq_13.ds__extract_dow
+                        , subq_13.ds__extract_doy
+                        , subq_13.ds_partitioned__day
+                        , subq_13.ds_partitioned__week
+                        , subq_13.ds_partitioned__month
+                        , subq_13.ds_partitioned__quarter
+                        , subq_13.ds_partitioned__year
+                        , subq_13.ds_partitioned__extract_year
+                        , subq_13.ds_partitioned__extract_quarter
+                        , subq_13.ds_partitioned__extract_month
+                        , subq_13.ds_partitioned__extract_day
+                        , subq_13.ds_partitioned__extract_dow
+                        , subq_13.ds_partitioned__extract_doy
+                        , subq_13.paid_at__day
+                        , subq_13.paid_at__week
+                        , subq_13.paid_at__month
+                        , subq_13.paid_at__quarter
+                        , subq_13.paid_at__year
+                        , subq_13.paid_at__extract_year
+                        , subq_13.paid_at__extract_quarter
+                        , subq_13.paid_at__extract_month
+                        , subq_13.paid_at__extract_day
+                        , subq_13.paid_at__extract_dow
+                        , subq_13.paid_at__extract_doy
+                        , subq_13.booking__ds__day
+                        , subq_13.booking__ds__week
+                        , subq_13.booking__ds__month
+                        , subq_13.booking__ds__quarter
+                        , subq_13.booking__ds__year
+                        , subq_13.booking__ds__extract_year
+                        , subq_13.booking__ds__extract_quarter
+                        , subq_13.booking__ds__extract_month
+                        , subq_13.booking__ds__extract_day
+                        , subq_13.booking__ds__extract_dow
+                        , subq_13.booking__ds__extract_doy
+                        , subq_13.booking__ds_partitioned__day
+                        , subq_13.booking__ds_partitioned__week
+                        , subq_13.booking__ds_partitioned__month
+                        , subq_13.booking__ds_partitioned__quarter
+                        , subq_13.booking__ds_partitioned__year
+                        , subq_13.booking__ds_partitioned__extract_year
+                        , subq_13.booking__ds_partitioned__extract_quarter
+                        , subq_13.booking__ds_partitioned__extract_month
+                        , subq_13.booking__ds_partitioned__extract_day
+                        , subq_13.booking__ds_partitioned__extract_dow
+                        , subq_13.booking__ds_partitioned__extract_doy
+                        , subq_13.booking__paid_at__day
+                        , subq_13.booking__paid_at__week
+                        , subq_13.booking__paid_at__month
+                        , subq_13.booking__paid_at__quarter
+                        , subq_13.booking__paid_at__year
+                        , subq_13.booking__paid_at__extract_year
+                        , subq_13.booking__paid_at__extract_quarter
+                        , subq_13.booking__paid_at__extract_month
+                        , subq_13.booking__paid_at__extract_day
+                        , subq_13.booking__paid_at__extract_dow
+                        , subq_13.booking__paid_at__extract_doy
+                        , subq_13.ds__day AS metric_time__day
+                        , subq_13.ds__week AS metric_time__week
+                        , subq_13.ds__month AS metric_time__month
+                        , subq_13.ds__quarter AS metric_time__quarter
+                        , subq_13.ds__year AS metric_time__year
+                        , subq_13.ds__extract_year AS metric_time__extract_year
+                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_13.ds__extract_month AS metric_time__extract_month
+                        , subq_13.ds__extract_day AS metric_time__extract_day
+                        , subq_13.ds__extract_dow AS metric_time__extract_dow
+                        , subq_13.ds__extract_doy AS metric_time__extract_doy
+                        , subq_13.listing
+                        , subq_13.guest
+                        , subq_13.host
+                        , subq_13.booking__listing
+                        , subq_13.booking__guest
+                        , subq_13.booking__host
+                        , subq_13.is_instant
+                        , subq_13.booking__is_instant
+                        , subq_13.bookings
+                        , subq_13.instant_bookings
+                        , subq_13.booking_value
+                        , subq_13.max_booking_value
+                        , subq_13.min_booking_value
+                        , subq_13.bookers
+                        , subq_13.average_booking_value
+                        , subq_13.referred_bookings
+                        , subq_13.median_booking_value
+                        , subq_13.booking_value_p99
+                        , subq_13.discrete_booking_value_p99
+                        , subq_13.approximate_continuous_booking_value_p99
+                        , subq_13.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -825,86 +825,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_19
-                    ) subq_20
+                      ) subq_13
+                    ) subq_14
                     WHERE booking__is_instant
-                  ) subq_21
-                ) subq_22
+                  ) subq_15
+                ) subq_16
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_24.listing
-                    , subq_24.is_lux_latest
+                    subq_18.listing
+                    , subq_18.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_23.ds__day
-                      , subq_23.ds__week
-                      , subq_23.ds__month
-                      , subq_23.ds__quarter
-                      , subq_23.ds__year
-                      , subq_23.ds__extract_year
-                      , subq_23.ds__extract_quarter
-                      , subq_23.ds__extract_month
-                      , subq_23.ds__extract_day
-                      , subq_23.ds__extract_dow
-                      , subq_23.ds__extract_doy
-                      , subq_23.created_at__day
-                      , subq_23.created_at__week
-                      , subq_23.created_at__month
-                      , subq_23.created_at__quarter
-                      , subq_23.created_at__year
-                      , subq_23.created_at__extract_year
-                      , subq_23.created_at__extract_quarter
-                      , subq_23.created_at__extract_month
-                      , subq_23.created_at__extract_day
-                      , subq_23.created_at__extract_dow
-                      , subq_23.created_at__extract_doy
-                      , subq_23.listing__ds__day
-                      , subq_23.listing__ds__week
-                      , subq_23.listing__ds__month
-                      , subq_23.listing__ds__quarter
-                      , subq_23.listing__ds__year
-                      , subq_23.listing__ds__extract_year
-                      , subq_23.listing__ds__extract_quarter
-                      , subq_23.listing__ds__extract_month
-                      , subq_23.listing__ds__extract_day
-                      , subq_23.listing__ds__extract_dow
-                      , subq_23.listing__ds__extract_doy
-                      , subq_23.listing__created_at__day
-                      , subq_23.listing__created_at__week
-                      , subq_23.listing__created_at__month
-                      , subq_23.listing__created_at__quarter
-                      , subq_23.listing__created_at__year
-                      , subq_23.listing__created_at__extract_year
-                      , subq_23.listing__created_at__extract_quarter
-                      , subq_23.listing__created_at__extract_month
-                      , subq_23.listing__created_at__extract_day
-                      , subq_23.listing__created_at__extract_dow
-                      , subq_23.listing__created_at__extract_doy
-                      , subq_23.ds__day AS metric_time__day
-                      , subq_23.ds__week AS metric_time__week
-                      , subq_23.ds__month AS metric_time__month
-                      , subq_23.ds__quarter AS metric_time__quarter
-                      , subq_23.ds__year AS metric_time__year
-                      , subq_23.ds__extract_year AS metric_time__extract_year
-                      , subq_23.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_23.ds__extract_month AS metric_time__extract_month
-                      , subq_23.ds__extract_day AS metric_time__extract_day
-                      , subq_23.ds__extract_dow AS metric_time__extract_dow
-                      , subq_23.ds__extract_doy AS metric_time__extract_doy
-                      , subq_23.listing
-                      , subq_23.user
-                      , subq_23.listing__user
-                      , subq_23.country_latest
-                      , subq_23.is_lux_latest
-                      , subq_23.capacity_latest
-                      , subq_23.listing__country_latest
-                      , subq_23.listing__is_lux_latest
-                      , subq_23.listing__capacity_latest
-                      , subq_23.listings
-                      , subq_23.largest_listing
-                      , subq_23.smallest_listing
+                      subq_17.ds__day
+                      , subq_17.ds__week
+                      , subq_17.ds__month
+                      , subq_17.ds__quarter
+                      , subq_17.ds__year
+                      , subq_17.ds__extract_year
+                      , subq_17.ds__extract_quarter
+                      , subq_17.ds__extract_month
+                      , subq_17.ds__extract_day
+                      , subq_17.ds__extract_dow
+                      , subq_17.ds__extract_doy
+                      , subq_17.created_at__day
+                      , subq_17.created_at__week
+                      , subq_17.created_at__month
+                      , subq_17.created_at__quarter
+                      , subq_17.created_at__year
+                      , subq_17.created_at__extract_year
+                      , subq_17.created_at__extract_quarter
+                      , subq_17.created_at__extract_month
+                      , subq_17.created_at__extract_day
+                      , subq_17.created_at__extract_dow
+                      , subq_17.created_at__extract_doy
+                      , subq_17.listing__ds__day
+                      , subq_17.listing__ds__week
+                      , subq_17.listing__ds__month
+                      , subq_17.listing__ds__quarter
+                      , subq_17.listing__ds__year
+                      , subq_17.listing__ds__extract_year
+                      , subq_17.listing__ds__extract_quarter
+                      , subq_17.listing__ds__extract_month
+                      , subq_17.listing__ds__extract_day
+                      , subq_17.listing__ds__extract_dow
+                      , subq_17.listing__ds__extract_doy
+                      , subq_17.listing__created_at__day
+                      , subq_17.listing__created_at__week
+                      , subq_17.listing__created_at__month
+                      , subq_17.listing__created_at__quarter
+                      , subq_17.listing__created_at__year
+                      , subq_17.listing__created_at__extract_year
+                      , subq_17.listing__created_at__extract_quarter
+                      , subq_17.listing__created_at__extract_month
+                      , subq_17.listing__created_at__extract_day
+                      , subq_17.listing__created_at__extract_dow
+                      , subq_17.listing__created_at__extract_doy
+                      , subq_17.ds__day AS metric_time__day
+                      , subq_17.ds__week AS metric_time__week
+                      , subq_17.ds__month AS metric_time__month
+                      , subq_17.ds__quarter AS metric_time__quarter
+                      , subq_17.ds__year AS metric_time__year
+                      , subq_17.ds__extract_year AS metric_time__extract_year
+                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_17.ds__extract_month AS metric_time__extract_month
+                      , subq_17.ds__extract_day AS metric_time__extract_day
+                      , subq_17.ds__extract_dow AS metric_time__extract_dow
+                      , subq_17.ds__extract_doy AS metric_time__extract_doy
+                      , subq_17.listing
+                      , subq_17.user
+                      , subq_17.listing__user
+                      , subq_17.country_latest
+                      , subq_17.is_lux_latest
+                      , subq_17.capacity_latest
+                      , subq_17.listing__country_latest
+                      , subq_17.listing__is_lux_latest
+                      , subq_17.listing__capacity_latest
+                      , subq_17.listings
+                      , subq_17.largest_listing
+                      , subq_17.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,242 +965,242 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_23
-                  ) subq_24
-                ) subq_25
+                    ) subq_17
+                  ) subq_18
+                ) subq_19
                 ON
-                  subq_22.listing = subq_25.listing
-              ) subq_26
-            ) subq_27
+                  subq_16.listing = subq_19.listing
+              ) subq_20
+            ) subq_21
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_28
-        ) subq_29
-      ) subq_30
-    ) subq_31
+          ) subq_22
+        ) subq_23
+      ) subq_24
+    ) subq_25
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_38.booking_value
+        subq_32.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_37.booking_value) AS booking_value
+          SUM(subq_31.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_36.booking_value
+            subq_30.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_35.booking__is_instant
-              , subq_35.booking_value
+              subq_29.booking__is_instant
+              , subq_29.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_34.booking__is_instant
-                , subq_34.booking_value
+                subq_28.booking__is_instant
+                , subq_28.booking_value
               FROM (
                 -- Constrain Output with WHERE
                 SELECT
-                  subq_33.ds__day
-                  , subq_33.ds__week
-                  , subq_33.ds__month
-                  , subq_33.ds__quarter
-                  , subq_33.ds__year
-                  , subq_33.ds__extract_year
-                  , subq_33.ds__extract_quarter
-                  , subq_33.ds__extract_month
-                  , subq_33.ds__extract_day
-                  , subq_33.ds__extract_dow
-                  , subq_33.ds__extract_doy
-                  , subq_33.ds_partitioned__day
-                  , subq_33.ds_partitioned__week
-                  , subq_33.ds_partitioned__month
-                  , subq_33.ds_partitioned__quarter
-                  , subq_33.ds_partitioned__year
-                  , subq_33.ds_partitioned__extract_year
-                  , subq_33.ds_partitioned__extract_quarter
-                  , subq_33.ds_partitioned__extract_month
-                  , subq_33.ds_partitioned__extract_day
-                  , subq_33.ds_partitioned__extract_dow
-                  , subq_33.ds_partitioned__extract_doy
-                  , subq_33.paid_at__day
-                  , subq_33.paid_at__week
-                  , subq_33.paid_at__month
-                  , subq_33.paid_at__quarter
-                  , subq_33.paid_at__year
-                  , subq_33.paid_at__extract_year
-                  , subq_33.paid_at__extract_quarter
-                  , subq_33.paid_at__extract_month
-                  , subq_33.paid_at__extract_day
-                  , subq_33.paid_at__extract_dow
-                  , subq_33.paid_at__extract_doy
-                  , subq_33.booking__ds__day
-                  , subq_33.booking__ds__week
-                  , subq_33.booking__ds__month
-                  , subq_33.booking__ds__quarter
-                  , subq_33.booking__ds__year
-                  , subq_33.booking__ds__extract_year
-                  , subq_33.booking__ds__extract_quarter
-                  , subq_33.booking__ds__extract_month
-                  , subq_33.booking__ds__extract_day
-                  , subq_33.booking__ds__extract_dow
-                  , subq_33.booking__ds__extract_doy
-                  , subq_33.booking__ds_partitioned__day
-                  , subq_33.booking__ds_partitioned__week
-                  , subq_33.booking__ds_partitioned__month
-                  , subq_33.booking__ds_partitioned__quarter
-                  , subq_33.booking__ds_partitioned__year
-                  , subq_33.booking__ds_partitioned__extract_year
-                  , subq_33.booking__ds_partitioned__extract_quarter
-                  , subq_33.booking__ds_partitioned__extract_month
-                  , subq_33.booking__ds_partitioned__extract_day
-                  , subq_33.booking__ds_partitioned__extract_dow
-                  , subq_33.booking__ds_partitioned__extract_doy
-                  , subq_33.booking__paid_at__day
-                  , subq_33.booking__paid_at__week
-                  , subq_33.booking__paid_at__month
-                  , subq_33.booking__paid_at__quarter
-                  , subq_33.booking__paid_at__year
-                  , subq_33.booking__paid_at__extract_year
-                  , subq_33.booking__paid_at__extract_quarter
-                  , subq_33.booking__paid_at__extract_month
-                  , subq_33.booking__paid_at__extract_day
-                  , subq_33.booking__paid_at__extract_dow
-                  , subq_33.booking__paid_at__extract_doy
-                  , subq_33.metric_time__day
-                  , subq_33.metric_time__week
-                  , subq_33.metric_time__month
-                  , subq_33.metric_time__quarter
-                  , subq_33.metric_time__year
-                  , subq_33.metric_time__extract_year
-                  , subq_33.metric_time__extract_quarter
-                  , subq_33.metric_time__extract_month
-                  , subq_33.metric_time__extract_day
-                  , subq_33.metric_time__extract_dow
-                  , subq_33.metric_time__extract_doy
-                  , subq_33.listing
-                  , subq_33.guest
-                  , subq_33.host
-                  , subq_33.booking__listing
-                  , subq_33.booking__guest
-                  , subq_33.booking__host
-                  , subq_33.is_instant
-                  , subq_33.booking__is_instant
-                  , subq_33.bookings
-                  , subq_33.instant_bookings
-                  , subq_33.booking_value
-                  , subq_33.max_booking_value
-                  , subq_33.min_booking_value
-                  , subq_33.bookers
-                  , subq_33.average_booking_value
-                  , subq_33.referred_bookings
-                  , subq_33.median_booking_value
-                  , subq_33.booking_value_p99
-                  , subq_33.discrete_booking_value_p99
-                  , subq_33.approximate_continuous_booking_value_p99
-                  , subq_33.approximate_discrete_booking_value_p99
+                  subq_27.ds__day
+                  , subq_27.ds__week
+                  , subq_27.ds__month
+                  , subq_27.ds__quarter
+                  , subq_27.ds__year
+                  , subq_27.ds__extract_year
+                  , subq_27.ds__extract_quarter
+                  , subq_27.ds__extract_month
+                  , subq_27.ds__extract_day
+                  , subq_27.ds__extract_dow
+                  , subq_27.ds__extract_doy
+                  , subq_27.ds_partitioned__day
+                  , subq_27.ds_partitioned__week
+                  , subq_27.ds_partitioned__month
+                  , subq_27.ds_partitioned__quarter
+                  , subq_27.ds_partitioned__year
+                  , subq_27.ds_partitioned__extract_year
+                  , subq_27.ds_partitioned__extract_quarter
+                  , subq_27.ds_partitioned__extract_month
+                  , subq_27.ds_partitioned__extract_day
+                  , subq_27.ds_partitioned__extract_dow
+                  , subq_27.ds_partitioned__extract_doy
+                  , subq_27.paid_at__day
+                  , subq_27.paid_at__week
+                  , subq_27.paid_at__month
+                  , subq_27.paid_at__quarter
+                  , subq_27.paid_at__year
+                  , subq_27.paid_at__extract_year
+                  , subq_27.paid_at__extract_quarter
+                  , subq_27.paid_at__extract_month
+                  , subq_27.paid_at__extract_day
+                  , subq_27.paid_at__extract_dow
+                  , subq_27.paid_at__extract_doy
+                  , subq_27.booking__ds__day
+                  , subq_27.booking__ds__week
+                  , subq_27.booking__ds__month
+                  , subq_27.booking__ds__quarter
+                  , subq_27.booking__ds__year
+                  , subq_27.booking__ds__extract_year
+                  , subq_27.booking__ds__extract_quarter
+                  , subq_27.booking__ds__extract_month
+                  , subq_27.booking__ds__extract_day
+                  , subq_27.booking__ds__extract_dow
+                  , subq_27.booking__ds__extract_doy
+                  , subq_27.booking__ds_partitioned__day
+                  , subq_27.booking__ds_partitioned__week
+                  , subq_27.booking__ds_partitioned__month
+                  , subq_27.booking__ds_partitioned__quarter
+                  , subq_27.booking__ds_partitioned__year
+                  , subq_27.booking__ds_partitioned__extract_year
+                  , subq_27.booking__ds_partitioned__extract_quarter
+                  , subq_27.booking__ds_partitioned__extract_month
+                  , subq_27.booking__ds_partitioned__extract_day
+                  , subq_27.booking__ds_partitioned__extract_dow
+                  , subq_27.booking__ds_partitioned__extract_doy
+                  , subq_27.booking__paid_at__day
+                  , subq_27.booking__paid_at__week
+                  , subq_27.booking__paid_at__month
+                  , subq_27.booking__paid_at__quarter
+                  , subq_27.booking__paid_at__year
+                  , subq_27.booking__paid_at__extract_year
+                  , subq_27.booking__paid_at__extract_quarter
+                  , subq_27.booking__paid_at__extract_month
+                  , subq_27.booking__paid_at__extract_day
+                  , subq_27.booking__paid_at__extract_dow
+                  , subq_27.booking__paid_at__extract_doy
+                  , subq_27.metric_time__day
+                  , subq_27.metric_time__week
+                  , subq_27.metric_time__month
+                  , subq_27.metric_time__quarter
+                  , subq_27.metric_time__year
+                  , subq_27.metric_time__extract_year
+                  , subq_27.metric_time__extract_quarter
+                  , subq_27.metric_time__extract_month
+                  , subq_27.metric_time__extract_day
+                  , subq_27.metric_time__extract_dow
+                  , subq_27.metric_time__extract_doy
+                  , subq_27.listing
+                  , subq_27.guest
+                  , subq_27.host
+                  , subq_27.booking__listing
+                  , subq_27.booking__guest
+                  , subq_27.booking__host
+                  , subq_27.is_instant
+                  , subq_27.booking__is_instant
+                  , subq_27.bookings
+                  , subq_27.instant_bookings
+                  , subq_27.booking_value
+                  , subq_27.max_booking_value
+                  , subq_27.min_booking_value
+                  , subq_27.bookers
+                  , subq_27.average_booking_value
+                  , subq_27.referred_bookings
+                  , subq_27.median_booking_value
+                  , subq_27.booking_value_p99
+                  , subq_27.discrete_booking_value_p99
+                  , subq_27.approximate_continuous_booking_value_p99
+                  , subq_27.approximate_discrete_booking_value_p99
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_32.ds__day
-                    , subq_32.ds__week
-                    , subq_32.ds__month
-                    , subq_32.ds__quarter
-                    , subq_32.ds__year
-                    , subq_32.ds__extract_year
-                    , subq_32.ds__extract_quarter
-                    , subq_32.ds__extract_month
-                    , subq_32.ds__extract_day
-                    , subq_32.ds__extract_dow
-                    , subq_32.ds__extract_doy
-                    , subq_32.ds_partitioned__day
-                    , subq_32.ds_partitioned__week
-                    , subq_32.ds_partitioned__month
-                    , subq_32.ds_partitioned__quarter
-                    , subq_32.ds_partitioned__year
-                    , subq_32.ds_partitioned__extract_year
-                    , subq_32.ds_partitioned__extract_quarter
-                    , subq_32.ds_partitioned__extract_month
-                    , subq_32.ds_partitioned__extract_day
-                    , subq_32.ds_partitioned__extract_dow
-                    , subq_32.ds_partitioned__extract_doy
-                    , subq_32.paid_at__day
-                    , subq_32.paid_at__week
-                    , subq_32.paid_at__month
-                    , subq_32.paid_at__quarter
-                    , subq_32.paid_at__year
-                    , subq_32.paid_at__extract_year
-                    , subq_32.paid_at__extract_quarter
-                    , subq_32.paid_at__extract_month
-                    , subq_32.paid_at__extract_day
-                    , subq_32.paid_at__extract_dow
-                    , subq_32.paid_at__extract_doy
-                    , subq_32.booking__ds__day
-                    , subq_32.booking__ds__week
-                    , subq_32.booking__ds__month
-                    , subq_32.booking__ds__quarter
-                    , subq_32.booking__ds__year
-                    , subq_32.booking__ds__extract_year
-                    , subq_32.booking__ds__extract_quarter
-                    , subq_32.booking__ds__extract_month
-                    , subq_32.booking__ds__extract_day
-                    , subq_32.booking__ds__extract_dow
-                    , subq_32.booking__ds__extract_doy
-                    , subq_32.booking__ds_partitioned__day
-                    , subq_32.booking__ds_partitioned__week
-                    , subq_32.booking__ds_partitioned__month
-                    , subq_32.booking__ds_partitioned__quarter
-                    , subq_32.booking__ds_partitioned__year
-                    , subq_32.booking__ds_partitioned__extract_year
-                    , subq_32.booking__ds_partitioned__extract_quarter
-                    , subq_32.booking__ds_partitioned__extract_month
-                    , subq_32.booking__ds_partitioned__extract_day
-                    , subq_32.booking__ds_partitioned__extract_dow
-                    , subq_32.booking__ds_partitioned__extract_doy
-                    , subq_32.booking__paid_at__day
-                    , subq_32.booking__paid_at__week
-                    , subq_32.booking__paid_at__month
-                    , subq_32.booking__paid_at__quarter
-                    , subq_32.booking__paid_at__year
-                    , subq_32.booking__paid_at__extract_year
-                    , subq_32.booking__paid_at__extract_quarter
-                    , subq_32.booking__paid_at__extract_month
-                    , subq_32.booking__paid_at__extract_day
-                    , subq_32.booking__paid_at__extract_dow
-                    , subq_32.booking__paid_at__extract_doy
-                    , subq_32.ds__day AS metric_time__day
-                    , subq_32.ds__week AS metric_time__week
-                    , subq_32.ds__month AS metric_time__month
-                    , subq_32.ds__quarter AS metric_time__quarter
-                    , subq_32.ds__year AS metric_time__year
-                    , subq_32.ds__extract_year AS metric_time__extract_year
-                    , subq_32.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_32.ds__extract_month AS metric_time__extract_month
-                    , subq_32.ds__extract_day AS metric_time__extract_day
-                    , subq_32.ds__extract_dow AS metric_time__extract_dow
-                    , subq_32.ds__extract_doy AS metric_time__extract_doy
-                    , subq_32.listing
-                    , subq_32.guest
-                    , subq_32.host
-                    , subq_32.booking__listing
-                    , subq_32.booking__guest
-                    , subq_32.booking__host
-                    , subq_32.is_instant
-                    , subq_32.booking__is_instant
-                    , subq_32.bookings
-                    , subq_32.instant_bookings
-                    , subq_32.booking_value
-                    , subq_32.max_booking_value
-                    , subq_32.min_booking_value
-                    , subq_32.bookers
-                    , subq_32.average_booking_value
-                    , subq_32.referred_bookings
-                    , subq_32.median_booking_value
-                    , subq_32.booking_value_p99
-                    , subq_32.discrete_booking_value_p99
-                    , subq_32.approximate_continuous_booking_value_p99
-                    , subq_32.approximate_discrete_booking_value_p99
+                    subq_26.ds__day
+                    , subq_26.ds__week
+                    , subq_26.ds__month
+                    , subq_26.ds__quarter
+                    , subq_26.ds__year
+                    , subq_26.ds__extract_year
+                    , subq_26.ds__extract_quarter
+                    , subq_26.ds__extract_month
+                    , subq_26.ds__extract_day
+                    , subq_26.ds__extract_dow
+                    , subq_26.ds__extract_doy
+                    , subq_26.ds_partitioned__day
+                    , subq_26.ds_partitioned__week
+                    , subq_26.ds_partitioned__month
+                    , subq_26.ds_partitioned__quarter
+                    , subq_26.ds_partitioned__year
+                    , subq_26.ds_partitioned__extract_year
+                    , subq_26.ds_partitioned__extract_quarter
+                    , subq_26.ds_partitioned__extract_month
+                    , subq_26.ds_partitioned__extract_day
+                    , subq_26.ds_partitioned__extract_dow
+                    , subq_26.ds_partitioned__extract_doy
+                    , subq_26.paid_at__day
+                    , subq_26.paid_at__week
+                    , subq_26.paid_at__month
+                    , subq_26.paid_at__quarter
+                    , subq_26.paid_at__year
+                    , subq_26.paid_at__extract_year
+                    , subq_26.paid_at__extract_quarter
+                    , subq_26.paid_at__extract_month
+                    , subq_26.paid_at__extract_day
+                    , subq_26.paid_at__extract_dow
+                    , subq_26.paid_at__extract_doy
+                    , subq_26.booking__ds__day
+                    , subq_26.booking__ds__week
+                    , subq_26.booking__ds__month
+                    , subq_26.booking__ds__quarter
+                    , subq_26.booking__ds__year
+                    , subq_26.booking__ds__extract_year
+                    , subq_26.booking__ds__extract_quarter
+                    , subq_26.booking__ds__extract_month
+                    , subq_26.booking__ds__extract_day
+                    , subq_26.booking__ds__extract_dow
+                    , subq_26.booking__ds__extract_doy
+                    , subq_26.booking__ds_partitioned__day
+                    , subq_26.booking__ds_partitioned__week
+                    , subq_26.booking__ds_partitioned__month
+                    , subq_26.booking__ds_partitioned__quarter
+                    , subq_26.booking__ds_partitioned__year
+                    , subq_26.booking__ds_partitioned__extract_year
+                    , subq_26.booking__ds_partitioned__extract_quarter
+                    , subq_26.booking__ds_partitioned__extract_month
+                    , subq_26.booking__ds_partitioned__extract_day
+                    , subq_26.booking__ds_partitioned__extract_dow
+                    , subq_26.booking__ds_partitioned__extract_doy
+                    , subq_26.booking__paid_at__day
+                    , subq_26.booking__paid_at__week
+                    , subq_26.booking__paid_at__month
+                    , subq_26.booking__paid_at__quarter
+                    , subq_26.booking__paid_at__year
+                    , subq_26.booking__paid_at__extract_year
+                    , subq_26.booking__paid_at__extract_quarter
+                    , subq_26.booking__paid_at__extract_month
+                    , subq_26.booking__paid_at__extract_day
+                    , subq_26.booking__paid_at__extract_dow
+                    , subq_26.booking__paid_at__extract_doy
+                    , subq_26.ds__day AS metric_time__day
+                    , subq_26.ds__week AS metric_time__week
+                    , subq_26.ds__month AS metric_time__month
+                    , subq_26.ds__quarter AS metric_time__quarter
+                    , subq_26.ds__year AS metric_time__year
+                    , subq_26.ds__extract_year AS metric_time__extract_year
+                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_26.ds__extract_month AS metric_time__extract_month
+                    , subq_26.ds__extract_day AS metric_time__extract_day
+                    , subq_26.ds__extract_dow AS metric_time__extract_dow
+                    , subq_26.ds__extract_doy AS metric_time__extract_doy
+                    , subq_26.listing
+                    , subq_26.guest
+                    , subq_26.host
+                    , subq_26.booking__listing
+                    , subq_26.booking__guest
+                    , subq_26.booking__host
+                    , subq_26.is_instant
+                    , subq_26.booking__is_instant
+                    , subq_26.bookings
+                    , subq_26.instant_bookings
+                    , subq_26.booking_value
+                    , subq_26.max_booking_value
+                    , subq_26.min_booking_value
+                    , subq_26.bookers
+                    , subq_26.average_booking_value
+                    , subq_26.referred_bookings
+                    , subq_26.median_booking_value
+                    , subq_26.booking_value_p99
+                    , subq_26.discrete_booking_value_p99
+                    , subq_26.approximate_continuous_booking_value_p99
+                    , subq_26.approximate_discrete_booking_value_p99
                   FROM (
                     -- Read Elements From Semantic Model 'bookings_source'
                     SELECT
@@ -1293,15 +1293,15 @@ FROM (
                       , bookings_source_src_28000.guest_id AS booking__guest
                       , bookings_source_src_28000.host_id AS booking__host
                     FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_32
-                ) subq_33
+                  ) subq_26
+                ) subq_27
                 WHERE booking__is_instant
-              ) subq_34
-            ) subq_35
+              ) subq_28
+            ) subq_29
             WHERE booking__is_instant
-          ) subq_36
-        ) subq_37
-      ) subq_38
-    ) subq_39
-  ) subq_40
-) subq_41
+          ) subq_30
+        ) subq_31
+      ) subq_32
+    ) subq_33
+  ) subq_34
+) subq_35

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_60.average_booking_value) AS average_booking_value
-      , MAX(subq_73.bookings) AS bookings
-      , MAX(subq_81.booking_value) AS booking_value
+      MAX(subq_48.average_booking_value) AS average_booking_value
+      , MAX(subq_61.bookings) AS bookings
+      , MAX(subq_69.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_51.booking__is_instant AS booking__is_instant
+          subq_39.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_51.average_booking_value AS average_booking_value
+          , subq_39.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_49
+          ) subq_37
           WHERE booking__is_instant
-        ) subq_51
+        ) subq_39
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_51.listing = listings_latest_src_28000.listing_id
-      ) subq_56
+          subq_39.listing = listings_latest_src_28000.listing_id
+      ) subq_44
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_60
+    ) subq_48
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_64.booking__is_instant AS booking__is_instant
+          subq_52.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_64.bookings AS bookings
+          , subq_52.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_62
+          ) subq_50
           WHERE booking__is_instant
-        ) subq_64
+        ) subq_52
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_64.listing = listings_latest_src_28000.listing_id
-      ) subq_69
+          subq_52.listing = listings_latest_src_28000.listing_id
+      ) subq_57
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_73
+    ) subq_61
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_75
+        ) subq_63
         WHERE booking__is_instant
-      ) subq_77
+      ) subq_65
       WHERE booking__is_instant
-    ) subq_81
-  ) subq_82
-) subq_83
+    ) subq_69
+  ) subq_70
+) subq_71

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0.sql
@@ -8,248 +8,248 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_18.average_booking_value) AS average_booking_value
-      , MAX(subq_31.bookings) AS bookings
-      , MAX(subq_39.booking_value) AS booking_value
+      MAX(subq_12.average_booking_value) AS average_booking_value
+      , MAX(subq_25.bookings) AS bookings
+      , MAX(subq_33.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.average_booking_value
+        subq_11.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_16.average_booking_value) AS average_booking_value
+          AVG(subq_10.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_15.average_booking_value
+            subq_9.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.booking__is_instant
-              , subq_14.listing__is_lux_latest
-              , subq_14.average_booking_value
+              subq_8.booking__is_instant
+              , subq_8.listing__is_lux_latest
+              , subq_8.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_13.booking__is_instant
-                , subq_13.listing__is_lux_latest
-                , subq_13.average_booking_value
+                subq_7.booking__is_instant
+                , subq_7.listing__is_lux_latest
+                , subq_7.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_9.listing AS listing
-                  , subq_9.booking__is_instant AS booking__is_instant
-                  , subq_12.is_lux_latest AS listing__is_lux_latest
-                  , subq_9.average_booking_value AS average_booking_value
+                  subq_3.listing AS listing
+                  , subq_3.booking__is_instant AS booking__is_instant
+                  , subq_6.is_lux_latest AS listing__is_lux_latest
+                  , subq_3.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.booking__is_instant
-                    , subq_8.average_booking_value
+                    subq_2.listing
+                    , subq_2.booking__is_instant
+                    , subq_2.average_booking_value
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.metric_time__day
-                      , subq_7.metric_time__week
-                      , subq_7.metric_time__month
-                      , subq_7.metric_time__quarter
-                      , subq_7.metric_time__year
-                      , subq_7.metric_time__extract_year
-                      , subq_7.metric_time__extract_quarter
-                      , subq_7.metric_time__extract_month
-                      , subq_7.metric_time__extract_day
-                      , subq_7.metric_time__extract_dow
-                      , subq_7.metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_1.ds__day
+                      , subq_1.ds__week
+                      , subq_1.ds__month
+                      , subq_1.ds__quarter
+                      , subq_1.ds__year
+                      , subq_1.ds__extract_year
+                      , subq_1.ds__extract_quarter
+                      , subq_1.ds__extract_month
+                      , subq_1.ds__extract_day
+                      , subq_1.ds__extract_dow
+                      , subq_1.ds__extract_doy
+                      , subq_1.ds_partitioned__day
+                      , subq_1.ds_partitioned__week
+                      , subq_1.ds_partitioned__month
+                      , subq_1.ds_partitioned__quarter
+                      , subq_1.ds_partitioned__year
+                      , subq_1.ds_partitioned__extract_year
+                      , subq_1.ds_partitioned__extract_quarter
+                      , subq_1.ds_partitioned__extract_month
+                      , subq_1.ds_partitioned__extract_day
+                      , subq_1.ds_partitioned__extract_dow
+                      , subq_1.ds_partitioned__extract_doy
+                      , subq_1.paid_at__day
+                      , subq_1.paid_at__week
+                      , subq_1.paid_at__month
+                      , subq_1.paid_at__quarter
+                      , subq_1.paid_at__year
+                      , subq_1.paid_at__extract_year
+                      , subq_1.paid_at__extract_quarter
+                      , subq_1.paid_at__extract_month
+                      , subq_1.paid_at__extract_day
+                      , subq_1.paid_at__extract_dow
+                      , subq_1.paid_at__extract_doy
+                      , subq_1.booking__ds__day
+                      , subq_1.booking__ds__week
+                      , subq_1.booking__ds__month
+                      , subq_1.booking__ds__quarter
+                      , subq_1.booking__ds__year
+                      , subq_1.booking__ds__extract_year
+                      , subq_1.booking__ds__extract_quarter
+                      , subq_1.booking__ds__extract_month
+                      , subq_1.booking__ds__extract_day
+                      , subq_1.booking__ds__extract_dow
+                      , subq_1.booking__ds__extract_doy
+                      , subq_1.booking__ds_partitioned__day
+                      , subq_1.booking__ds_partitioned__week
+                      , subq_1.booking__ds_partitioned__month
+                      , subq_1.booking__ds_partitioned__quarter
+                      , subq_1.booking__ds_partitioned__year
+                      , subq_1.booking__ds_partitioned__extract_year
+                      , subq_1.booking__ds_partitioned__extract_quarter
+                      , subq_1.booking__ds_partitioned__extract_month
+                      , subq_1.booking__ds_partitioned__extract_day
+                      , subq_1.booking__ds_partitioned__extract_dow
+                      , subq_1.booking__ds_partitioned__extract_doy
+                      , subq_1.booking__paid_at__day
+                      , subq_1.booking__paid_at__week
+                      , subq_1.booking__paid_at__month
+                      , subq_1.booking__paid_at__quarter
+                      , subq_1.booking__paid_at__year
+                      , subq_1.booking__paid_at__extract_year
+                      , subq_1.booking__paid_at__extract_quarter
+                      , subq_1.booking__paid_at__extract_month
+                      , subq_1.booking__paid_at__extract_day
+                      , subq_1.booking__paid_at__extract_dow
+                      , subq_1.booking__paid_at__extract_doy
+                      , subq_1.metric_time__day
+                      , subq_1.metric_time__week
+                      , subq_1.metric_time__month
+                      , subq_1.metric_time__quarter
+                      , subq_1.metric_time__year
+                      , subq_1.metric_time__extract_year
+                      , subq_1.metric_time__extract_quarter
+                      , subq_1.metric_time__extract_month
+                      , subq_1.metric_time__extract_day
+                      , subq_1.metric_time__extract_dow
+                      , subq_1.metric_time__extract_doy
+                      , subq_1.listing
+                      , subq_1.guest
+                      , subq_1.host
+                      , subq_1.booking__listing
+                      , subq_1.booking__guest
+                      , subq_1.booking__host
+                      , subq_1.is_instant
+                      , subq_1.booking__is_instant
+                      , subq_1.bookings
+                      , subq_1.instant_bookings
+                      , subq_1.booking_value
+                      , subq_1.max_booking_value
+                      , subq_1.min_booking_value
+                      , subq_1.bookers
+                      , subq_1.average_booking_value
+                      , subq_1.referred_bookings
+                      , subq_1.median_booking_value
+                      , subq_1.booking_value_p99
+                      , subq_1.discrete_booking_value_p99
+                      , subq_1.approximate_continuous_booking_value_p99
+                      , subq_1.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_6.ds__day
-                        , subq_6.ds__week
-                        , subq_6.ds__month
-                        , subq_6.ds__quarter
-                        , subq_6.ds__year
-                        , subq_6.ds__extract_year
-                        , subq_6.ds__extract_quarter
-                        , subq_6.ds__extract_month
-                        , subq_6.ds__extract_day
-                        , subq_6.ds__extract_dow
-                        , subq_6.ds__extract_doy
-                        , subq_6.ds_partitioned__day
-                        , subq_6.ds_partitioned__week
-                        , subq_6.ds_partitioned__month
-                        , subq_6.ds_partitioned__quarter
-                        , subq_6.ds_partitioned__year
-                        , subq_6.ds_partitioned__extract_year
-                        , subq_6.ds_partitioned__extract_quarter
-                        , subq_6.ds_partitioned__extract_month
-                        , subq_6.ds_partitioned__extract_day
-                        , subq_6.ds_partitioned__extract_dow
-                        , subq_6.ds_partitioned__extract_doy
-                        , subq_6.paid_at__day
-                        , subq_6.paid_at__week
-                        , subq_6.paid_at__month
-                        , subq_6.paid_at__quarter
-                        , subq_6.paid_at__year
-                        , subq_6.paid_at__extract_year
-                        , subq_6.paid_at__extract_quarter
-                        , subq_6.paid_at__extract_month
-                        , subq_6.paid_at__extract_day
-                        , subq_6.paid_at__extract_dow
-                        , subq_6.paid_at__extract_doy
-                        , subq_6.booking__ds__day
-                        , subq_6.booking__ds__week
-                        , subq_6.booking__ds__month
-                        , subq_6.booking__ds__quarter
-                        , subq_6.booking__ds__year
-                        , subq_6.booking__ds__extract_year
-                        , subq_6.booking__ds__extract_quarter
-                        , subq_6.booking__ds__extract_month
-                        , subq_6.booking__ds__extract_day
-                        , subq_6.booking__ds__extract_dow
-                        , subq_6.booking__ds__extract_doy
-                        , subq_6.booking__ds_partitioned__day
-                        , subq_6.booking__ds_partitioned__week
-                        , subq_6.booking__ds_partitioned__month
-                        , subq_6.booking__ds_partitioned__quarter
-                        , subq_6.booking__ds_partitioned__year
-                        , subq_6.booking__ds_partitioned__extract_year
-                        , subq_6.booking__ds_partitioned__extract_quarter
-                        , subq_6.booking__ds_partitioned__extract_month
-                        , subq_6.booking__ds_partitioned__extract_day
-                        , subq_6.booking__ds_partitioned__extract_dow
-                        , subq_6.booking__ds_partitioned__extract_doy
-                        , subq_6.booking__paid_at__day
-                        , subq_6.booking__paid_at__week
-                        , subq_6.booking__paid_at__month
-                        , subq_6.booking__paid_at__quarter
-                        , subq_6.booking__paid_at__year
-                        , subq_6.booking__paid_at__extract_year
-                        , subq_6.booking__paid_at__extract_quarter
-                        , subq_6.booking__paid_at__extract_month
-                        , subq_6.booking__paid_at__extract_day
-                        , subq_6.booking__paid_at__extract_dow
-                        , subq_6.booking__paid_at__extract_doy
-                        , subq_6.ds__day AS metric_time__day
-                        , subq_6.ds__week AS metric_time__week
-                        , subq_6.ds__month AS metric_time__month
-                        , subq_6.ds__quarter AS metric_time__quarter
-                        , subq_6.ds__year AS metric_time__year
-                        , subq_6.ds__extract_year AS metric_time__extract_year
-                        , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_6.ds__extract_month AS metric_time__extract_month
-                        , subq_6.ds__extract_day AS metric_time__extract_day
-                        , subq_6.ds__extract_dow AS metric_time__extract_dow
-                        , subq_6.ds__extract_doy AS metric_time__extract_doy
-                        , subq_6.listing
-                        , subq_6.guest
-                        , subq_6.host
-                        , subq_6.booking__listing
-                        , subq_6.booking__guest
-                        , subq_6.booking__host
-                        , subq_6.is_instant
-                        , subq_6.booking__is_instant
-                        , subq_6.bookings
-                        , subq_6.instant_bookings
-                        , subq_6.booking_value
-                        , subq_6.max_booking_value
-                        , subq_6.min_booking_value
-                        , subq_6.bookers
-                        , subq_6.average_booking_value
-                        , subq_6.referred_bookings
-                        , subq_6.median_booking_value
-                        , subq_6.booking_value_p99
-                        , subq_6.discrete_booking_value_p99
-                        , subq_6.approximate_continuous_booking_value_p99
-                        , subq_6.approximate_discrete_booking_value_p99
+                        subq_0.ds__day
+                        , subq_0.ds__week
+                        , subq_0.ds__month
+                        , subq_0.ds__quarter
+                        , subq_0.ds__year
+                        , subq_0.ds__extract_year
+                        , subq_0.ds__extract_quarter
+                        , subq_0.ds__extract_month
+                        , subq_0.ds__extract_day
+                        , subq_0.ds__extract_dow
+                        , subq_0.ds__extract_doy
+                        , subq_0.ds_partitioned__day
+                        , subq_0.ds_partitioned__week
+                        , subq_0.ds_partitioned__month
+                        , subq_0.ds_partitioned__quarter
+                        , subq_0.ds_partitioned__year
+                        , subq_0.ds_partitioned__extract_year
+                        , subq_0.ds_partitioned__extract_quarter
+                        , subq_0.ds_partitioned__extract_month
+                        , subq_0.ds_partitioned__extract_day
+                        , subq_0.ds_partitioned__extract_dow
+                        , subq_0.ds_partitioned__extract_doy
+                        , subq_0.paid_at__day
+                        , subq_0.paid_at__week
+                        , subq_0.paid_at__month
+                        , subq_0.paid_at__quarter
+                        , subq_0.paid_at__year
+                        , subq_0.paid_at__extract_year
+                        , subq_0.paid_at__extract_quarter
+                        , subq_0.paid_at__extract_month
+                        , subq_0.paid_at__extract_day
+                        , subq_0.paid_at__extract_dow
+                        , subq_0.paid_at__extract_doy
+                        , subq_0.booking__ds__day
+                        , subq_0.booking__ds__week
+                        , subq_0.booking__ds__month
+                        , subq_0.booking__ds__quarter
+                        , subq_0.booking__ds__year
+                        , subq_0.booking__ds__extract_year
+                        , subq_0.booking__ds__extract_quarter
+                        , subq_0.booking__ds__extract_month
+                        , subq_0.booking__ds__extract_day
+                        , subq_0.booking__ds__extract_dow
+                        , subq_0.booking__ds__extract_doy
+                        , subq_0.booking__ds_partitioned__day
+                        , subq_0.booking__ds_partitioned__week
+                        , subq_0.booking__ds_partitioned__month
+                        , subq_0.booking__ds_partitioned__quarter
+                        , subq_0.booking__ds_partitioned__year
+                        , subq_0.booking__ds_partitioned__extract_year
+                        , subq_0.booking__ds_partitioned__extract_quarter
+                        , subq_0.booking__ds_partitioned__extract_month
+                        , subq_0.booking__ds_partitioned__extract_day
+                        , subq_0.booking__ds_partitioned__extract_dow
+                        , subq_0.booking__ds_partitioned__extract_doy
+                        , subq_0.booking__paid_at__day
+                        , subq_0.booking__paid_at__week
+                        , subq_0.booking__paid_at__month
+                        , subq_0.booking__paid_at__quarter
+                        , subq_0.booking__paid_at__year
+                        , subq_0.booking__paid_at__extract_year
+                        , subq_0.booking__paid_at__extract_quarter
+                        , subq_0.booking__paid_at__extract_month
+                        , subq_0.booking__paid_at__extract_day
+                        , subq_0.booking__paid_at__extract_dow
+                        , subq_0.booking__paid_at__extract_doy
+                        , subq_0.ds__day AS metric_time__day
+                        , subq_0.ds__week AS metric_time__week
+                        , subq_0.ds__month AS metric_time__month
+                        , subq_0.ds__quarter AS metric_time__quarter
+                        , subq_0.ds__year AS metric_time__year
+                        , subq_0.ds__extract_year AS metric_time__extract_year
+                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_0.ds__extract_month AS metric_time__extract_month
+                        , subq_0.ds__extract_day AS metric_time__extract_day
+                        , subq_0.ds__extract_dow AS metric_time__extract_dow
+                        , subq_0.ds__extract_doy AS metric_time__extract_doy
+                        , subq_0.listing
+                        , subq_0.guest
+                        , subq_0.host
+                        , subq_0.booking__listing
+                        , subq_0.booking__guest
+                        , subq_0.booking__host
+                        , subq_0.is_instant
+                        , subq_0.booking__is_instant
+                        , subq_0.bookings
+                        , subq_0.instant_bookings
+                        , subq_0.booking_value
+                        , subq_0.max_booking_value
+                        , subq_0.min_booking_value
+                        , subq_0.bookers
+                        , subq_0.average_booking_value
+                        , subq_0.referred_bookings
+                        , subq_0.median_booking_value
+                        , subq_0.booking_value_p99
+                        , subq_0.discrete_booking_value_p99
+                        , subq_0.approximate_continuous_booking_value_p99
+                        , subq_0.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -342,86 +342,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_6
-                    ) subq_7
+                      ) subq_0
+                    ) subq_1
                     WHERE booking__is_instant
-                  ) subq_8
-                ) subq_9
+                  ) subq_2
+                ) subq_3
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_11.listing
-                    , subq_11.is_lux_latest
+                    subq_5.listing
+                    , subq_5.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_10.ds__day
-                      , subq_10.ds__week
-                      , subq_10.ds__month
-                      , subq_10.ds__quarter
-                      , subq_10.ds__year
-                      , subq_10.ds__extract_year
-                      , subq_10.ds__extract_quarter
-                      , subq_10.ds__extract_month
-                      , subq_10.ds__extract_day
-                      , subq_10.ds__extract_dow
-                      , subq_10.ds__extract_doy
-                      , subq_10.created_at__day
-                      , subq_10.created_at__week
-                      , subq_10.created_at__month
-                      , subq_10.created_at__quarter
-                      , subq_10.created_at__year
-                      , subq_10.created_at__extract_year
-                      , subq_10.created_at__extract_quarter
-                      , subq_10.created_at__extract_month
-                      , subq_10.created_at__extract_day
-                      , subq_10.created_at__extract_dow
-                      , subq_10.created_at__extract_doy
-                      , subq_10.listing__ds__day
-                      , subq_10.listing__ds__week
-                      , subq_10.listing__ds__month
-                      , subq_10.listing__ds__quarter
-                      , subq_10.listing__ds__year
-                      , subq_10.listing__ds__extract_year
-                      , subq_10.listing__ds__extract_quarter
-                      , subq_10.listing__ds__extract_month
-                      , subq_10.listing__ds__extract_day
-                      , subq_10.listing__ds__extract_dow
-                      , subq_10.listing__ds__extract_doy
-                      , subq_10.listing__created_at__day
-                      , subq_10.listing__created_at__week
-                      , subq_10.listing__created_at__month
-                      , subq_10.listing__created_at__quarter
-                      , subq_10.listing__created_at__year
-                      , subq_10.listing__created_at__extract_year
-                      , subq_10.listing__created_at__extract_quarter
-                      , subq_10.listing__created_at__extract_month
-                      , subq_10.listing__created_at__extract_day
-                      , subq_10.listing__created_at__extract_dow
-                      , subq_10.listing__created_at__extract_doy
-                      , subq_10.ds__day AS metric_time__day
-                      , subq_10.ds__week AS metric_time__week
-                      , subq_10.ds__month AS metric_time__month
-                      , subq_10.ds__quarter AS metric_time__quarter
-                      , subq_10.ds__year AS metric_time__year
-                      , subq_10.ds__extract_year AS metric_time__extract_year
-                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_10.ds__extract_month AS metric_time__extract_month
-                      , subq_10.ds__extract_day AS metric_time__extract_day
-                      , subq_10.ds__extract_dow AS metric_time__extract_dow
-                      , subq_10.ds__extract_doy AS metric_time__extract_doy
-                      , subq_10.listing
-                      , subq_10.user
-                      , subq_10.listing__user
-                      , subq_10.country_latest
-                      , subq_10.is_lux_latest
-                      , subq_10.capacity_latest
-                      , subq_10.listing__country_latest
-                      , subq_10.listing__is_lux_latest
-                      , subq_10.listing__capacity_latest
-                      , subq_10.listings
-                      , subq_10.largest_listing
-                      , subq_10.smallest_listing
+                      subq_4.ds__day
+                      , subq_4.ds__week
+                      , subq_4.ds__month
+                      , subq_4.ds__quarter
+                      , subq_4.ds__year
+                      , subq_4.ds__extract_year
+                      , subq_4.ds__extract_quarter
+                      , subq_4.ds__extract_month
+                      , subq_4.ds__extract_day
+                      , subq_4.ds__extract_dow
+                      , subq_4.ds__extract_doy
+                      , subq_4.created_at__day
+                      , subq_4.created_at__week
+                      , subq_4.created_at__month
+                      , subq_4.created_at__quarter
+                      , subq_4.created_at__year
+                      , subq_4.created_at__extract_year
+                      , subq_4.created_at__extract_quarter
+                      , subq_4.created_at__extract_month
+                      , subq_4.created_at__extract_day
+                      , subq_4.created_at__extract_dow
+                      , subq_4.created_at__extract_doy
+                      , subq_4.listing__ds__day
+                      , subq_4.listing__ds__week
+                      , subq_4.listing__ds__month
+                      , subq_4.listing__ds__quarter
+                      , subq_4.listing__ds__year
+                      , subq_4.listing__ds__extract_year
+                      , subq_4.listing__ds__extract_quarter
+                      , subq_4.listing__ds__extract_month
+                      , subq_4.listing__ds__extract_day
+                      , subq_4.listing__ds__extract_dow
+                      , subq_4.listing__ds__extract_doy
+                      , subq_4.listing__created_at__day
+                      , subq_4.listing__created_at__week
+                      , subq_4.listing__created_at__month
+                      , subq_4.listing__created_at__quarter
+                      , subq_4.listing__created_at__year
+                      , subq_4.listing__created_at__extract_year
+                      , subq_4.listing__created_at__extract_quarter
+                      , subq_4.listing__created_at__extract_month
+                      , subq_4.listing__created_at__extract_day
+                      , subq_4.listing__created_at__extract_dow
+                      , subq_4.listing__created_at__extract_doy
+                      , subq_4.ds__day AS metric_time__day
+                      , subq_4.ds__week AS metric_time__week
+                      , subq_4.ds__month AS metric_time__month
+                      , subq_4.ds__quarter AS metric_time__quarter
+                      , subq_4.ds__year AS metric_time__year
+                      , subq_4.ds__extract_year AS metric_time__extract_year
+                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_4.ds__extract_month AS metric_time__extract_month
+                      , subq_4.ds__extract_day AS metric_time__extract_day
+                      , subq_4.ds__extract_dow AS metric_time__extract_dow
+                      , subq_4.ds__extract_doy AS metric_time__extract_doy
+                      , subq_4.listing
+                      , subq_4.user
+                      , subq_4.listing__user
+                      , subq_4.country_latest
+                      , subq_4.is_lux_latest
+                      , subq_4.capacity_latest
+                      , subq_4.listing__country_latest
+                      , subq_4.listing__is_lux_latest
+                      , subq_4.listing__capacity_latest
+                      , subq_4.listings
+                      , subq_4.largest_listing
+                      , subq_4.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,257 +482,257 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_10
-                  ) subq_11
-                ) subq_12
+                    ) subq_4
+                  ) subq_5
+                ) subq_6
                 ON
-                  subq_9.listing = subq_12.listing
-              ) subq_13
-            ) subq_14
+                  subq_3.listing = subq_6.listing
+              ) subq_7
+            ) subq_8
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_15
-        ) subq_16
-      ) subq_17
-    ) subq_18
+          ) subq_9
+        ) subq_10
+      ) subq_11
+    ) subq_12
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_30.bookings
+        subq_24.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_29.bookings) AS bookings
+          SUM(subq_23.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_28.bookings
+            subq_22.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_27.booking__is_instant
-              , subq_27.listing__is_lux_latest
-              , subq_27.bookings
+              subq_21.booking__is_instant
+              , subq_21.listing__is_lux_latest
+              , subq_21.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_26.booking__is_instant
-                , subq_26.listing__is_lux_latest
-                , subq_26.bookings
+                subq_20.booking__is_instant
+                , subq_20.listing__is_lux_latest
+                , subq_20.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_22.listing AS listing
-                  , subq_22.booking__is_instant AS booking__is_instant
-                  , subq_25.is_lux_latest AS listing__is_lux_latest
-                  , subq_22.bookings AS bookings
+                  subq_16.listing AS listing
+                  , subq_16.booking__is_instant AS booking__is_instant
+                  , subq_19.is_lux_latest AS listing__is_lux_latest
+                  , subq_16.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_21.listing
-                    , subq_21.booking__is_instant
-                    , subq_21.bookings
+                    subq_15.listing
+                    , subq_15.booking__is_instant
+                    , subq_15.bookings
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_20.ds__day
-                      , subq_20.ds__week
-                      , subq_20.ds__month
-                      , subq_20.ds__quarter
-                      , subq_20.ds__year
-                      , subq_20.ds__extract_year
-                      , subq_20.ds__extract_quarter
-                      , subq_20.ds__extract_month
-                      , subq_20.ds__extract_day
-                      , subq_20.ds__extract_dow
-                      , subq_20.ds__extract_doy
-                      , subq_20.ds_partitioned__day
-                      , subq_20.ds_partitioned__week
-                      , subq_20.ds_partitioned__month
-                      , subq_20.ds_partitioned__quarter
-                      , subq_20.ds_partitioned__year
-                      , subq_20.ds_partitioned__extract_year
-                      , subq_20.ds_partitioned__extract_quarter
-                      , subq_20.ds_partitioned__extract_month
-                      , subq_20.ds_partitioned__extract_day
-                      , subq_20.ds_partitioned__extract_dow
-                      , subq_20.ds_partitioned__extract_doy
-                      , subq_20.paid_at__day
-                      , subq_20.paid_at__week
-                      , subq_20.paid_at__month
-                      , subq_20.paid_at__quarter
-                      , subq_20.paid_at__year
-                      , subq_20.paid_at__extract_year
-                      , subq_20.paid_at__extract_quarter
-                      , subq_20.paid_at__extract_month
-                      , subq_20.paid_at__extract_day
-                      , subq_20.paid_at__extract_dow
-                      , subq_20.paid_at__extract_doy
-                      , subq_20.booking__ds__day
-                      , subq_20.booking__ds__week
-                      , subq_20.booking__ds__month
-                      , subq_20.booking__ds__quarter
-                      , subq_20.booking__ds__year
-                      , subq_20.booking__ds__extract_year
-                      , subq_20.booking__ds__extract_quarter
-                      , subq_20.booking__ds__extract_month
-                      , subq_20.booking__ds__extract_day
-                      , subq_20.booking__ds__extract_dow
-                      , subq_20.booking__ds__extract_doy
-                      , subq_20.booking__ds_partitioned__day
-                      , subq_20.booking__ds_partitioned__week
-                      , subq_20.booking__ds_partitioned__month
-                      , subq_20.booking__ds_partitioned__quarter
-                      , subq_20.booking__ds_partitioned__year
-                      , subq_20.booking__ds_partitioned__extract_year
-                      , subq_20.booking__ds_partitioned__extract_quarter
-                      , subq_20.booking__ds_partitioned__extract_month
-                      , subq_20.booking__ds_partitioned__extract_day
-                      , subq_20.booking__ds_partitioned__extract_dow
-                      , subq_20.booking__ds_partitioned__extract_doy
-                      , subq_20.booking__paid_at__day
-                      , subq_20.booking__paid_at__week
-                      , subq_20.booking__paid_at__month
-                      , subq_20.booking__paid_at__quarter
-                      , subq_20.booking__paid_at__year
-                      , subq_20.booking__paid_at__extract_year
-                      , subq_20.booking__paid_at__extract_quarter
-                      , subq_20.booking__paid_at__extract_month
-                      , subq_20.booking__paid_at__extract_day
-                      , subq_20.booking__paid_at__extract_dow
-                      , subq_20.booking__paid_at__extract_doy
-                      , subq_20.metric_time__day
-                      , subq_20.metric_time__week
-                      , subq_20.metric_time__month
-                      , subq_20.metric_time__quarter
-                      , subq_20.metric_time__year
-                      , subq_20.metric_time__extract_year
-                      , subq_20.metric_time__extract_quarter
-                      , subq_20.metric_time__extract_month
-                      , subq_20.metric_time__extract_day
-                      , subq_20.metric_time__extract_dow
-                      , subq_20.metric_time__extract_doy
-                      , subq_20.listing
-                      , subq_20.guest
-                      , subq_20.host
-                      , subq_20.booking__listing
-                      , subq_20.booking__guest
-                      , subq_20.booking__host
-                      , subq_20.is_instant
-                      , subq_20.booking__is_instant
-                      , subq_20.bookings
-                      , subq_20.instant_bookings
-                      , subq_20.booking_value
-                      , subq_20.max_booking_value
-                      , subq_20.min_booking_value
-                      , subq_20.bookers
-                      , subq_20.average_booking_value
-                      , subq_20.referred_bookings
-                      , subq_20.median_booking_value
-                      , subq_20.booking_value_p99
-                      , subq_20.discrete_booking_value_p99
-                      , subq_20.approximate_continuous_booking_value_p99
-                      , subq_20.approximate_discrete_booking_value_p99
+                      subq_14.ds__day
+                      , subq_14.ds__week
+                      , subq_14.ds__month
+                      , subq_14.ds__quarter
+                      , subq_14.ds__year
+                      , subq_14.ds__extract_year
+                      , subq_14.ds__extract_quarter
+                      , subq_14.ds__extract_month
+                      , subq_14.ds__extract_day
+                      , subq_14.ds__extract_dow
+                      , subq_14.ds__extract_doy
+                      , subq_14.ds_partitioned__day
+                      , subq_14.ds_partitioned__week
+                      , subq_14.ds_partitioned__month
+                      , subq_14.ds_partitioned__quarter
+                      , subq_14.ds_partitioned__year
+                      , subq_14.ds_partitioned__extract_year
+                      , subq_14.ds_partitioned__extract_quarter
+                      , subq_14.ds_partitioned__extract_month
+                      , subq_14.ds_partitioned__extract_day
+                      , subq_14.ds_partitioned__extract_dow
+                      , subq_14.ds_partitioned__extract_doy
+                      , subq_14.paid_at__day
+                      , subq_14.paid_at__week
+                      , subq_14.paid_at__month
+                      , subq_14.paid_at__quarter
+                      , subq_14.paid_at__year
+                      , subq_14.paid_at__extract_year
+                      , subq_14.paid_at__extract_quarter
+                      , subq_14.paid_at__extract_month
+                      , subq_14.paid_at__extract_day
+                      , subq_14.paid_at__extract_dow
+                      , subq_14.paid_at__extract_doy
+                      , subq_14.booking__ds__day
+                      , subq_14.booking__ds__week
+                      , subq_14.booking__ds__month
+                      , subq_14.booking__ds__quarter
+                      , subq_14.booking__ds__year
+                      , subq_14.booking__ds__extract_year
+                      , subq_14.booking__ds__extract_quarter
+                      , subq_14.booking__ds__extract_month
+                      , subq_14.booking__ds__extract_day
+                      , subq_14.booking__ds__extract_dow
+                      , subq_14.booking__ds__extract_doy
+                      , subq_14.booking__ds_partitioned__day
+                      , subq_14.booking__ds_partitioned__week
+                      , subq_14.booking__ds_partitioned__month
+                      , subq_14.booking__ds_partitioned__quarter
+                      , subq_14.booking__ds_partitioned__year
+                      , subq_14.booking__ds_partitioned__extract_year
+                      , subq_14.booking__ds_partitioned__extract_quarter
+                      , subq_14.booking__ds_partitioned__extract_month
+                      , subq_14.booking__ds_partitioned__extract_day
+                      , subq_14.booking__ds_partitioned__extract_dow
+                      , subq_14.booking__ds_partitioned__extract_doy
+                      , subq_14.booking__paid_at__day
+                      , subq_14.booking__paid_at__week
+                      , subq_14.booking__paid_at__month
+                      , subq_14.booking__paid_at__quarter
+                      , subq_14.booking__paid_at__year
+                      , subq_14.booking__paid_at__extract_year
+                      , subq_14.booking__paid_at__extract_quarter
+                      , subq_14.booking__paid_at__extract_month
+                      , subq_14.booking__paid_at__extract_day
+                      , subq_14.booking__paid_at__extract_dow
+                      , subq_14.booking__paid_at__extract_doy
+                      , subq_14.metric_time__day
+                      , subq_14.metric_time__week
+                      , subq_14.metric_time__month
+                      , subq_14.metric_time__quarter
+                      , subq_14.metric_time__year
+                      , subq_14.metric_time__extract_year
+                      , subq_14.metric_time__extract_quarter
+                      , subq_14.metric_time__extract_month
+                      , subq_14.metric_time__extract_day
+                      , subq_14.metric_time__extract_dow
+                      , subq_14.metric_time__extract_doy
+                      , subq_14.listing
+                      , subq_14.guest
+                      , subq_14.host
+                      , subq_14.booking__listing
+                      , subq_14.booking__guest
+                      , subq_14.booking__host
+                      , subq_14.is_instant
+                      , subq_14.booking__is_instant
+                      , subq_14.bookings
+                      , subq_14.instant_bookings
+                      , subq_14.booking_value
+                      , subq_14.max_booking_value
+                      , subq_14.min_booking_value
+                      , subq_14.bookers
+                      , subq_14.average_booking_value
+                      , subq_14.referred_bookings
+                      , subq_14.median_booking_value
+                      , subq_14.booking_value_p99
+                      , subq_14.discrete_booking_value_p99
+                      , subq_14.approximate_continuous_booking_value_p99
+                      , subq_14.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_19.ds__day
-                        , subq_19.ds__week
-                        , subq_19.ds__month
-                        , subq_19.ds__quarter
-                        , subq_19.ds__year
-                        , subq_19.ds__extract_year
-                        , subq_19.ds__extract_quarter
-                        , subq_19.ds__extract_month
-                        , subq_19.ds__extract_day
-                        , subq_19.ds__extract_dow
-                        , subq_19.ds__extract_doy
-                        , subq_19.ds_partitioned__day
-                        , subq_19.ds_partitioned__week
-                        , subq_19.ds_partitioned__month
-                        , subq_19.ds_partitioned__quarter
-                        , subq_19.ds_partitioned__year
-                        , subq_19.ds_partitioned__extract_year
-                        , subq_19.ds_partitioned__extract_quarter
-                        , subq_19.ds_partitioned__extract_month
-                        , subq_19.ds_partitioned__extract_day
-                        , subq_19.ds_partitioned__extract_dow
-                        , subq_19.ds_partitioned__extract_doy
-                        , subq_19.paid_at__day
-                        , subq_19.paid_at__week
-                        , subq_19.paid_at__month
-                        , subq_19.paid_at__quarter
-                        , subq_19.paid_at__year
-                        , subq_19.paid_at__extract_year
-                        , subq_19.paid_at__extract_quarter
-                        , subq_19.paid_at__extract_month
-                        , subq_19.paid_at__extract_day
-                        , subq_19.paid_at__extract_dow
-                        , subq_19.paid_at__extract_doy
-                        , subq_19.booking__ds__day
-                        , subq_19.booking__ds__week
-                        , subq_19.booking__ds__month
-                        , subq_19.booking__ds__quarter
-                        , subq_19.booking__ds__year
-                        , subq_19.booking__ds__extract_year
-                        , subq_19.booking__ds__extract_quarter
-                        , subq_19.booking__ds__extract_month
-                        , subq_19.booking__ds__extract_day
-                        , subq_19.booking__ds__extract_dow
-                        , subq_19.booking__ds__extract_doy
-                        , subq_19.booking__ds_partitioned__day
-                        , subq_19.booking__ds_partitioned__week
-                        , subq_19.booking__ds_partitioned__month
-                        , subq_19.booking__ds_partitioned__quarter
-                        , subq_19.booking__ds_partitioned__year
-                        , subq_19.booking__ds_partitioned__extract_year
-                        , subq_19.booking__ds_partitioned__extract_quarter
-                        , subq_19.booking__ds_partitioned__extract_month
-                        , subq_19.booking__ds_partitioned__extract_day
-                        , subq_19.booking__ds_partitioned__extract_dow
-                        , subq_19.booking__ds_partitioned__extract_doy
-                        , subq_19.booking__paid_at__day
-                        , subq_19.booking__paid_at__week
-                        , subq_19.booking__paid_at__month
-                        , subq_19.booking__paid_at__quarter
-                        , subq_19.booking__paid_at__year
-                        , subq_19.booking__paid_at__extract_year
-                        , subq_19.booking__paid_at__extract_quarter
-                        , subq_19.booking__paid_at__extract_month
-                        , subq_19.booking__paid_at__extract_day
-                        , subq_19.booking__paid_at__extract_dow
-                        , subq_19.booking__paid_at__extract_doy
-                        , subq_19.ds__day AS metric_time__day
-                        , subq_19.ds__week AS metric_time__week
-                        , subq_19.ds__month AS metric_time__month
-                        , subq_19.ds__quarter AS metric_time__quarter
-                        , subq_19.ds__year AS metric_time__year
-                        , subq_19.ds__extract_year AS metric_time__extract_year
-                        , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_19.ds__extract_month AS metric_time__extract_month
-                        , subq_19.ds__extract_day AS metric_time__extract_day
-                        , subq_19.ds__extract_dow AS metric_time__extract_dow
-                        , subq_19.ds__extract_doy AS metric_time__extract_doy
-                        , subq_19.listing
-                        , subq_19.guest
-                        , subq_19.host
-                        , subq_19.booking__listing
-                        , subq_19.booking__guest
-                        , subq_19.booking__host
-                        , subq_19.is_instant
-                        , subq_19.booking__is_instant
-                        , subq_19.bookings
-                        , subq_19.instant_bookings
-                        , subq_19.booking_value
-                        , subq_19.max_booking_value
-                        , subq_19.min_booking_value
-                        , subq_19.bookers
-                        , subq_19.average_booking_value
-                        , subq_19.referred_bookings
-                        , subq_19.median_booking_value
-                        , subq_19.booking_value_p99
-                        , subq_19.discrete_booking_value_p99
-                        , subq_19.approximate_continuous_booking_value_p99
-                        , subq_19.approximate_discrete_booking_value_p99
+                        subq_13.ds__day
+                        , subq_13.ds__week
+                        , subq_13.ds__month
+                        , subq_13.ds__quarter
+                        , subq_13.ds__year
+                        , subq_13.ds__extract_year
+                        , subq_13.ds__extract_quarter
+                        , subq_13.ds__extract_month
+                        , subq_13.ds__extract_day
+                        , subq_13.ds__extract_dow
+                        , subq_13.ds__extract_doy
+                        , subq_13.ds_partitioned__day
+                        , subq_13.ds_partitioned__week
+                        , subq_13.ds_partitioned__month
+                        , subq_13.ds_partitioned__quarter
+                        , subq_13.ds_partitioned__year
+                        , subq_13.ds_partitioned__extract_year
+                        , subq_13.ds_partitioned__extract_quarter
+                        , subq_13.ds_partitioned__extract_month
+                        , subq_13.ds_partitioned__extract_day
+                        , subq_13.ds_partitioned__extract_dow
+                        , subq_13.ds_partitioned__extract_doy
+                        , subq_13.paid_at__day
+                        , subq_13.paid_at__week
+                        , subq_13.paid_at__month
+                        , subq_13.paid_at__quarter
+                        , subq_13.paid_at__year
+                        , subq_13.paid_at__extract_year
+                        , subq_13.paid_at__extract_quarter
+                        , subq_13.paid_at__extract_month
+                        , subq_13.paid_at__extract_day
+                        , subq_13.paid_at__extract_dow
+                        , subq_13.paid_at__extract_doy
+                        , subq_13.booking__ds__day
+                        , subq_13.booking__ds__week
+                        , subq_13.booking__ds__month
+                        , subq_13.booking__ds__quarter
+                        , subq_13.booking__ds__year
+                        , subq_13.booking__ds__extract_year
+                        , subq_13.booking__ds__extract_quarter
+                        , subq_13.booking__ds__extract_month
+                        , subq_13.booking__ds__extract_day
+                        , subq_13.booking__ds__extract_dow
+                        , subq_13.booking__ds__extract_doy
+                        , subq_13.booking__ds_partitioned__day
+                        , subq_13.booking__ds_partitioned__week
+                        , subq_13.booking__ds_partitioned__month
+                        , subq_13.booking__ds_partitioned__quarter
+                        , subq_13.booking__ds_partitioned__year
+                        , subq_13.booking__ds_partitioned__extract_year
+                        , subq_13.booking__ds_partitioned__extract_quarter
+                        , subq_13.booking__ds_partitioned__extract_month
+                        , subq_13.booking__ds_partitioned__extract_day
+                        , subq_13.booking__ds_partitioned__extract_dow
+                        , subq_13.booking__ds_partitioned__extract_doy
+                        , subq_13.booking__paid_at__day
+                        , subq_13.booking__paid_at__week
+                        , subq_13.booking__paid_at__month
+                        , subq_13.booking__paid_at__quarter
+                        , subq_13.booking__paid_at__year
+                        , subq_13.booking__paid_at__extract_year
+                        , subq_13.booking__paid_at__extract_quarter
+                        , subq_13.booking__paid_at__extract_month
+                        , subq_13.booking__paid_at__extract_day
+                        , subq_13.booking__paid_at__extract_dow
+                        , subq_13.booking__paid_at__extract_doy
+                        , subq_13.ds__day AS metric_time__day
+                        , subq_13.ds__week AS metric_time__week
+                        , subq_13.ds__month AS metric_time__month
+                        , subq_13.ds__quarter AS metric_time__quarter
+                        , subq_13.ds__year AS metric_time__year
+                        , subq_13.ds__extract_year AS metric_time__extract_year
+                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_13.ds__extract_month AS metric_time__extract_month
+                        , subq_13.ds__extract_day AS metric_time__extract_day
+                        , subq_13.ds__extract_dow AS metric_time__extract_dow
+                        , subq_13.ds__extract_doy AS metric_time__extract_doy
+                        , subq_13.listing
+                        , subq_13.guest
+                        , subq_13.host
+                        , subq_13.booking__listing
+                        , subq_13.booking__guest
+                        , subq_13.booking__host
+                        , subq_13.is_instant
+                        , subq_13.booking__is_instant
+                        , subq_13.bookings
+                        , subq_13.instant_bookings
+                        , subq_13.booking_value
+                        , subq_13.max_booking_value
+                        , subq_13.min_booking_value
+                        , subq_13.bookers
+                        , subq_13.average_booking_value
+                        , subq_13.referred_bookings
+                        , subq_13.median_booking_value
+                        , subq_13.booking_value_p99
+                        , subq_13.discrete_booking_value_p99
+                        , subq_13.approximate_continuous_booking_value_p99
+                        , subq_13.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -825,86 +825,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_19
-                    ) subq_20
+                      ) subq_13
+                    ) subq_14
                     WHERE booking__is_instant
-                  ) subq_21
-                ) subq_22
+                  ) subq_15
+                ) subq_16
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_24.listing
-                    , subq_24.is_lux_latest
+                    subq_18.listing
+                    , subq_18.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_23.ds__day
-                      , subq_23.ds__week
-                      , subq_23.ds__month
-                      , subq_23.ds__quarter
-                      , subq_23.ds__year
-                      , subq_23.ds__extract_year
-                      , subq_23.ds__extract_quarter
-                      , subq_23.ds__extract_month
-                      , subq_23.ds__extract_day
-                      , subq_23.ds__extract_dow
-                      , subq_23.ds__extract_doy
-                      , subq_23.created_at__day
-                      , subq_23.created_at__week
-                      , subq_23.created_at__month
-                      , subq_23.created_at__quarter
-                      , subq_23.created_at__year
-                      , subq_23.created_at__extract_year
-                      , subq_23.created_at__extract_quarter
-                      , subq_23.created_at__extract_month
-                      , subq_23.created_at__extract_day
-                      , subq_23.created_at__extract_dow
-                      , subq_23.created_at__extract_doy
-                      , subq_23.listing__ds__day
-                      , subq_23.listing__ds__week
-                      , subq_23.listing__ds__month
-                      , subq_23.listing__ds__quarter
-                      , subq_23.listing__ds__year
-                      , subq_23.listing__ds__extract_year
-                      , subq_23.listing__ds__extract_quarter
-                      , subq_23.listing__ds__extract_month
-                      , subq_23.listing__ds__extract_day
-                      , subq_23.listing__ds__extract_dow
-                      , subq_23.listing__ds__extract_doy
-                      , subq_23.listing__created_at__day
-                      , subq_23.listing__created_at__week
-                      , subq_23.listing__created_at__month
-                      , subq_23.listing__created_at__quarter
-                      , subq_23.listing__created_at__year
-                      , subq_23.listing__created_at__extract_year
-                      , subq_23.listing__created_at__extract_quarter
-                      , subq_23.listing__created_at__extract_month
-                      , subq_23.listing__created_at__extract_day
-                      , subq_23.listing__created_at__extract_dow
-                      , subq_23.listing__created_at__extract_doy
-                      , subq_23.ds__day AS metric_time__day
-                      , subq_23.ds__week AS metric_time__week
-                      , subq_23.ds__month AS metric_time__month
-                      , subq_23.ds__quarter AS metric_time__quarter
-                      , subq_23.ds__year AS metric_time__year
-                      , subq_23.ds__extract_year AS metric_time__extract_year
-                      , subq_23.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_23.ds__extract_month AS metric_time__extract_month
-                      , subq_23.ds__extract_day AS metric_time__extract_day
-                      , subq_23.ds__extract_dow AS metric_time__extract_dow
-                      , subq_23.ds__extract_doy AS metric_time__extract_doy
-                      , subq_23.listing
-                      , subq_23.user
-                      , subq_23.listing__user
-                      , subq_23.country_latest
-                      , subq_23.is_lux_latest
-                      , subq_23.capacity_latest
-                      , subq_23.listing__country_latest
-                      , subq_23.listing__is_lux_latest
-                      , subq_23.listing__capacity_latest
-                      , subq_23.listings
-                      , subq_23.largest_listing
-                      , subq_23.smallest_listing
+                      subq_17.ds__day
+                      , subq_17.ds__week
+                      , subq_17.ds__month
+                      , subq_17.ds__quarter
+                      , subq_17.ds__year
+                      , subq_17.ds__extract_year
+                      , subq_17.ds__extract_quarter
+                      , subq_17.ds__extract_month
+                      , subq_17.ds__extract_day
+                      , subq_17.ds__extract_dow
+                      , subq_17.ds__extract_doy
+                      , subq_17.created_at__day
+                      , subq_17.created_at__week
+                      , subq_17.created_at__month
+                      , subq_17.created_at__quarter
+                      , subq_17.created_at__year
+                      , subq_17.created_at__extract_year
+                      , subq_17.created_at__extract_quarter
+                      , subq_17.created_at__extract_month
+                      , subq_17.created_at__extract_day
+                      , subq_17.created_at__extract_dow
+                      , subq_17.created_at__extract_doy
+                      , subq_17.listing__ds__day
+                      , subq_17.listing__ds__week
+                      , subq_17.listing__ds__month
+                      , subq_17.listing__ds__quarter
+                      , subq_17.listing__ds__year
+                      , subq_17.listing__ds__extract_year
+                      , subq_17.listing__ds__extract_quarter
+                      , subq_17.listing__ds__extract_month
+                      , subq_17.listing__ds__extract_day
+                      , subq_17.listing__ds__extract_dow
+                      , subq_17.listing__ds__extract_doy
+                      , subq_17.listing__created_at__day
+                      , subq_17.listing__created_at__week
+                      , subq_17.listing__created_at__month
+                      , subq_17.listing__created_at__quarter
+                      , subq_17.listing__created_at__year
+                      , subq_17.listing__created_at__extract_year
+                      , subq_17.listing__created_at__extract_quarter
+                      , subq_17.listing__created_at__extract_month
+                      , subq_17.listing__created_at__extract_day
+                      , subq_17.listing__created_at__extract_dow
+                      , subq_17.listing__created_at__extract_doy
+                      , subq_17.ds__day AS metric_time__day
+                      , subq_17.ds__week AS metric_time__week
+                      , subq_17.ds__month AS metric_time__month
+                      , subq_17.ds__quarter AS metric_time__quarter
+                      , subq_17.ds__year AS metric_time__year
+                      , subq_17.ds__extract_year AS metric_time__extract_year
+                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_17.ds__extract_month AS metric_time__extract_month
+                      , subq_17.ds__extract_day AS metric_time__extract_day
+                      , subq_17.ds__extract_dow AS metric_time__extract_dow
+                      , subq_17.ds__extract_doy AS metric_time__extract_doy
+                      , subq_17.listing
+                      , subq_17.user
+                      , subq_17.listing__user
+                      , subq_17.country_latest
+                      , subq_17.is_lux_latest
+                      , subq_17.capacity_latest
+                      , subq_17.listing__country_latest
+                      , subq_17.listing__is_lux_latest
+                      , subq_17.listing__capacity_latest
+                      , subq_17.listings
+                      , subq_17.largest_listing
+                      , subq_17.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,242 +965,242 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_23
-                  ) subq_24
-                ) subq_25
+                    ) subq_17
+                  ) subq_18
+                ) subq_19
                 ON
-                  subq_22.listing = subq_25.listing
-              ) subq_26
-            ) subq_27
+                  subq_16.listing = subq_19.listing
+              ) subq_20
+            ) subq_21
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_28
-        ) subq_29
-      ) subq_30
-    ) subq_31
+          ) subq_22
+        ) subq_23
+      ) subq_24
+    ) subq_25
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_38.booking_value
+        subq_32.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_37.booking_value) AS booking_value
+          SUM(subq_31.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_36.booking_value
+            subq_30.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_35.booking__is_instant
-              , subq_35.booking_value
+              subq_29.booking__is_instant
+              , subq_29.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_34.booking__is_instant
-                , subq_34.booking_value
+                subq_28.booking__is_instant
+                , subq_28.booking_value
               FROM (
                 -- Constrain Output with WHERE
                 SELECT
-                  subq_33.ds__day
-                  , subq_33.ds__week
-                  , subq_33.ds__month
-                  , subq_33.ds__quarter
-                  , subq_33.ds__year
-                  , subq_33.ds__extract_year
-                  , subq_33.ds__extract_quarter
-                  , subq_33.ds__extract_month
-                  , subq_33.ds__extract_day
-                  , subq_33.ds__extract_dow
-                  , subq_33.ds__extract_doy
-                  , subq_33.ds_partitioned__day
-                  , subq_33.ds_partitioned__week
-                  , subq_33.ds_partitioned__month
-                  , subq_33.ds_partitioned__quarter
-                  , subq_33.ds_partitioned__year
-                  , subq_33.ds_partitioned__extract_year
-                  , subq_33.ds_partitioned__extract_quarter
-                  , subq_33.ds_partitioned__extract_month
-                  , subq_33.ds_partitioned__extract_day
-                  , subq_33.ds_partitioned__extract_dow
-                  , subq_33.ds_partitioned__extract_doy
-                  , subq_33.paid_at__day
-                  , subq_33.paid_at__week
-                  , subq_33.paid_at__month
-                  , subq_33.paid_at__quarter
-                  , subq_33.paid_at__year
-                  , subq_33.paid_at__extract_year
-                  , subq_33.paid_at__extract_quarter
-                  , subq_33.paid_at__extract_month
-                  , subq_33.paid_at__extract_day
-                  , subq_33.paid_at__extract_dow
-                  , subq_33.paid_at__extract_doy
-                  , subq_33.booking__ds__day
-                  , subq_33.booking__ds__week
-                  , subq_33.booking__ds__month
-                  , subq_33.booking__ds__quarter
-                  , subq_33.booking__ds__year
-                  , subq_33.booking__ds__extract_year
-                  , subq_33.booking__ds__extract_quarter
-                  , subq_33.booking__ds__extract_month
-                  , subq_33.booking__ds__extract_day
-                  , subq_33.booking__ds__extract_dow
-                  , subq_33.booking__ds__extract_doy
-                  , subq_33.booking__ds_partitioned__day
-                  , subq_33.booking__ds_partitioned__week
-                  , subq_33.booking__ds_partitioned__month
-                  , subq_33.booking__ds_partitioned__quarter
-                  , subq_33.booking__ds_partitioned__year
-                  , subq_33.booking__ds_partitioned__extract_year
-                  , subq_33.booking__ds_partitioned__extract_quarter
-                  , subq_33.booking__ds_partitioned__extract_month
-                  , subq_33.booking__ds_partitioned__extract_day
-                  , subq_33.booking__ds_partitioned__extract_dow
-                  , subq_33.booking__ds_partitioned__extract_doy
-                  , subq_33.booking__paid_at__day
-                  , subq_33.booking__paid_at__week
-                  , subq_33.booking__paid_at__month
-                  , subq_33.booking__paid_at__quarter
-                  , subq_33.booking__paid_at__year
-                  , subq_33.booking__paid_at__extract_year
-                  , subq_33.booking__paid_at__extract_quarter
-                  , subq_33.booking__paid_at__extract_month
-                  , subq_33.booking__paid_at__extract_day
-                  , subq_33.booking__paid_at__extract_dow
-                  , subq_33.booking__paid_at__extract_doy
-                  , subq_33.metric_time__day
-                  , subq_33.metric_time__week
-                  , subq_33.metric_time__month
-                  , subq_33.metric_time__quarter
-                  , subq_33.metric_time__year
-                  , subq_33.metric_time__extract_year
-                  , subq_33.metric_time__extract_quarter
-                  , subq_33.metric_time__extract_month
-                  , subq_33.metric_time__extract_day
-                  , subq_33.metric_time__extract_dow
-                  , subq_33.metric_time__extract_doy
-                  , subq_33.listing
-                  , subq_33.guest
-                  , subq_33.host
-                  , subq_33.booking__listing
-                  , subq_33.booking__guest
-                  , subq_33.booking__host
-                  , subq_33.is_instant
-                  , subq_33.booking__is_instant
-                  , subq_33.bookings
-                  , subq_33.instant_bookings
-                  , subq_33.booking_value
-                  , subq_33.max_booking_value
-                  , subq_33.min_booking_value
-                  , subq_33.bookers
-                  , subq_33.average_booking_value
-                  , subq_33.referred_bookings
-                  , subq_33.median_booking_value
-                  , subq_33.booking_value_p99
-                  , subq_33.discrete_booking_value_p99
-                  , subq_33.approximate_continuous_booking_value_p99
-                  , subq_33.approximate_discrete_booking_value_p99
+                  subq_27.ds__day
+                  , subq_27.ds__week
+                  , subq_27.ds__month
+                  , subq_27.ds__quarter
+                  , subq_27.ds__year
+                  , subq_27.ds__extract_year
+                  , subq_27.ds__extract_quarter
+                  , subq_27.ds__extract_month
+                  , subq_27.ds__extract_day
+                  , subq_27.ds__extract_dow
+                  , subq_27.ds__extract_doy
+                  , subq_27.ds_partitioned__day
+                  , subq_27.ds_partitioned__week
+                  , subq_27.ds_partitioned__month
+                  , subq_27.ds_partitioned__quarter
+                  , subq_27.ds_partitioned__year
+                  , subq_27.ds_partitioned__extract_year
+                  , subq_27.ds_partitioned__extract_quarter
+                  , subq_27.ds_partitioned__extract_month
+                  , subq_27.ds_partitioned__extract_day
+                  , subq_27.ds_partitioned__extract_dow
+                  , subq_27.ds_partitioned__extract_doy
+                  , subq_27.paid_at__day
+                  , subq_27.paid_at__week
+                  , subq_27.paid_at__month
+                  , subq_27.paid_at__quarter
+                  , subq_27.paid_at__year
+                  , subq_27.paid_at__extract_year
+                  , subq_27.paid_at__extract_quarter
+                  , subq_27.paid_at__extract_month
+                  , subq_27.paid_at__extract_day
+                  , subq_27.paid_at__extract_dow
+                  , subq_27.paid_at__extract_doy
+                  , subq_27.booking__ds__day
+                  , subq_27.booking__ds__week
+                  , subq_27.booking__ds__month
+                  , subq_27.booking__ds__quarter
+                  , subq_27.booking__ds__year
+                  , subq_27.booking__ds__extract_year
+                  , subq_27.booking__ds__extract_quarter
+                  , subq_27.booking__ds__extract_month
+                  , subq_27.booking__ds__extract_day
+                  , subq_27.booking__ds__extract_dow
+                  , subq_27.booking__ds__extract_doy
+                  , subq_27.booking__ds_partitioned__day
+                  , subq_27.booking__ds_partitioned__week
+                  , subq_27.booking__ds_partitioned__month
+                  , subq_27.booking__ds_partitioned__quarter
+                  , subq_27.booking__ds_partitioned__year
+                  , subq_27.booking__ds_partitioned__extract_year
+                  , subq_27.booking__ds_partitioned__extract_quarter
+                  , subq_27.booking__ds_partitioned__extract_month
+                  , subq_27.booking__ds_partitioned__extract_day
+                  , subq_27.booking__ds_partitioned__extract_dow
+                  , subq_27.booking__ds_partitioned__extract_doy
+                  , subq_27.booking__paid_at__day
+                  , subq_27.booking__paid_at__week
+                  , subq_27.booking__paid_at__month
+                  , subq_27.booking__paid_at__quarter
+                  , subq_27.booking__paid_at__year
+                  , subq_27.booking__paid_at__extract_year
+                  , subq_27.booking__paid_at__extract_quarter
+                  , subq_27.booking__paid_at__extract_month
+                  , subq_27.booking__paid_at__extract_day
+                  , subq_27.booking__paid_at__extract_dow
+                  , subq_27.booking__paid_at__extract_doy
+                  , subq_27.metric_time__day
+                  , subq_27.metric_time__week
+                  , subq_27.metric_time__month
+                  , subq_27.metric_time__quarter
+                  , subq_27.metric_time__year
+                  , subq_27.metric_time__extract_year
+                  , subq_27.metric_time__extract_quarter
+                  , subq_27.metric_time__extract_month
+                  , subq_27.metric_time__extract_day
+                  , subq_27.metric_time__extract_dow
+                  , subq_27.metric_time__extract_doy
+                  , subq_27.listing
+                  , subq_27.guest
+                  , subq_27.host
+                  , subq_27.booking__listing
+                  , subq_27.booking__guest
+                  , subq_27.booking__host
+                  , subq_27.is_instant
+                  , subq_27.booking__is_instant
+                  , subq_27.bookings
+                  , subq_27.instant_bookings
+                  , subq_27.booking_value
+                  , subq_27.max_booking_value
+                  , subq_27.min_booking_value
+                  , subq_27.bookers
+                  , subq_27.average_booking_value
+                  , subq_27.referred_bookings
+                  , subq_27.median_booking_value
+                  , subq_27.booking_value_p99
+                  , subq_27.discrete_booking_value_p99
+                  , subq_27.approximate_continuous_booking_value_p99
+                  , subq_27.approximate_discrete_booking_value_p99
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_32.ds__day
-                    , subq_32.ds__week
-                    , subq_32.ds__month
-                    , subq_32.ds__quarter
-                    , subq_32.ds__year
-                    , subq_32.ds__extract_year
-                    , subq_32.ds__extract_quarter
-                    , subq_32.ds__extract_month
-                    , subq_32.ds__extract_day
-                    , subq_32.ds__extract_dow
-                    , subq_32.ds__extract_doy
-                    , subq_32.ds_partitioned__day
-                    , subq_32.ds_partitioned__week
-                    , subq_32.ds_partitioned__month
-                    , subq_32.ds_partitioned__quarter
-                    , subq_32.ds_partitioned__year
-                    , subq_32.ds_partitioned__extract_year
-                    , subq_32.ds_partitioned__extract_quarter
-                    , subq_32.ds_partitioned__extract_month
-                    , subq_32.ds_partitioned__extract_day
-                    , subq_32.ds_partitioned__extract_dow
-                    , subq_32.ds_partitioned__extract_doy
-                    , subq_32.paid_at__day
-                    , subq_32.paid_at__week
-                    , subq_32.paid_at__month
-                    , subq_32.paid_at__quarter
-                    , subq_32.paid_at__year
-                    , subq_32.paid_at__extract_year
-                    , subq_32.paid_at__extract_quarter
-                    , subq_32.paid_at__extract_month
-                    , subq_32.paid_at__extract_day
-                    , subq_32.paid_at__extract_dow
-                    , subq_32.paid_at__extract_doy
-                    , subq_32.booking__ds__day
-                    , subq_32.booking__ds__week
-                    , subq_32.booking__ds__month
-                    , subq_32.booking__ds__quarter
-                    , subq_32.booking__ds__year
-                    , subq_32.booking__ds__extract_year
-                    , subq_32.booking__ds__extract_quarter
-                    , subq_32.booking__ds__extract_month
-                    , subq_32.booking__ds__extract_day
-                    , subq_32.booking__ds__extract_dow
-                    , subq_32.booking__ds__extract_doy
-                    , subq_32.booking__ds_partitioned__day
-                    , subq_32.booking__ds_partitioned__week
-                    , subq_32.booking__ds_partitioned__month
-                    , subq_32.booking__ds_partitioned__quarter
-                    , subq_32.booking__ds_partitioned__year
-                    , subq_32.booking__ds_partitioned__extract_year
-                    , subq_32.booking__ds_partitioned__extract_quarter
-                    , subq_32.booking__ds_partitioned__extract_month
-                    , subq_32.booking__ds_partitioned__extract_day
-                    , subq_32.booking__ds_partitioned__extract_dow
-                    , subq_32.booking__ds_partitioned__extract_doy
-                    , subq_32.booking__paid_at__day
-                    , subq_32.booking__paid_at__week
-                    , subq_32.booking__paid_at__month
-                    , subq_32.booking__paid_at__quarter
-                    , subq_32.booking__paid_at__year
-                    , subq_32.booking__paid_at__extract_year
-                    , subq_32.booking__paid_at__extract_quarter
-                    , subq_32.booking__paid_at__extract_month
-                    , subq_32.booking__paid_at__extract_day
-                    , subq_32.booking__paid_at__extract_dow
-                    , subq_32.booking__paid_at__extract_doy
-                    , subq_32.ds__day AS metric_time__day
-                    , subq_32.ds__week AS metric_time__week
-                    , subq_32.ds__month AS metric_time__month
-                    , subq_32.ds__quarter AS metric_time__quarter
-                    , subq_32.ds__year AS metric_time__year
-                    , subq_32.ds__extract_year AS metric_time__extract_year
-                    , subq_32.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_32.ds__extract_month AS metric_time__extract_month
-                    , subq_32.ds__extract_day AS metric_time__extract_day
-                    , subq_32.ds__extract_dow AS metric_time__extract_dow
-                    , subq_32.ds__extract_doy AS metric_time__extract_doy
-                    , subq_32.listing
-                    , subq_32.guest
-                    , subq_32.host
-                    , subq_32.booking__listing
-                    , subq_32.booking__guest
-                    , subq_32.booking__host
-                    , subq_32.is_instant
-                    , subq_32.booking__is_instant
-                    , subq_32.bookings
-                    , subq_32.instant_bookings
-                    , subq_32.booking_value
-                    , subq_32.max_booking_value
-                    , subq_32.min_booking_value
-                    , subq_32.bookers
-                    , subq_32.average_booking_value
-                    , subq_32.referred_bookings
-                    , subq_32.median_booking_value
-                    , subq_32.booking_value_p99
-                    , subq_32.discrete_booking_value_p99
-                    , subq_32.approximate_continuous_booking_value_p99
-                    , subq_32.approximate_discrete_booking_value_p99
+                    subq_26.ds__day
+                    , subq_26.ds__week
+                    , subq_26.ds__month
+                    , subq_26.ds__quarter
+                    , subq_26.ds__year
+                    , subq_26.ds__extract_year
+                    , subq_26.ds__extract_quarter
+                    , subq_26.ds__extract_month
+                    , subq_26.ds__extract_day
+                    , subq_26.ds__extract_dow
+                    , subq_26.ds__extract_doy
+                    , subq_26.ds_partitioned__day
+                    , subq_26.ds_partitioned__week
+                    , subq_26.ds_partitioned__month
+                    , subq_26.ds_partitioned__quarter
+                    , subq_26.ds_partitioned__year
+                    , subq_26.ds_partitioned__extract_year
+                    , subq_26.ds_partitioned__extract_quarter
+                    , subq_26.ds_partitioned__extract_month
+                    , subq_26.ds_partitioned__extract_day
+                    , subq_26.ds_partitioned__extract_dow
+                    , subq_26.ds_partitioned__extract_doy
+                    , subq_26.paid_at__day
+                    , subq_26.paid_at__week
+                    , subq_26.paid_at__month
+                    , subq_26.paid_at__quarter
+                    , subq_26.paid_at__year
+                    , subq_26.paid_at__extract_year
+                    , subq_26.paid_at__extract_quarter
+                    , subq_26.paid_at__extract_month
+                    , subq_26.paid_at__extract_day
+                    , subq_26.paid_at__extract_dow
+                    , subq_26.paid_at__extract_doy
+                    , subq_26.booking__ds__day
+                    , subq_26.booking__ds__week
+                    , subq_26.booking__ds__month
+                    , subq_26.booking__ds__quarter
+                    , subq_26.booking__ds__year
+                    , subq_26.booking__ds__extract_year
+                    , subq_26.booking__ds__extract_quarter
+                    , subq_26.booking__ds__extract_month
+                    , subq_26.booking__ds__extract_day
+                    , subq_26.booking__ds__extract_dow
+                    , subq_26.booking__ds__extract_doy
+                    , subq_26.booking__ds_partitioned__day
+                    , subq_26.booking__ds_partitioned__week
+                    , subq_26.booking__ds_partitioned__month
+                    , subq_26.booking__ds_partitioned__quarter
+                    , subq_26.booking__ds_partitioned__year
+                    , subq_26.booking__ds_partitioned__extract_year
+                    , subq_26.booking__ds_partitioned__extract_quarter
+                    , subq_26.booking__ds_partitioned__extract_month
+                    , subq_26.booking__ds_partitioned__extract_day
+                    , subq_26.booking__ds_partitioned__extract_dow
+                    , subq_26.booking__ds_partitioned__extract_doy
+                    , subq_26.booking__paid_at__day
+                    , subq_26.booking__paid_at__week
+                    , subq_26.booking__paid_at__month
+                    , subq_26.booking__paid_at__quarter
+                    , subq_26.booking__paid_at__year
+                    , subq_26.booking__paid_at__extract_year
+                    , subq_26.booking__paid_at__extract_quarter
+                    , subq_26.booking__paid_at__extract_month
+                    , subq_26.booking__paid_at__extract_day
+                    , subq_26.booking__paid_at__extract_dow
+                    , subq_26.booking__paid_at__extract_doy
+                    , subq_26.ds__day AS metric_time__day
+                    , subq_26.ds__week AS metric_time__week
+                    , subq_26.ds__month AS metric_time__month
+                    , subq_26.ds__quarter AS metric_time__quarter
+                    , subq_26.ds__year AS metric_time__year
+                    , subq_26.ds__extract_year AS metric_time__extract_year
+                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_26.ds__extract_month AS metric_time__extract_month
+                    , subq_26.ds__extract_day AS metric_time__extract_day
+                    , subq_26.ds__extract_dow AS metric_time__extract_dow
+                    , subq_26.ds__extract_doy AS metric_time__extract_doy
+                    , subq_26.listing
+                    , subq_26.guest
+                    , subq_26.host
+                    , subq_26.booking__listing
+                    , subq_26.booking__guest
+                    , subq_26.booking__host
+                    , subq_26.is_instant
+                    , subq_26.booking__is_instant
+                    , subq_26.bookings
+                    , subq_26.instant_bookings
+                    , subq_26.booking_value
+                    , subq_26.max_booking_value
+                    , subq_26.min_booking_value
+                    , subq_26.bookers
+                    , subq_26.average_booking_value
+                    , subq_26.referred_bookings
+                    , subq_26.median_booking_value
+                    , subq_26.booking_value_p99
+                    , subq_26.discrete_booking_value_p99
+                    , subq_26.approximate_continuous_booking_value_p99
+                    , subq_26.approximate_discrete_booking_value_p99
                   FROM (
                     -- Read Elements From Semantic Model 'bookings_source'
                     SELECT
@@ -1293,15 +1293,15 @@ FROM (
                       , bookings_source_src_28000.guest_id AS booking__guest
                       , bookings_source_src_28000.host_id AS booking__host
                     FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_32
-                ) subq_33
+                  ) subq_26
+                ) subq_27
                 WHERE booking__is_instant
-              ) subq_34
-            ) subq_35
+              ) subq_28
+            ) subq_29
             WHERE booking__is_instant
-          ) subq_36
-        ) subq_37
-      ) subq_38
-    ) subq_39
-  ) subq_40
-) subq_41
+          ) subq_30
+        ) subq_31
+      ) subq_32
+    ) subq_33
+  ) subq_34
+) subq_35

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_60.average_booking_value) AS average_booking_value
-      , MAX(subq_73.bookings) AS bookings
-      , MAX(subq_81.booking_value) AS booking_value
+      MAX(subq_48.average_booking_value) AS average_booking_value
+      , MAX(subq_61.bookings) AS bookings
+      , MAX(subq_69.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_51.booking__is_instant AS booking__is_instant
+          subq_39.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_51.average_booking_value AS average_booking_value
+          , subq_39.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_49
+          ) subq_37
           WHERE booking__is_instant
-        ) subq_51
+        ) subq_39
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_51.listing = listings_latest_src_28000.listing_id
-      ) subq_56
+          subq_39.listing = listings_latest_src_28000.listing_id
+      ) subq_44
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_60
+    ) subq_48
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_64.booking__is_instant AS booking__is_instant
+          subq_52.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_64.bookings AS bookings
+          , subq_52.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_62
+          ) subq_50
           WHERE booking__is_instant
-        ) subq_64
+        ) subq_52
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_64.listing = listings_latest_src_28000.listing_id
-      ) subq_69
+          subq_52.listing = listings_latest_src_28000.listing_id
+      ) subq_57
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_73
+    ) subq_61
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_75
+        ) subq_63
         WHERE booking__is_instant
-      ) subq_77
+      ) subq_65
       WHERE booking__is_instant
-    ) subq_81
-  ) subq_82
-) subq_83
+    ) subq_69
+  ) subq_70
+) subq_71

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0.sql
@@ -8,248 +8,248 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_18.average_booking_value) AS average_booking_value
-      , MAX(subq_31.bookings) AS bookings
-      , MAX(subq_39.booking_value) AS booking_value
+      MAX(subq_12.average_booking_value) AS average_booking_value
+      , MAX(subq_25.bookings) AS bookings
+      , MAX(subq_33.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.average_booking_value
+        subq_11.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_16.average_booking_value) AS average_booking_value
+          AVG(subq_10.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_15.average_booking_value
+            subq_9.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.booking__is_instant
-              , subq_14.listing__is_lux_latest
-              , subq_14.average_booking_value
+              subq_8.booking__is_instant
+              , subq_8.listing__is_lux_latest
+              , subq_8.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_13.booking__is_instant
-                , subq_13.listing__is_lux_latest
-                , subq_13.average_booking_value
+                subq_7.booking__is_instant
+                , subq_7.listing__is_lux_latest
+                , subq_7.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_9.listing AS listing
-                  , subq_9.booking__is_instant AS booking__is_instant
-                  , subq_12.is_lux_latest AS listing__is_lux_latest
-                  , subq_9.average_booking_value AS average_booking_value
+                  subq_3.listing AS listing
+                  , subq_3.booking__is_instant AS booking__is_instant
+                  , subq_6.is_lux_latest AS listing__is_lux_latest
+                  , subq_3.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.booking__is_instant
-                    , subq_8.average_booking_value
+                    subq_2.listing
+                    , subq_2.booking__is_instant
+                    , subq_2.average_booking_value
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.metric_time__day
-                      , subq_7.metric_time__week
-                      , subq_7.metric_time__month
-                      , subq_7.metric_time__quarter
-                      , subq_7.metric_time__year
-                      , subq_7.metric_time__extract_year
-                      , subq_7.metric_time__extract_quarter
-                      , subq_7.metric_time__extract_month
-                      , subq_7.metric_time__extract_day
-                      , subq_7.metric_time__extract_dow
-                      , subq_7.metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_1.ds__day
+                      , subq_1.ds__week
+                      , subq_1.ds__month
+                      , subq_1.ds__quarter
+                      , subq_1.ds__year
+                      , subq_1.ds__extract_year
+                      , subq_1.ds__extract_quarter
+                      , subq_1.ds__extract_month
+                      , subq_1.ds__extract_day
+                      , subq_1.ds__extract_dow
+                      , subq_1.ds__extract_doy
+                      , subq_1.ds_partitioned__day
+                      , subq_1.ds_partitioned__week
+                      , subq_1.ds_partitioned__month
+                      , subq_1.ds_partitioned__quarter
+                      , subq_1.ds_partitioned__year
+                      , subq_1.ds_partitioned__extract_year
+                      , subq_1.ds_partitioned__extract_quarter
+                      , subq_1.ds_partitioned__extract_month
+                      , subq_1.ds_partitioned__extract_day
+                      , subq_1.ds_partitioned__extract_dow
+                      , subq_1.ds_partitioned__extract_doy
+                      , subq_1.paid_at__day
+                      , subq_1.paid_at__week
+                      , subq_1.paid_at__month
+                      , subq_1.paid_at__quarter
+                      , subq_1.paid_at__year
+                      , subq_1.paid_at__extract_year
+                      , subq_1.paid_at__extract_quarter
+                      , subq_1.paid_at__extract_month
+                      , subq_1.paid_at__extract_day
+                      , subq_1.paid_at__extract_dow
+                      , subq_1.paid_at__extract_doy
+                      , subq_1.booking__ds__day
+                      , subq_1.booking__ds__week
+                      , subq_1.booking__ds__month
+                      , subq_1.booking__ds__quarter
+                      , subq_1.booking__ds__year
+                      , subq_1.booking__ds__extract_year
+                      , subq_1.booking__ds__extract_quarter
+                      , subq_1.booking__ds__extract_month
+                      , subq_1.booking__ds__extract_day
+                      , subq_1.booking__ds__extract_dow
+                      , subq_1.booking__ds__extract_doy
+                      , subq_1.booking__ds_partitioned__day
+                      , subq_1.booking__ds_partitioned__week
+                      , subq_1.booking__ds_partitioned__month
+                      , subq_1.booking__ds_partitioned__quarter
+                      , subq_1.booking__ds_partitioned__year
+                      , subq_1.booking__ds_partitioned__extract_year
+                      , subq_1.booking__ds_partitioned__extract_quarter
+                      , subq_1.booking__ds_partitioned__extract_month
+                      , subq_1.booking__ds_partitioned__extract_day
+                      , subq_1.booking__ds_partitioned__extract_dow
+                      , subq_1.booking__ds_partitioned__extract_doy
+                      , subq_1.booking__paid_at__day
+                      , subq_1.booking__paid_at__week
+                      , subq_1.booking__paid_at__month
+                      , subq_1.booking__paid_at__quarter
+                      , subq_1.booking__paid_at__year
+                      , subq_1.booking__paid_at__extract_year
+                      , subq_1.booking__paid_at__extract_quarter
+                      , subq_1.booking__paid_at__extract_month
+                      , subq_1.booking__paid_at__extract_day
+                      , subq_1.booking__paid_at__extract_dow
+                      , subq_1.booking__paid_at__extract_doy
+                      , subq_1.metric_time__day
+                      , subq_1.metric_time__week
+                      , subq_1.metric_time__month
+                      , subq_1.metric_time__quarter
+                      , subq_1.metric_time__year
+                      , subq_1.metric_time__extract_year
+                      , subq_1.metric_time__extract_quarter
+                      , subq_1.metric_time__extract_month
+                      , subq_1.metric_time__extract_day
+                      , subq_1.metric_time__extract_dow
+                      , subq_1.metric_time__extract_doy
+                      , subq_1.listing
+                      , subq_1.guest
+                      , subq_1.host
+                      , subq_1.booking__listing
+                      , subq_1.booking__guest
+                      , subq_1.booking__host
+                      , subq_1.is_instant
+                      , subq_1.booking__is_instant
+                      , subq_1.bookings
+                      , subq_1.instant_bookings
+                      , subq_1.booking_value
+                      , subq_1.max_booking_value
+                      , subq_1.min_booking_value
+                      , subq_1.bookers
+                      , subq_1.average_booking_value
+                      , subq_1.referred_bookings
+                      , subq_1.median_booking_value
+                      , subq_1.booking_value_p99
+                      , subq_1.discrete_booking_value_p99
+                      , subq_1.approximate_continuous_booking_value_p99
+                      , subq_1.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_6.ds__day
-                        , subq_6.ds__week
-                        , subq_6.ds__month
-                        , subq_6.ds__quarter
-                        , subq_6.ds__year
-                        , subq_6.ds__extract_year
-                        , subq_6.ds__extract_quarter
-                        , subq_6.ds__extract_month
-                        , subq_6.ds__extract_day
-                        , subq_6.ds__extract_dow
-                        , subq_6.ds__extract_doy
-                        , subq_6.ds_partitioned__day
-                        , subq_6.ds_partitioned__week
-                        , subq_6.ds_partitioned__month
-                        , subq_6.ds_partitioned__quarter
-                        , subq_6.ds_partitioned__year
-                        , subq_6.ds_partitioned__extract_year
-                        , subq_6.ds_partitioned__extract_quarter
-                        , subq_6.ds_partitioned__extract_month
-                        , subq_6.ds_partitioned__extract_day
-                        , subq_6.ds_partitioned__extract_dow
-                        , subq_6.ds_partitioned__extract_doy
-                        , subq_6.paid_at__day
-                        , subq_6.paid_at__week
-                        , subq_6.paid_at__month
-                        , subq_6.paid_at__quarter
-                        , subq_6.paid_at__year
-                        , subq_6.paid_at__extract_year
-                        , subq_6.paid_at__extract_quarter
-                        , subq_6.paid_at__extract_month
-                        , subq_6.paid_at__extract_day
-                        , subq_6.paid_at__extract_dow
-                        , subq_6.paid_at__extract_doy
-                        , subq_6.booking__ds__day
-                        , subq_6.booking__ds__week
-                        , subq_6.booking__ds__month
-                        , subq_6.booking__ds__quarter
-                        , subq_6.booking__ds__year
-                        , subq_6.booking__ds__extract_year
-                        , subq_6.booking__ds__extract_quarter
-                        , subq_6.booking__ds__extract_month
-                        , subq_6.booking__ds__extract_day
-                        , subq_6.booking__ds__extract_dow
-                        , subq_6.booking__ds__extract_doy
-                        , subq_6.booking__ds_partitioned__day
-                        , subq_6.booking__ds_partitioned__week
-                        , subq_6.booking__ds_partitioned__month
-                        , subq_6.booking__ds_partitioned__quarter
-                        , subq_6.booking__ds_partitioned__year
-                        , subq_6.booking__ds_partitioned__extract_year
-                        , subq_6.booking__ds_partitioned__extract_quarter
-                        , subq_6.booking__ds_partitioned__extract_month
-                        , subq_6.booking__ds_partitioned__extract_day
-                        , subq_6.booking__ds_partitioned__extract_dow
-                        , subq_6.booking__ds_partitioned__extract_doy
-                        , subq_6.booking__paid_at__day
-                        , subq_6.booking__paid_at__week
-                        , subq_6.booking__paid_at__month
-                        , subq_6.booking__paid_at__quarter
-                        , subq_6.booking__paid_at__year
-                        , subq_6.booking__paid_at__extract_year
-                        , subq_6.booking__paid_at__extract_quarter
-                        , subq_6.booking__paid_at__extract_month
-                        , subq_6.booking__paid_at__extract_day
-                        , subq_6.booking__paid_at__extract_dow
-                        , subq_6.booking__paid_at__extract_doy
-                        , subq_6.ds__day AS metric_time__day
-                        , subq_6.ds__week AS metric_time__week
-                        , subq_6.ds__month AS metric_time__month
-                        , subq_6.ds__quarter AS metric_time__quarter
-                        , subq_6.ds__year AS metric_time__year
-                        , subq_6.ds__extract_year AS metric_time__extract_year
-                        , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_6.ds__extract_month AS metric_time__extract_month
-                        , subq_6.ds__extract_day AS metric_time__extract_day
-                        , subq_6.ds__extract_dow AS metric_time__extract_dow
-                        , subq_6.ds__extract_doy AS metric_time__extract_doy
-                        , subq_6.listing
-                        , subq_6.guest
-                        , subq_6.host
-                        , subq_6.booking__listing
-                        , subq_6.booking__guest
-                        , subq_6.booking__host
-                        , subq_6.is_instant
-                        , subq_6.booking__is_instant
-                        , subq_6.bookings
-                        , subq_6.instant_bookings
-                        , subq_6.booking_value
-                        , subq_6.max_booking_value
-                        , subq_6.min_booking_value
-                        , subq_6.bookers
-                        , subq_6.average_booking_value
-                        , subq_6.referred_bookings
-                        , subq_6.median_booking_value
-                        , subq_6.booking_value_p99
-                        , subq_6.discrete_booking_value_p99
-                        , subq_6.approximate_continuous_booking_value_p99
-                        , subq_6.approximate_discrete_booking_value_p99
+                        subq_0.ds__day
+                        , subq_0.ds__week
+                        , subq_0.ds__month
+                        , subq_0.ds__quarter
+                        , subq_0.ds__year
+                        , subq_0.ds__extract_year
+                        , subq_0.ds__extract_quarter
+                        , subq_0.ds__extract_month
+                        , subq_0.ds__extract_day
+                        , subq_0.ds__extract_dow
+                        , subq_0.ds__extract_doy
+                        , subq_0.ds_partitioned__day
+                        , subq_0.ds_partitioned__week
+                        , subq_0.ds_partitioned__month
+                        , subq_0.ds_partitioned__quarter
+                        , subq_0.ds_partitioned__year
+                        , subq_0.ds_partitioned__extract_year
+                        , subq_0.ds_partitioned__extract_quarter
+                        , subq_0.ds_partitioned__extract_month
+                        , subq_0.ds_partitioned__extract_day
+                        , subq_0.ds_partitioned__extract_dow
+                        , subq_0.ds_partitioned__extract_doy
+                        , subq_0.paid_at__day
+                        , subq_0.paid_at__week
+                        , subq_0.paid_at__month
+                        , subq_0.paid_at__quarter
+                        , subq_0.paid_at__year
+                        , subq_0.paid_at__extract_year
+                        , subq_0.paid_at__extract_quarter
+                        , subq_0.paid_at__extract_month
+                        , subq_0.paid_at__extract_day
+                        , subq_0.paid_at__extract_dow
+                        , subq_0.paid_at__extract_doy
+                        , subq_0.booking__ds__day
+                        , subq_0.booking__ds__week
+                        , subq_0.booking__ds__month
+                        , subq_0.booking__ds__quarter
+                        , subq_0.booking__ds__year
+                        , subq_0.booking__ds__extract_year
+                        , subq_0.booking__ds__extract_quarter
+                        , subq_0.booking__ds__extract_month
+                        , subq_0.booking__ds__extract_day
+                        , subq_0.booking__ds__extract_dow
+                        , subq_0.booking__ds__extract_doy
+                        , subq_0.booking__ds_partitioned__day
+                        , subq_0.booking__ds_partitioned__week
+                        , subq_0.booking__ds_partitioned__month
+                        , subq_0.booking__ds_partitioned__quarter
+                        , subq_0.booking__ds_partitioned__year
+                        , subq_0.booking__ds_partitioned__extract_year
+                        , subq_0.booking__ds_partitioned__extract_quarter
+                        , subq_0.booking__ds_partitioned__extract_month
+                        , subq_0.booking__ds_partitioned__extract_day
+                        , subq_0.booking__ds_partitioned__extract_dow
+                        , subq_0.booking__ds_partitioned__extract_doy
+                        , subq_0.booking__paid_at__day
+                        , subq_0.booking__paid_at__week
+                        , subq_0.booking__paid_at__month
+                        , subq_0.booking__paid_at__quarter
+                        , subq_0.booking__paid_at__year
+                        , subq_0.booking__paid_at__extract_year
+                        , subq_0.booking__paid_at__extract_quarter
+                        , subq_0.booking__paid_at__extract_month
+                        , subq_0.booking__paid_at__extract_day
+                        , subq_0.booking__paid_at__extract_dow
+                        , subq_0.booking__paid_at__extract_doy
+                        , subq_0.ds__day AS metric_time__day
+                        , subq_0.ds__week AS metric_time__week
+                        , subq_0.ds__month AS metric_time__month
+                        , subq_0.ds__quarter AS metric_time__quarter
+                        , subq_0.ds__year AS metric_time__year
+                        , subq_0.ds__extract_year AS metric_time__extract_year
+                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_0.ds__extract_month AS metric_time__extract_month
+                        , subq_0.ds__extract_day AS metric_time__extract_day
+                        , subq_0.ds__extract_dow AS metric_time__extract_dow
+                        , subq_0.ds__extract_doy AS metric_time__extract_doy
+                        , subq_0.listing
+                        , subq_0.guest
+                        , subq_0.host
+                        , subq_0.booking__listing
+                        , subq_0.booking__guest
+                        , subq_0.booking__host
+                        , subq_0.is_instant
+                        , subq_0.booking__is_instant
+                        , subq_0.bookings
+                        , subq_0.instant_bookings
+                        , subq_0.booking_value
+                        , subq_0.max_booking_value
+                        , subq_0.min_booking_value
+                        , subq_0.bookers
+                        , subq_0.average_booking_value
+                        , subq_0.referred_bookings
+                        , subq_0.median_booking_value
+                        , subq_0.booking_value_p99
+                        , subq_0.discrete_booking_value_p99
+                        , subq_0.approximate_continuous_booking_value_p99
+                        , subq_0.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -342,86 +342,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_6
-                    ) subq_7
+                      ) subq_0
+                    ) subq_1
                     WHERE booking__is_instant
-                  ) subq_8
-                ) subq_9
+                  ) subq_2
+                ) subq_3
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_11.listing
-                    , subq_11.is_lux_latest
+                    subq_5.listing
+                    , subq_5.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_10.ds__day
-                      , subq_10.ds__week
-                      , subq_10.ds__month
-                      , subq_10.ds__quarter
-                      , subq_10.ds__year
-                      , subq_10.ds__extract_year
-                      , subq_10.ds__extract_quarter
-                      , subq_10.ds__extract_month
-                      , subq_10.ds__extract_day
-                      , subq_10.ds__extract_dow
-                      , subq_10.ds__extract_doy
-                      , subq_10.created_at__day
-                      , subq_10.created_at__week
-                      , subq_10.created_at__month
-                      , subq_10.created_at__quarter
-                      , subq_10.created_at__year
-                      , subq_10.created_at__extract_year
-                      , subq_10.created_at__extract_quarter
-                      , subq_10.created_at__extract_month
-                      , subq_10.created_at__extract_day
-                      , subq_10.created_at__extract_dow
-                      , subq_10.created_at__extract_doy
-                      , subq_10.listing__ds__day
-                      , subq_10.listing__ds__week
-                      , subq_10.listing__ds__month
-                      , subq_10.listing__ds__quarter
-                      , subq_10.listing__ds__year
-                      , subq_10.listing__ds__extract_year
-                      , subq_10.listing__ds__extract_quarter
-                      , subq_10.listing__ds__extract_month
-                      , subq_10.listing__ds__extract_day
-                      , subq_10.listing__ds__extract_dow
-                      , subq_10.listing__ds__extract_doy
-                      , subq_10.listing__created_at__day
-                      , subq_10.listing__created_at__week
-                      , subq_10.listing__created_at__month
-                      , subq_10.listing__created_at__quarter
-                      , subq_10.listing__created_at__year
-                      , subq_10.listing__created_at__extract_year
-                      , subq_10.listing__created_at__extract_quarter
-                      , subq_10.listing__created_at__extract_month
-                      , subq_10.listing__created_at__extract_day
-                      , subq_10.listing__created_at__extract_dow
-                      , subq_10.listing__created_at__extract_doy
-                      , subq_10.ds__day AS metric_time__day
-                      , subq_10.ds__week AS metric_time__week
-                      , subq_10.ds__month AS metric_time__month
-                      , subq_10.ds__quarter AS metric_time__quarter
-                      , subq_10.ds__year AS metric_time__year
-                      , subq_10.ds__extract_year AS metric_time__extract_year
-                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_10.ds__extract_month AS metric_time__extract_month
-                      , subq_10.ds__extract_day AS metric_time__extract_day
-                      , subq_10.ds__extract_dow AS metric_time__extract_dow
-                      , subq_10.ds__extract_doy AS metric_time__extract_doy
-                      , subq_10.listing
-                      , subq_10.user
-                      , subq_10.listing__user
-                      , subq_10.country_latest
-                      , subq_10.is_lux_latest
-                      , subq_10.capacity_latest
-                      , subq_10.listing__country_latest
-                      , subq_10.listing__is_lux_latest
-                      , subq_10.listing__capacity_latest
-                      , subq_10.listings
-                      , subq_10.largest_listing
-                      , subq_10.smallest_listing
+                      subq_4.ds__day
+                      , subq_4.ds__week
+                      , subq_4.ds__month
+                      , subq_4.ds__quarter
+                      , subq_4.ds__year
+                      , subq_4.ds__extract_year
+                      , subq_4.ds__extract_quarter
+                      , subq_4.ds__extract_month
+                      , subq_4.ds__extract_day
+                      , subq_4.ds__extract_dow
+                      , subq_4.ds__extract_doy
+                      , subq_4.created_at__day
+                      , subq_4.created_at__week
+                      , subq_4.created_at__month
+                      , subq_4.created_at__quarter
+                      , subq_4.created_at__year
+                      , subq_4.created_at__extract_year
+                      , subq_4.created_at__extract_quarter
+                      , subq_4.created_at__extract_month
+                      , subq_4.created_at__extract_day
+                      , subq_4.created_at__extract_dow
+                      , subq_4.created_at__extract_doy
+                      , subq_4.listing__ds__day
+                      , subq_4.listing__ds__week
+                      , subq_4.listing__ds__month
+                      , subq_4.listing__ds__quarter
+                      , subq_4.listing__ds__year
+                      , subq_4.listing__ds__extract_year
+                      , subq_4.listing__ds__extract_quarter
+                      , subq_4.listing__ds__extract_month
+                      , subq_4.listing__ds__extract_day
+                      , subq_4.listing__ds__extract_dow
+                      , subq_4.listing__ds__extract_doy
+                      , subq_4.listing__created_at__day
+                      , subq_4.listing__created_at__week
+                      , subq_4.listing__created_at__month
+                      , subq_4.listing__created_at__quarter
+                      , subq_4.listing__created_at__year
+                      , subq_4.listing__created_at__extract_year
+                      , subq_4.listing__created_at__extract_quarter
+                      , subq_4.listing__created_at__extract_month
+                      , subq_4.listing__created_at__extract_day
+                      , subq_4.listing__created_at__extract_dow
+                      , subq_4.listing__created_at__extract_doy
+                      , subq_4.ds__day AS metric_time__day
+                      , subq_4.ds__week AS metric_time__week
+                      , subq_4.ds__month AS metric_time__month
+                      , subq_4.ds__quarter AS metric_time__quarter
+                      , subq_4.ds__year AS metric_time__year
+                      , subq_4.ds__extract_year AS metric_time__extract_year
+                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_4.ds__extract_month AS metric_time__extract_month
+                      , subq_4.ds__extract_day AS metric_time__extract_day
+                      , subq_4.ds__extract_dow AS metric_time__extract_dow
+                      , subq_4.ds__extract_doy AS metric_time__extract_doy
+                      , subq_4.listing
+                      , subq_4.user
+                      , subq_4.listing__user
+                      , subq_4.country_latest
+                      , subq_4.is_lux_latest
+                      , subq_4.capacity_latest
+                      , subq_4.listing__country_latest
+                      , subq_4.listing__is_lux_latest
+                      , subq_4.listing__capacity_latest
+                      , subq_4.listings
+                      , subq_4.largest_listing
+                      , subq_4.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,257 +482,257 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_10
-                  ) subq_11
-                ) subq_12
+                    ) subq_4
+                  ) subq_5
+                ) subq_6
                 ON
-                  subq_9.listing = subq_12.listing
-              ) subq_13
-            ) subq_14
+                  subq_3.listing = subq_6.listing
+              ) subq_7
+            ) subq_8
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_15
-        ) subq_16
-      ) subq_17
-    ) subq_18
+          ) subq_9
+        ) subq_10
+      ) subq_11
+    ) subq_12
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_30.bookings
+        subq_24.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_29.bookings) AS bookings
+          SUM(subq_23.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_28.bookings
+            subq_22.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_27.booking__is_instant
-              , subq_27.listing__is_lux_latest
-              , subq_27.bookings
+              subq_21.booking__is_instant
+              , subq_21.listing__is_lux_latest
+              , subq_21.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_26.booking__is_instant
-                , subq_26.listing__is_lux_latest
-                , subq_26.bookings
+                subq_20.booking__is_instant
+                , subq_20.listing__is_lux_latest
+                , subq_20.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_22.listing AS listing
-                  , subq_22.booking__is_instant AS booking__is_instant
-                  , subq_25.is_lux_latest AS listing__is_lux_latest
-                  , subq_22.bookings AS bookings
+                  subq_16.listing AS listing
+                  , subq_16.booking__is_instant AS booking__is_instant
+                  , subq_19.is_lux_latest AS listing__is_lux_latest
+                  , subq_16.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_21.listing
-                    , subq_21.booking__is_instant
-                    , subq_21.bookings
+                    subq_15.listing
+                    , subq_15.booking__is_instant
+                    , subq_15.bookings
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_20.ds__day
-                      , subq_20.ds__week
-                      , subq_20.ds__month
-                      , subq_20.ds__quarter
-                      , subq_20.ds__year
-                      , subq_20.ds__extract_year
-                      , subq_20.ds__extract_quarter
-                      , subq_20.ds__extract_month
-                      , subq_20.ds__extract_day
-                      , subq_20.ds__extract_dow
-                      , subq_20.ds__extract_doy
-                      , subq_20.ds_partitioned__day
-                      , subq_20.ds_partitioned__week
-                      , subq_20.ds_partitioned__month
-                      , subq_20.ds_partitioned__quarter
-                      , subq_20.ds_partitioned__year
-                      , subq_20.ds_partitioned__extract_year
-                      , subq_20.ds_partitioned__extract_quarter
-                      , subq_20.ds_partitioned__extract_month
-                      , subq_20.ds_partitioned__extract_day
-                      , subq_20.ds_partitioned__extract_dow
-                      , subq_20.ds_partitioned__extract_doy
-                      , subq_20.paid_at__day
-                      , subq_20.paid_at__week
-                      , subq_20.paid_at__month
-                      , subq_20.paid_at__quarter
-                      , subq_20.paid_at__year
-                      , subq_20.paid_at__extract_year
-                      , subq_20.paid_at__extract_quarter
-                      , subq_20.paid_at__extract_month
-                      , subq_20.paid_at__extract_day
-                      , subq_20.paid_at__extract_dow
-                      , subq_20.paid_at__extract_doy
-                      , subq_20.booking__ds__day
-                      , subq_20.booking__ds__week
-                      , subq_20.booking__ds__month
-                      , subq_20.booking__ds__quarter
-                      , subq_20.booking__ds__year
-                      , subq_20.booking__ds__extract_year
-                      , subq_20.booking__ds__extract_quarter
-                      , subq_20.booking__ds__extract_month
-                      , subq_20.booking__ds__extract_day
-                      , subq_20.booking__ds__extract_dow
-                      , subq_20.booking__ds__extract_doy
-                      , subq_20.booking__ds_partitioned__day
-                      , subq_20.booking__ds_partitioned__week
-                      , subq_20.booking__ds_partitioned__month
-                      , subq_20.booking__ds_partitioned__quarter
-                      , subq_20.booking__ds_partitioned__year
-                      , subq_20.booking__ds_partitioned__extract_year
-                      , subq_20.booking__ds_partitioned__extract_quarter
-                      , subq_20.booking__ds_partitioned__extract_month
-                      , subq_20.booking__ds_partitioned__extract_day
-                      , subq_20.booking__ds_partitioned__extract_dow
-                      , subq_20.booking__ds_partitioned__extract_doy
-                      , subq_20.booking__paid_at__day
-                      , subq_20.booking__paid_at__week
-                      , subq_20.booking__paid_at__month
-                      , subq_20.booking__paid_at__quarter
-                      , subq_20.booking__paid_at__year
-                      , subq_20.booking__paid_at__extract_year
-                      , subq_20.booking__paid_at__extract_quarter
-                      , subq_20.booking__paid_at__extract_month
-                      , subq_20.booking__paid_at__extract_day
-                      , subq_20.booking__paid_at__extract_dow
-                      , subq_20.booking__paid_at__extract_doy
-                      , subq_20.metric_time__day
-                      , subq_20.metric_time__week
-                      , subq_20.metric_time__month
-                      , subq_20.metric_time__quarter
-                      , subq_20.metric_time__year
-                      , subq_20.metric_time__extract_year
-                      , subq_20.metric_time__extract_quarter
-                      , subq_20.metric_time__extract_month
-                      , subq_20.metric_time__extract_day
-                      , subq_20.metric_time__extract_dow
-                      , subq_20.metric_time__extract_doy
-                      , subq_20.listing
-                      , subq_20.guest
-                      , subq_20.host
-                      , subq_20.booking__listing
-                      , subq_20.booking__guest
-                      , subq_20.booking__host
-                      , subq_20.is_instant
-                      , subq_20.booking__is_instant
-                      , subq_20.bookings
-                      , subq_20.instant_bookings
-                      , subq_20.booking_value
-                      , subq_20.max_booking_value
-                      , subq_20.min_booking_value
-                      , subq_20.bookers
-                      , subq_20.average_booking_value
-                      , subq_20.referred_bookings
-                      , subq_20.median_booking_value
-                      , subq_20.booking_value_p99
-                      , subq_20.discrete_booking_value_p99
-                      , subq_20.approximate_continuous_booking_value_p99
-                      , subq_20.approximate_discrete_booking_value_p99
+                      subq_14.ds__day
+                      , subq_14.ds__week
+                      , subq_14.ds__month
+                      , subq_14.ds__quarter
+                      , subq_14.ds__year
+                      , subq_14.ds__extract_year
+                      , subq_14.ds__extract_quarter
+                      , subq_14.ds__extract_month
+                      , subq_14.ds__extract_day
+                      , subq_14.ds__extract_dow
+                      , subq_14.ds__extract_doy
+                      , subq_14.ds_partitioned__day
+                      , subq_14.ds_partitioned__week
+                      , subq_14.ds_partitioned__month
+                      , subq_14.ds_partitioned__quarter
+                      , subq_14.ds_partitioned__year
+                      , subq_14.ds_partitioned__extract_year
+                      , subq_14.ds_partitioned__extract_quarter
+                      , subq_14.ds_partitioned__extract_month
+                      , subq_14.ds_partitioned__extract_day
+                      , subq_14.ds_partitioned__extract_dow
+                      , subq_14.ds_partitioned__extract_doy
+                      , subq_14.paid_at__day
+                      , subq_14.paid_at__week
+                      , subq_14.paid_at__month
+                      , subq_14.paid_at__quarter
+                      , subq_14.paid_at__year
+                      , subq_14.paid_at__extract_year
+                      , subq_14.paid_at__extract_quarter
+                      , subq_14.paid_at__extract_month
+                      , subq_14.paid_at__extract_day
+                      , subq_14.paid_at__extract_dow
+                      , subq_14.paid_at__extract_doy
+                      , subq_14.booking__ds__day
+                      , subq_14.booking__ds__week
+                      , subq_14.booking__ds__month
+                      , subq_14.booking__ds__quarter
+                      , subq_14.booking__ds__year
+                      , subq_14.booking__ds__extract_year
+                      , subq_14.booking__ds__extract_quarter
+                      , subq_14.booking__ds__extract_month
+                      , subq_14.booking__ds__extract_day
+                      , subq_14.booking__ds__extract_dow
+                      , subq_14.booking__ds__extract_doy
+                      , subq_14.booking__ds_partitioned__day
+                      , subq_14.booking__ds_partitioned__week
+                      , subq_14.booking__ds_partitioned__month
+                      , subq_14.booking__ds_partitioned__quarter
+                      , subq_14.booking__ds_partitioned__year
+                      , subq_14.booking__ds_partitioned__extract_year
+                      , subq_14.booking__ds_partitioned__extract_quarter
+                      , subq_14.booking__ds_partitioned__extract_month
+                      , subq_14.booking__ds_partitioned__extract_day
+                      , subq_14.booking__ds_partitioned__extract_dow
+                      , subq_14.booking__ds_partitioned__extract_doy
+                      , subq_14.booking__paid_at__day
+                      , subq_14.booking__paid_at__week
+                      , subq_14.booking__paid_at__month
+                      , subq_14.booking__paid_at__quarter
+                      , subq_14.booking__paid_at__year
+                      , subq_14.booking__paid_at__extract_year
+                      , subq_14.booking__paid_at__extract_quarter
+                      , subq_14.booking__paid_at__extract_month
+                      , subq_14.booking__paid_at__extract_day
+                      , subq_14.booking__paid_at__extract_dow
+                      , subq_14.booking__paid_at__extract_doy
+                      , subq_14.metric_time__day
+                      , subq_14.metric_time__week
+                      , subq_14.metric_time__month
+                      , subq_14.metric_time__quarter
+                      , subq_14.metric_time__year
+                      , subq_14.metric_time__extract_year
+                      , subq_14.metric_time__extract_quarter
+                      , subq_14.metric_time__extract_month
+                      , subq_14.metric_time__extract_day
+                      , subq_14.metric_time__extract_dow
+                      , subq_14.metric_time__extract_doy
+                      , subq_14.listing
+                      , subq_14.guest
+                      , subq_14.host
+                      , subq_14.booking__listing
+                      , subq_14.booking__guest
+                      , subq_14.booking__host
+                      , subq_14.is_instant
+                      , subq_14.booking__is_instant
+                      , subq_14.bookings
+                      , subq_14.instant_bookings
+                      , subq_14.booking_value
+                      , subq_14.max_booking_value
+                      , subq_14.min_booking_value
+                      , subq_14.bookers
+                      , subq_14.average_booking_value
+                      , subq_14.referred_bookings
+                      , subq_14.median_booking_value
+                      , subq_14.booking_value_p99
+                      , subq_14.discrete_booking_value_p99
+                      , subq_14.approximate_continuous_booking_value_p99
+                      , subq_14.approximate_discrete_booking_value_p99
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_19.ds__day
-                        , subq_19.ds__week
-                        , subq_19.ds__month
-                        , subq_19.ds__quarter
-                        , subq_19.ds__year
-                        , subq_19.ds__extract_year
-                        , subq_19.ds__extract_quarter
-                        , subq_19.ds__extract_month
-                        , subq_19.ds__extract_day
-                        , subq_19.ds__extract_dow
-                        , subq_19.ds__extract_doy
-                        , subq_19.ds_partitioned__day
-                        , subq_19.ds_partitioned__week
-                        , subq_19.ds_partitioned__month
-                        , subq_19.ds_partitioned__quarter
-                        , subq_19.ds_partitioned__year
-                        , subq_19.ds_partitioned__extract_year
-                        , subq_19.ds_partitioned__extract_quarter
-                        , subq_19.ds_partitioned__extract_month
-                        , subq_19.ds_partitioned__extract_day
-                        , subq_19.ds_partitioned__extract_dow
-                        , subq_19.ds_partitioned__extract_doy
-                        , subq_19.paid_at__day
-                        , subq_19.paid_at__week
-                        , subq_19.paid_at__month
-                        , subq_19.paid_at__quarter
-                        , subq_19.paid_at__year
-                        , subq_19.paid_at__extract_year
-                        , subq_19.paid_at__extract_quarter
-                        , subq_19.paid_at__extract_month
-                        , subq_19.paid_at__extract_day
-                        , subq_19.paid_at__extract_dow
-                        , subq_19.paid_at__extract_doy
-                        , subq_19.booking__ds__day
-                        , subq_19.booking__ds__week
-                        , subq_19.booking__ds__month
-                        , subq_19.booking__ds__quarter
-                        , subq_19.booking__ds__year
-                        , subq_19.booking__ds__extract_year
-                        , subq_19.booking__ds__extract_quarter
-                        , subq_19.booking__ds__extract_month
-                        , subq_19.booking__ds__extract_day
-                        , subq_19.booking__ds__extract_dow
-                        , subq_19.booking__ds__extract_doy
-                        , subq_19.booking__ds_partitioned__day
-                        , subq_19.booking__ds_partitioned__week
-                        , subq_19.booking__ds_partitioned__month
-                        , subq_19.booking__ds_partitioned__quarter
-                        , subq_19.booking__ds_partitioned__year
-                        , subq_19.booking__ds_partitioned__extract_year
-                        , subq_19.booking__ds_partitioned__extract_quarter
-                        , subq_19.booking__ds_partitioned__extract_month
-                        , subq_19.booking__ds_partitioned__extract_day
-                        , subq_19.booking__ds_partitioned__extract_dow
-                        , subq_19.booking__ds_partitioned__extract_doy
-                        , subq_19.booking__paid_at__day
-                        , subq_19.booking__paid_at__week
-                        , subq_19.booking__paid_at__month
-                        , subq_19.booking__paid_at__quarter
-                        , subq_19.booking__paid_at__year
-                        , subq_19.booking__paid_at__extract_year
-                        , subq_19.booking__paid_at__extract_quarter
-                        , subq_19.booking__paid_at__extract_month
-                        , subq_19.booking__paid_at__extract_day
-                        , subq_19.booking__paid_at__extract_dow
-                        , subq_19.booking__paid_at__extract_doy
-                        , subq_19.ds__day AS metric_time__day
-                        , subq_19.ds__week AS metric_time__week
-                        , subq_19.ds__month AS metric_time__month
-                        , subq_19.ds__quarter AS metric_time__quarter
-                        , subq_19.ds__year AS metric_time__year
-                        , subq_19.ds__extract_year AS metric_time__extract_year
-                        , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_19.ds__extract_month AS metric_time__extract_month
-                        , subq_19.ds__extract_day AS metric_time__extract_day
-                        , subq_19.ds__extract_dow AS metric_time__extract_dow
-                        , subq_19.ds__extract_doy AS metric_time__extract_doy
-                        , subq_19.listing
-                        , subq_19.guest
-                        , subq_19.host
-                        , subq_19.booking__listing
-                        , subq_19.booking__guest
-                        , subq_19.booking__host
-                        , subq_19.is_instant
-                        , subq_19.booking__is_instant
-                        , subq_19.bookings
-                        , subq_19.instant_bookings
-                        , subq_19.booking_value
-                        , subq_19.max_booking_value
-                        , subq_19.min_booking_value
-                        , subq_19.bookers
-                        , subq_19.average_booking_value
-                        , subq_19.referred_bookings
-                        , subq_19.median_booking_value
-                        , subq_19.booking_value_p99
-                        , subq_19.discrete_booking_value_p99
-                        , subq_19.approximate_continuous_booking_value_p99
-                        , subq_19.approximate_discrete_booking_value_p99
+                        subq_13.ds__day
+                        , subq_13.ds__week
+                        , subq_13.ds__month
+                        , subq_13.ds__quarter
+                        , subq_13.ds__year
+                        , subq_13.ds__extract_year
+                        , subq_13.ds__extract_quarter
+                        , subq_13.ds__extract_month
+                        , subq_13.ds__extract_day
+                        , subq_13.ds__extract_dow
+                        , subq_13.ds__extract_doy
+                        , subq_13.ds_partitioned__day
+                        , subq_13.ds_partitioned__week
+                        , subq_13.ds_partitioned__month
+                        , subq_13.ds_partitioned__quarter
+                        , subq_13.ds_partitioned__year
+                        , subq_13.ds_partitioned__extract_year
+                        , subq_13.ds_partitioned__extract_quarter
+                        , subq_13.ds_partitioned__extract_month
+                        , subq_13.ds_partitioned__extract_day
+                        , subq_13.ds_partitioned__extract_dow
+                        , subq_13.ds_partitioned__extract_doy
+                        , subq_13.paid_at__day
+                        , subq_13.paid_at__week
+                        , subq_13.paid_at__month
+                        , subq_13.paid_at__quarter
+                        , subq_13.paid_at__year
+                        , subq_13.paid_at__extract_year
+                        , subq_13.paid_at__extract_quarter
+                        , subq_13.paid_at__extract_month
+                        , subq_13.paid_at__extract_day
+                        , subq_13.paid_at__extract_dow
+                        , subq_13.paid_at__extract_doy
+                        , subq_13.booking__ds__day
+                        , subq_13.booking__ds__week
+                        , subq_13.booking__ds__month
+                        , subq_13.booking__ds__quarter
+                        , subq_13.booking__ds__year
+                        , subq_13.booking__ds__extract_year
+                        , subq_13.booking__ds__extract_quarter
+                        , subq_13.booking__ds__extract_month
+                        , subq_13.booking__ds__extract_day
+                        , subq_13.booking__ds__extract_dow
+                        , subq_13.booking__ds__extract_doy
+                        , subq_13.booking__ds_partitioned__day
+                        , subq_13.booking__ds_partitioned__week
+                        , subq_13.booking__ds_partitioned__month
+                        , subq_13.booking__ds_partitioned__quarter
+                        , subq_13.booking__ds_partitioned__year
+                        , subq_13.booking__ds_partitioned__extract_year
+                        , subq_13.booking__ds_partitioned__extract_quarter
+                        , subq_13.booking__ds_partitioned__extract_month
+                        , subq_13.booking__ds_partitioned__extract_day
+                        , subq_13.booking__ds_partitioned__extract_dow
+                        , subq_13.booking__ds_partitioned__extract_doy
+                        , subq_13.booking__paid_at__day
+                        , subq_13.booking__paid_at__week
+                        , subq_13.booking__paid_at__month
+                        , subq_13.booking__paid_at__quarter
+                        , subq_13.booking__paid_at__year
+                        , subq_13.booking__paid_at__extract_year
+                        , subq_13.booking__paid_at__extract_quarter
+                        , subq_13.booking__paid_at__extract_month
+                        , subq_13.booking__paid_at__extract_day
+                        , subq_13.booking__paid_at__extract_dow
+                        , subq_13.booking__paid_at__extract_doy
+                        , subq_13.ds__day AS metric_time__day
+                        , subq_13.ds__week AS metric_time__week
+                        , subq_13.ds__month AS metric_time__month
+                        , subq_13.ds__quarter AS metric_time__quarter
+                        , subq_13.ds__year AS metric_time__year
+                        , subq_13.ds__extract_year AS metric_time__extract_year
+                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_13.ds__extract_month AS metric_time__extract_month
+                        , subq_13.ds__extract_day AS metric_time__extract_day
+                        , subq_13.ds__extract_dow AS metric_time__extract_dow
+                        , subq_13.ds__extract_doy AS metric_time__extract_doy
+                        , subq_13.listing
+                        , subq_13.guest
+                        , subq_13.host
+                        , subq_13.booking__listing
+                        , subq_13.booking__guest
+                        , subq_13.booking__host
+                        , subq_13.is_instant
+                        , subq_13.booking__is_instant
+                        , subq_13.bookings
+                        , subq_13.instant_bookings
+                        , subq_13.booking_value
+                        , subq_13.max_booking_value
+                        , subq_13.min_booking_value
+                        , subq_13.bookers
+                        , subq_13.average_booking_value
+                        , subq_13.referred_bookings
+                        , subq_13.median_booking_value
+                        , subq_13.booking_value_p99
+                        , subq_13.discrete_booking_value_p99
+                        , subq_13.approximate_continuous_booking_value_p99
+                        , subq_13.approximate_discrete_booking_value_p99
                       FROM (
                         -- Read Elements From Semantic Model 'bookings_source'
                         SELECT
@@ -825,86 +825,86 @@ FROM (
                           , bookings_source_src_28000.guest_id AS booking__guest
                           , bookings_source_src_28000.host_id AS booking__host
                         FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_19
-                    ) subq_20
+                      ) subq_13
+                    ) subq_14
                     WHERE booking__is_instant
-                  ) subq_21
-                ) subq_22
+                  ) subq_15
+                ) subq_16
                 LEFT OUTER JOIN (
                   -- Pass Only Elements: ['is_lux_latest', 'listing']
                   SELECT
-                    subq_24.listing
-                    , subq_24.is_lux_latest
+                    subq_18.listing
+                    , subq_18.is_lux_latest
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_23.ds__day
-                      , subq_23.ds__week
-                      , subq_23.ds__month
-                      , subq_23.ds__quarter
-                      , subq_23.ds__year
-                      , subq_23.ds__extract_year
-                      , subq_23.ds__extract_quarter
-                      , subq_23.ds__extract_month
-                      , subq_23.ds__extract_day
-                      , subq_23.ds__extract_dow
-                      , subq_23.ds__extract_doy
-                      , subq_23.created_at__day
-                      , subq_23.created_at__week
-                      , subq_23.created_at__month
-                      , subq_23.created_at__quarter
-                      , subq_23.created_at__year
-                      , subq_23.created_at__extract_year
-                      , subq_23.created_at__extract_quarter
-                      , subq_23.created_at__extract_month
-                      , subq_23.created_at__extract_day
-                      , subq_23.created_at__extract_dow
-                      , subq_23.created_at__extract_doy
-                      , subq_23.listing__ds__day
-                      , subq_23.listing__ds__week
-                      , subq_23.listing__ds__month
-                      , subq_23.listing__ds__quarter
-                      , subq_23.listing__ds__year
-                      , subq_23.listing__ds__extract_year
-                      , subq_23.listing__ds__extract_quarter
-                      , subq_23.listing__ds__extract_month
-                      , subq_23.listing__ds__extract_day
-                      , subq_23.listing__ds__extract_dow
-                      , subq_23.listing__ds__extract_doy
-                      , subq_23.listing__created_at__day
-                      , subq_23.listing__created_at__week
-                      , subq_23.listing__created_at__month
-                      , subq_23.listing__created_at__quarter
-                      , subq_23.listing__created_at__year
-                      , subq_23.listing__created_at__extract_year
-                      , subq_23.listing__created_at__extract_quarter
-                      , subq_23.listing__created_at__extract_month
-                      , subq_23.listing__created_at__extract_day
-                      , subq_23.listing__created_at__extract_dow
-                      , subq_23.listing__created_at__extract_doy
-                      , subq_23.ds__day AS metric_time__day
-                      , subq_23.ds__week AS metric_time__week
-                      , subq_23.ds__month AS metric_time__month
-                      , subq_23.ds__quarter AS metric_time__quarter
-                      , subq_23.ds__year AS metric_time__year
-                      , subq_23.ds__extract_year AS metric_time__extract_year
-                      , subq_23.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_23.ds__extract_month AS metric_time__extract_month
-                      , subq_23.ds__extract_day AS metric_time__extract_day
-                      , subq_23.ds__extract_dow AS metric_time__extract_dow
-                      , subq_23.ds__extract_doy AS metric_time__extract_doy
-                      , subq_23.listing
-                      , subq_23.user
-                      , subq_23.listing__user
-                      , subq_23.country_latest
-                      , subq_23.is_lux_latest
-                      , subq_23.capacity_latest
-                      , subq_23.listing__country_latest
-                      , subq_23.listing__is_lux_latest
-                      , subq_23.listing__capacity_latest
-                      , subq_23.listings
-                      , subq_23.largest_listing
-                      , subq_23.smallest_listing
+                      subq_17.ds__day
+                      , subq_17.ds__week
+                      , subq_17.ds__month
+                      , subq_17.ds__quarter
+                      , subq_17.ds__year
+                      , subq_17.ds__extract_year
+                      , subq_17.ds__extract_quarter
+                      , subq_17.ds__extract_month
+                      , subq_17.ds__extract_day
+                      , subq_17.ds__extract_dow
+                      , subq_17.ds__extract_doy
+                      , subq_17.created_at__day
+                      , subq_17.created_at__week
+                      , subq_17.created_at__month
+                      , subq_17.created_at__quarter
+                      , subq_17.created_at__year
+                      , subq_17.created_at__extract_year
+                      , subq_17.created_at__extract_quarter
+                      , subq_17.created_at__extract_month
+                      , subq_17.created_at__extract_day
+                      , subq_17.created_at__extract_dow
+                      , subq_17.created_at__extract_doy
+                      , subq_17.listing__ds__day
+                      , subq_17.listing__ds__week
+                      , subq_17.listing__ds__month
+                      , subq_17.listing__ds__quarter
+                      , subq_17.listing__ds__year
+                      , subq_17.listing__ds__extract_year
+                      , subq_17.listing__ds__extract_quarter
+                      , subq_17.listing__ds__extract_month
+                      , subq_17.listing__ds__extract_day
+                      , subq_17.listing__ds__extract_dow
+                      , subq_17.listing__ds__extract_doy
+                      , subq_17.listing__created_at__day
+                      , subq_17.listing__created_at__week
+                      , subq_17.listing__created_at__month
+                      , subq_17.listing__created_at__quarter
+                      , subq_17.listing__created_at__year
+                      , subq_17.listing__created_at__extract_year
+                      , subq_17.listing__created_at__extract_quarter
+                      , subq_17.listing__created_at__extract_month
+                      , subq_17.listing__created_at__extract_day
+                      , subq_17.listing__created_at__extract_dow
+                      , subq_17.listing__created_at__extract_doy
+                      , subq_17.ds__day AS metric_time__day
+                      , subq_17.ds__week AS metric_time__week
+                      , subq_17.ds__month AS metric_time__month
+                      , subq_17.ds__quarter AS metric_time__quarter
+                      , subq_17.ds__year AS metric_time__year
+                      , subq_17.ds__extract_year AS metric_time__extract_year
+                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_17.ds__extract_month AS metric_time__extract_month
+                      , subq_17.ds__extract_day AS metric_time__extract_day
+                      , subq_17.ds__extract_dow AS metric_time__extract_dow
+                      , subq_17.ds__extract_doy AS metric_time__extract_doy
+                      , subq_17.listing
+                      , subq_17.user
+                      , subq_17.listing__user
+                      , subq_17.country_latest
+                      , subq_17.is_lux_latest
+                      , subq_17.capacity_latest
+                      , subq_17.listing__country_latest
+                      , subq_17.listing__is_lux_latest
+                      , subq_17.listing__capacity_latest
+                      , subq_17.listings
+                      , subq_17.largest_listing
+                      , subq_17.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,242 +965,242 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_23
-                  ) subq_24
-                ) subq_25
+                    ) subq_17
+                  ) subq_18
+                ) subq_19
                 ON
-                  subq_22.listing = subq_25.listing
-              ) subq_26
-            ) subq_27
+                  subq_16.listing = subq_19.listing
+              ) subq_20
+            ) subq_21
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_28
-        ) subq_29
-      ) subq_30
-    ) subq_31
+          ) subq_22
+        ) subq_23
+      ) subq_24
+    ) subq_25
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_38.booking_value
+        subq_32.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_37.booking_value) AS booking_value
+          SUM(subq_31.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_36.booking_value
+            subq_30.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_35.booking__is_instant
-              , subq_35.booking_value
+              subq_29.booking__is_instant
+              , subq_29.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_34.booking__is_instant
-                , subq_34.booking_value
+                subq_28.booking__is_instant
+                , subq_28.booking_value
               FROM (
                 -- Constrain Output with WHERE
                 SELECT
-                  subq_33.ds__day
-                  , subq_33.ds__week
-                  , subq_33.ds__month
-                  , subq_33.ds__quarter
-                  , subq_33.ds__year
-                  , subq_33.ds__extract_year
-                  , subq_33.ds__extract_quarter
-                  , subq_33.ds__extract_month
-                  , subq_33.ds__extract_day
-                  , subq_33.ds__extract_dow
-                  , subq_33.ds__extract_doy
-                  , subq_33.ds_partitioned__day
-                  , subq_33.ds_partitioned__week
-                  , subq_33.ds_partitioned__month
-                  , subq_33.ds_partitioned__quarter
-                  , subq_33.ds_partitioned__year
-                  , subq_33.ds_partitioned__extract_year
-                  , subq_33.ds_partitioned__extract_quarter
-                  , subq_33.ds_partitioned__extract_month
-                  , subq_33.ds_partitioned__extract_day
-                  , subq_33.ds_partitioned__extract_dow
-                  , subq_33.ds_partitioned__extract_doy
-                  , subq_33.paid_at__day
-                  , subq_33.paid_at__week
-                  , subq_33.paid_at__month
-                  , subq_33.paid_at__quarter
-                  , subq_33.paid_at__year
-                  , subq_33.paid_at__extract_year
-                  , subq_33.paid_at__extract_quarter
-                  , subq_33.paid_at__extract_month
-                  , subq_33.paid_at__extract_day
-                  , subq_33.paid_at__extract_dow
-                  , subq_33.paid_at__extract_doy
-                  , subq_33.booking__ds__day
-                  , subq_33.booking__ds__week
-                  , subq_33.booking__ds__month
-                  , subq_33.booking__ds__quarter
-                  , subq_33.booking__ds__year
-                  , subq_33.booking__ds__extract_year
-                  , subq_33.booking__ds__extract_quarter
-                  , subq_33.booking__ds__extract_month
-                  , subq_33.booking__ds__extract_day
-                  , subq_33.booking__ds__extract_dow
-                  , subq_33.booking__ds__extract_doy
-                  , subq_33.booking__ds_partitioned__day
-                  , subq_33.booking__ds_partitioned__week
-                  , subq_33.booking__ds_partitioned__month
-                  , subq_33.booking__ds_partitioned__quarter
-                  , subq_33.booking__ds_partitioned__year
-                  , subq_33.booking__ds_partitioned__extract_year
-                  , subq_33.booking__ds_partitioned__extract_quarter
-                  , subq_33.booking__ds_partitioned__extract_month
-                  , subq_33.booking__ds_partitioned__extract_day
-                  , subq_33.booking__ds_partitioned__extract_dow
-                  , subq_33.booking__ds_partitioned__extract_doy
-                  , subq_33.booking__paid_at__day
-                  , subq_33.booking__paid_at__week
-                  , subq_33.booking__paid_at__month
-                  , subq_33.booking__paid_at__quarter
-                  , subq_33.booking__paid_at__year
-                  , subq_33.booking__paid_at__extract_year
-                  , subq_33.booking__paid_at__extract_quarter
-                  , subq_33.booking__paid_at__extract_month
-                  , subq_33.booking__paid_at__extract_day
-                  , subq_33.booking__paid_at__extract_dow
-                  , subq_33.booking__paid_at__extract_doy
-                  , subq_33.metric_time__day
-                  , subq_33.metric_time__week
-                  , subq_33.metric_time__month
-                  , subq_33.metric_time__quarter
-                  , subq_33.metric_time__year
-                  , subq_33.metric_time__extract_year
-                  , subq_33.metric_time__extract_quarter
-                  , subq_33.metric_time__extract_month
-                  , subq_33.metric_time__extract_day
-                  , subq_33.metric_time__extract_dow
-                  , subq_33.metric_time__extract_doy
-                  , subq_33.listing
-                  , subq_33.guest
-                  , subq_33.host
-                  , subq_33.booking__listing
-                  , subq_33.booking__guest
-                  , subq_33.booking__host
-                  , subq_33.is_instant
-                  , subq_33.booking__is_instant
-                  , subq_33.bookings
-                  , subq_33.instant_bookings
-                  , subq_33.booking_value
-                  , subq_33.max_booking_value
-                  , subq_33.min_booking_value
-                  , subq_33.bookers
-                  , subq_33.average_booking_value
-                  , subq_33.referred_bookings
-                  , subq_33.median_booking_value
-                  , subq_33.booking_value_p99
-                  , subq_33.discrete_booking_value_p99
-                  , subq_33.approximate_continuous_booking_value_p99
-                  , subq_33.approximate_discrete_booking_value_p99
+                  subq_27.ds__day
+                  , subq_27.ds__week
+                  , subq_27.ds__month
+                  , subq_27.ds__quarter
+                  , subq_27.ds__year
+                  , subq_27.ds__extract_year
+                  , subq_27.ds__extract_quarter
+                  , subq_27.ds__extract_month
+                  , subq_27.ds__extract_day
+                  , subq_27.ds__extract_dow
+                  , subq_27.ds__extract_doy
+                  , subq_27.ds_partitioned__day
+                  , subq_27.ds_partitioned__week
+                  , subq_27.ds_partitioned__month
+                  , subq_27.ds_partitioned__quarter
+                  , subq_27.ds_partitioned__year
+                  , subq_27.ds_partitioned__extract_year
+                  , subq_27.ds_partitioned__extract_quarter
+                  , subq_27.ds_partitioned__extract_month
+                  , subq_27.ds_partitioned__extract_day
+                  , subq_27.ds_partitioned__extract_dow
+                  , subq_27.ds_partitioned__extract_doy
+                  , subq_27.paid_at__day
+                  , subq_27.paid_at__week
+                  , subq_27.paid_at__month
+                  , subq_27.paid_at__quarter
+                  , subq_27.paid_at__year
+                  , subq_27.paid_at__extract_year
+                  , subq_27.paid_at__extract_quarter
+                  , subq_27.paid_at__extract_month
+                  , subq_27.paid_at__extract_day
+                  , subq_27.paid_at__extract_dow
+                  , subq_27.paid_at__extract_doy
+                  , subq_27.booking__ds__day
+                  , subq_27.booking__ds__week
+                  , subq_27.booking__ds__month
+                  , subq_27.booking__ds__quarter
+                  , subq_27.booking__ds__year
+                  , subq_27.booking__ds__extract_year
+                  , subq_27.booking__ds__extract_quarter
+                  , subq_27.booking__ds__extract_month
+                  , subq_27.booking__ds__extract_day
+                  , subq_27.booking__ds__extract_dow
+                  , subq_27.booking__ds__extract_doy
+                  , subq_27.booking__ds_partitioned__day
+                  , subq_27.booking__ds_partitioned__week
+                  , subq_27.booking__ds_partitioned__month
+                  , subq_27.booking__ds_partitioned__quarter
+                  , subq_27.booking__ds_partitioned__year
+                  , subq_27.booking__ds_partitioned__extract_year
+                  , subq_27.booking__ds_partitioned__extract_quarter
+                  , subq_27.booking__ds_partitioned__extract_month
+                  , subq_27.booking__ds_partitioned__extract_day
+                  , subq_27.booking__ds_partitioned__extract_dow
+                  , subq_27.booking__ds_partitioned__extract_doy
+                  , subq_27.booking__paid_at__day
+                  , subq_27.booking__paid_at__week
+                  , subq_27.booking__paid_at__month
+                  , subq_27.booking__paid_at__quarter
+                  , subq_27.booking__paid_at__year
+                  , subq_27.booking__paid_at__extract_year
+                  , subq_27.booking__paid_at__extract_quarter
+                  , subq_27.booking__paid_at__extract_month
+                  , subq_27.booking__paid_at__extract_day
+                  , subq_27.booking__paid_at__extract_dow
+                  , subq_27.booking__paid_at__extract_doy
+                  , subq_27.metric_time__day
+                  , subq_27.metric_time__week
+                  , subq_27.metric_time__month
+                  , subq_27.metric_time__quarter
+                  , subq_27.metric_time__year
+                  , subq_27.metric_time__extract_year
+                  , subq_27.metric_time__extract_quarter
+                  , subq_27.metric_time__extract_month
+                  , subq_27.metric_time__extract_day
+                  , subq_27.metric_time__extract_dow
+                  , subq_27.metric_time__extract_doy
+                  , subq_27.listing
+                  , subq_27.guest
+                  , subq_27.host
+                  , subq_27.booking__listing
+                  , subq_27.booking__guest
+                  , subq_27.booking__host
+                  , subq_27.is_instant
+                  , subq_27.booking__is_instant
+                  , subq_27.bookings
+                  , subq_27.instant_bookings
+                  , subq_27.booking_value
+                  , subq_27.max_booking_value
+                  , subq_27.min_booking_value
+                  , subq_27.bookers
+                  , subq_27.average_booking_value
+                  , subq_27.referred_bookings
+                  , subq_27.median_booking_value
+                  , subq_27.booking_value_p99
+                  , subq_27.discrete_booking_value_p99
+                  , subq_27.approximate_continuous_booking_value_p99
+                  , subq_27.approximate_discrete_booking_value_p99
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_32.ds__day
-                    , subq_32.ds__week
-                    , subq_32.ds__month
-                    , subq_32.ds__quarter
-                    , subq_32.ds__year
-                    , subq_32.ds__extract_year
-                    , subq_32.ds__extract_quarter
-                    , subq_32.ds__extract_month
-                    , subq_32.ds__extract_day
-                    , subq_32.ds__extract_dow
-                    , subq_32.ds__extract_doy
-                    , subq_32.ds_partitioned__day
-                    , subq_32.ds_partitioned__week
-                    , subq_32.ds_partitioned__month
-                    , subq_32.ds_partitioned__quarter
-                    , subq_32.ds_partitioned__year
-                    , subq_32.ds_partitioned__extract_year
-                    , subq_32.ds_partitioned__extract_quarter
-                    , subq_32.ds_partitioned__extract_month
-                    , subq_32.ds_partitioned__extract_day
-                    , subq_32.ds_partitioned__extract_dow
-                    , subq_32.ds_partitioned__extract_doy
-                    , subq_32.paid_at__day
-                    , subq_32.paid_at__week
-                    , subq_32.paid_at__month
-                    , subq_32.paid_at__quarter
-                    , subq_32.paid_at__year
-                    , subq_32.paid_at__extract_year
-                    , subq_32.paid_at__extract_quarter
-                    , subq_32.paid_at__extract_month
-                    , subq_32.paid_at__extract_day
-                    , subq_32.paid_at__extract_dow
-                    , subq_32.paid_at__extract_doy
-                    , subq_32.booking__ds__day
-                    , subq_32.booking__ds__week
-                    , subq_32.booking__ds__month
-                    , subq_32.booking__ds__quarter
-                    , subq_32.booking__ds__year
-                    , subq_32.booking__ds__extract_year
-                    , subq_32.booking__ds__extract_quarter
-                    , subq_32.booking__ds__extract_month
-                    , subq_32.booking__ds__extract_day
-                    , subq_32.booking__ds__extract_dow
-                    , subq_32.booking__ds__extract_doy
-                    , subq_32.booking__ds_partitioned__day
-                    , subq_32.booking__ds_partitioned__week
-                    , subq_32.booking__ds_partitioned__month
-                    , subq_32.booking__ds_partitioned__quarter
-                    , subq_32.booking__ds_partitioned__year
-                    , subq_32.booking__ds_partitioned__extract_year
-                    , subq_32.booking__ds_partitioned__extract_quarter
-                    , subq_32.booking__ds_partitioned__extract_month
-                    , subq_32.booking__ds_partitioned__extract_day
-                    , subq_32.booking__ds_partitioned__extract_dow
-                    , subq_32.booking__ds_partitioned__extract_doy
-                    , subq_32.booking__paid_at__day
-                    , subq_32.booking__paid_at__week
-                    , subq_32.booking__paid_at__month
-                    , subq_32.booking__paid_at__quarter
-                    , subq_32.booking__paid_at__year
-                    , subq_32.booking__paid_at__extract_year
-                    , subq_32.booking__paid_at__extract_quarter
-                    , subq_32.booking__paid_at__extract_month
-                    , subq_32.booking__paid_at__extract_day
-                    , subq_32.booking__paid_at__extract_dow
-                    , subq_32.booking__paid_at__extract_doy
-                    , subq_32.ds__day AS metric_time__day
-                    , subq_32.ds__week AS metric_time__week
-                    , subq_32.ds__month AS metric_time__month
-                    , subq_32.ds__quarter AS metric_time__quarter
-                    , subq_32.ds__year AS metric_time__year
-                    , subq_32.ds__extract_year AS metric_time__extract_year
-                    , subq_32.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_32.ds__extract_month AS metric_time__extract_month
-                    , subq_32.ds__extract_day AS metric_time__extract_day
-                    , subq_32.ds__extract_dow AS metric_time__extract_dow
-                    , subq_32.ds__extract_doy AS metric_time__extract_doy
-                    , subq_32.listing
-                    , subq_32.guest
-                    , subq_32.host
-                    , subq_32.booking__listing
-                    , subq_32.booking__guest
-                    , subq_32.booking__host
-                    , subq_32.is_instant
-                    , subq_32.booking__is_instant
-                    , subq_32.bookings
-                    , subq_32.instant_bookings
-                    , subq_32.booking_value
-                    , subq_32.max_booking_value
-                    , subq_32.min_booking_value
-                    , subq_32.bookers
-                    , subq_32.average_booking_value
-                    , subq_32.referred_bookings
-                    , subq_32.median_booking_value
-                    , subq_32.booking_value_p99
-                    , subq_32.discrete_booking_value_p99
-                    , subq_32.approximate_continuous_booking_value_p99
-                    , subq_32.approximate_discrete_booking_value_p99
+                    subq_26.ds__day
+                    , subq_26.ds__week
+                    , subq_26.ds__month
+                    , subq_26.ds__quarter
+                    , subq_26.ds__year
+                    , subq_26.ds__extract_year
+                    , subq_26.ds__extract_quarter
+                    , subq_26.ds__extract_month
+                    , subq_26.ds__extract_day
+                    , subq_26.ds__extract_dow
+                    , subq_26.ds__extract_doy
+                    , subq_26.ds_partitioned__day
+                    , subq_26.ds_partitioned__week
+                    , subq_26.ds_partitioned__month
+                    , subq_26.ds_partitioned__quarter
+                    , subq_26.ds_partitioned__year
+                    , subq_26.ds_partitioned__extract_year
+                    , subq_26.ds_partitioned__extract_quarter
+                    , subq_26.ds_partitioned__extract_month
+                    , subq_26.ds_partitioned__extract_day
+                    , subq_26.ds_partitioned__extract_dow
+                    , subq_26.ds_partitioned__extract_doy
+                    , subq_26.paid_at__day
+                    , subq_26.paid_at__week
+                    , subq_26.paid_at__month
+                    , subq_26.paid_at__quarter
+                    , subq_26.paid_at__year
+                    , subq_26.paid_at__extract_year
+                    , subq_26.paid_at__extract_quarter
+                    , subq_26.paid_at__extract_month
+                    , subq_26.paid_at__extract_day
+                    , subq_26.paid_at__extract_dow
+                    , subq_26.paid_at__extract_doy
+                    , subq_26.booking__ds__day
+                    , subq_26.booking__ds__week
+                    , subq_26.booking__ds__month
+                    , subq_26.booking__ds__quarter
+                    , subq_26.booking__ds__year
+                    , subq_26.booking__ds__extract_year
+                    , subq_26.booking__ds__extract_quarter
+                    , subq_26.booking__ds__extract_month
+                    , subq_26.booking__ds__extract_day
+                    , subq_26.booking__ds__extract_dow
+                    , subq_26.booking__ds__extract_doy
+                    , subq_26.booking__ds_partitioned__day
+                    , subq_26.booking__ds_partitioned__week
+                    , subq_26.booking__ds_partitioned__month
+                    , subq_26.booking__ds_partitioned__quarter
+                    , subq_26.booking__ds_partitioned__year
+                    , subq_26.booking__ds_partitioned__extract_year
+                    , subq_26.booking__ds_partitioned__extract_quarter
+                    , subq_26.booking__ds_partitioned__extract_month
+                    , subq_26.booking__ds_partitioned__extract_day
+                    , subq_26.booking__ds_partitioned__extract_dow
+                    , subq_26.booking__ds_partitioned__extract_doy
+                    , subq_26.booking__paid_at__day
+                    , subq_26.booking__paid_at__week
+                    , subq_26.booking__paid_at__month
+                    , subq_26.booking__paid_at__quarter
+                    , subq_26.booking__paid_at__year
+                    , subq_26.booking__paid_at__extract_year
+                    , subq_26.booking__paid_at__extract_quarter
+                    , subq_26.booking__paid_at__extract_month
+                    , subq_26.booking__paid_at__extract_day
+                    , subq_26.booking__paid_at__extract_dow
+                    , subq_26.booking__paid_at__extract_doy
+                    , subq_26.ds__day AS metric_time__day
+                    , subq_26.ds__week AS metric_time__week
+                    , subq_26.ds__month AS metric_time__month
+                    , subq_26.ds__quarter AS metric_time__quarter
+                    , subq_26.ds__year AS metric_time__year
+                    , subq_26.ds__extract_year AS metric_time__extract_year
+                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_26.ds__extract_month AS metric_time__extract_month
+                    , subq_26.ds__extract_day AS metric_time__extract_day
+                    , subq_26.ds__extract_dow AS metric_time__extract_dow
+                    , subq_26.ds__extract_doy AS metric_time__extract_doy
+                    , subq_26.listing
+                    , subq_26.guest
+                    , subq_26.host
+                    , subq_26.booking__listing
+                    , subq_26.booking__guest
+                    , subq_26.booking__host
+                    , subq_26.is_instant
+                    , subq_26.booking__is_instant
+                    , subq_26.bookings
+                    , subq_26.instant_bookings
+                    , subq_26.booking_value
+                    , subq_26.max_booking_value
+                    , subq_26.min_booking_value
+                    , subq_26.bookers
+                    , subq_26.average_booking_value
+                    , subq_26.referred_bookings
+                    , subq_26.median_booking_value
+                    , subq_26.booking_value_p99
+                    , subq_26.discrete_booking_value_p99
+                    , subq_26.approximate_continuous_booking_value_p99
+                    , subq_26.approximate_discrete_booking_value_p99
                   FROM (
                     -- Read Elements From Semantic Model 'bookings_source'
                     SELECT
@@ -1293,15 +1293,15 @@ FROM (
                       , bookings_source_src_28000.guest_id AS booking__guest
                       , bookings_source_src_28000.host_id AS booking__host
                     FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_32
-                ) subq_33
+                  ) subq_26
+                ) subq_27
                 WHERE booking__is_instant
-              ) subq_34
-            ) subq_35
+              ) subq_28
+            ) subq_29
             WHERE booking__is_instant
-          ) subq_36
-        ) subq_37
-      ) subq_38
-    ) subq_39
-  ) subq_40
-) subq_41
+          ) subq_30
+        ) subq_31
+      ) subq_32
+    ) subq_33
+  ) subq_34
+) subq_35

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_60.average_booking_value) AS average_booking_value
-      , MAX(subq_73.bookings) AS bookings
-      , MAX(subq_81.booking_value) AS booking_value
+      MAX(subq_48.average_booking_value) AS average_booking_value
+      , MAX(subq_61.bookings) AS bookings
+      , MAX(subq_69.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_51.booking__is_instant AS booking__is_instant
+          subq_39.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_51.average_booking_value AS average_booking_value
+          , subq_39.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_49
+          ) subq_37
           WHERE booking__is_instant
-        ) subq_51
+        ) subq_39
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_51.listing = listings_latest_src_28000.listing_id
-      ) subq_56
+          subq_39.listing = listings_latest_src_28000.listing_id
+      ) subq_44
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_60
+    ) subq_48
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_64.booking__is_instant AS booking__is_instant
+          subq_52.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_64.bookings AS bookings
+          , subq_52.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_62
+          ) subq_50
           WHERE booking__is_instant
-        ) subq_64
+        ) subq_52
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_64.listing = listings_latest_src_28000.listing_id
-      ) subq_69
+          subq_52.listing = listings_latest_src_28000.listing_id
+      ) subq_57
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_73
+    ) subq_61
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_75
+        ) subq_63
         WHERE booking__is_instant
-      ) subq_77
+      ) subq_65
       WHERE booking__is_instant
-    ) subq_81
-  ) subq_82
-) subq_83
+    ) subq_69
+  ) subq_70
+) subq_71

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
-  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings
+    subq_9.metric_time__day
+    , subq_9.bookings
   FROM (
     -- Constrain Output with WHERE
     SELECT
-      subq_10.metric_time__day
-      , subq_10.bookings
+      subq_8.metric_time__day
+      , subq_8.bookings
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_8.metric_time__day AS metric_time__day
-        , subq_7.bookings AS bookings
+        subq_6.metric_time__day AS metric_time__day
+        , subq_5.bookings AS bookings
       FROM (
         -- Time Spine
         SELECT
-          subq_9.ds AS metric_time__day
-        FROM ***************************.mf_time_spine subq_9
-        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_8
+          subq_7.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_7
+        WHERE subq_7.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_6
       LEFT OUTER JOIN (
         -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , SUM(subq_6.bookings) AS bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.bookings) AS bookings
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.bookings
+            subq_3.metric_time__day
+            , subq_3.bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day
+              , subq_2.bookings
             FROM (
               -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -333,20 +333,20 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
-              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-            ) subq_4
-          ) subq_5
+                ) subq_0
+              ) subq_1
+              WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_2
+          ) subq_3
           WHERE metric_time__day > '2020-01-01'
-        ) subq_6
+        ) subq_4
         GROUP BY
           metric_time__day
-      ) subq_7
+      ) subq_5
       ON
-        subq_8.metric_time__day = subq_7.metric_time__day
-    ) subq_10
+        subq_6.metric_time__day = subq_5.metric_time__day
+    ) subq_8
     WHERE metric_time__day > '2020-01-01'
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_12
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.metric_time__day AS metric_time__day
-      , subq_20.bookings AS bookings
+      subq_17.metric_time__day AS metric_time__day
+      , subq_16.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_22
+      FROM ***************************.mf_time_spine subq_18
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_21
+    ) subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_18
+      ) subq_14
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_20
+    ) subq_16
     ON
-      subq_21.metric_time__day = subq_20.metric_time__day
-  ) subq_23
+      subq_17.metric_time__day = subq_16.metric_time__day
+  ) subq_19
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_25
+) subq_21

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
-  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings
+    subq_9.metric_time__day
+    , subq_9.bookings
   FROM (
     -- Constrain Output with WHERE
     SELECT
-      subq_10.metric_time__day
-      , subq_10.bookings
+      subq_8.metric_time__day
+      , subq_8.bookings
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_8.metric_time__day AS metric_time__day
-        , subq_7.bookings AS bookings
+        subq_6.metric_time__day AS metric_time__day
+        , subq_5.bookings AS bookings
       FROM (
         -- Time Spine
         SELECT
-          subq_9.ds AS metric_time__day
-        FROM ***************************.mf_time_spine subq_9
-        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_8
+          subq_7.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_7
+        WHERE subq_7.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_6
       LEFT OUTER JOIN (
         -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , SUM(subq_6.bookings) AS bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.bookings) AS bookings
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.bookings
+            subq_3.metric_time__day
+            , subq_3.bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day
+              , subq_2.bookings
             FROM (
               -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -333,20 +333,20 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
-              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-            ) subq_4
-          ) subq_5
+                ) subq_0
+              ) subq_1
+              WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_2
+          ) subq_3
           WHERE metric_time__day > '2020-01-01'
-        ) subq_6
+        ) subq_4
         GROUP BY
-          subq_6.metric_time__day
-      ) subq_7
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        subq_8.metric_time__day = subq_7.metric_time__day
-    ) subq_10
+        subq_6.metric_time__day = subq_5.metric_time__day
+    ) subq_8
     WHERE metric_time__day > '2020-01-01'
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_12
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.metric_time__day AS metric_time__day
-      , subq_20.bookings AS bookings
+      subq_17.metric_time__day AS metric_time__day
+      , subq_16.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_22
+      FROM ***************************.mf_time_spine subq_18
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_21
+    ) subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_18
+      ) subq_14
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_20
+    ) subq_16
     ON
-      subq_21.metric_time__day = subq_20.metric_time__day
-  ) subq_23
+      subq_17.metric_time__day = subq_16.metric_time__day
+  ) subq_19
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_25
+) subq_21

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
-  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings
+    subq_9.metric_time__day
+    , subq_9.bookings
   FROM (
     -- Constrain Output with WHERE
     SELECT
-      subq_10.metric_time__day
-      , subq_10.bookings
+      subq_8.metric_time__day
+      , subq_8.bookings
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_8.metric_time__day AS metric_time__day
-        , subq_7.bookings AS bookings
+        subq_6.metric_time__day AS metric_time__day
+        , subq_5.bookings AS bookings
       FROM (
         -- Time Spine
         SELECT
-          subq_9.ds AS metric_time__day
-        FROM ***************************.mf_time_spine subq_9
-        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_8
+          subq_7.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_7
+        WHERE subq_7.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_6
       LEFT OUTER JOIN (
         -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , SUM(subq_6.bookings) AS bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.bookings) AS bookings
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.bookings
+            subq_3.metric_time__day
+            , subq_3.bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day
+              , subq_2.bookings
             FROM (
               -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -333,20 +333,20 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
-              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-            ) subq_4
-          ) subq_5
+                ) subq_0
+              ) subq_1
+              WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_2
+          ) subq_3
           WHERE metric_time__day > '2020-01-01'
-        ) subq_6
+        ) subq_4
         GROUP BY
-          subq_6.metric_time__day
-      ) subq_7
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        subq_8.metric_time__day = subq_7.metric_time__day
-    ) subq_10
+        subq_6.metric_time__day = subq_5.metric_time__day
+    ) subq_8
     WHERE metric_time__day > '2020-01-01'
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_12
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.metric_time__day AS metric_time__day
-      , subq_20.bookings AS bookings
+      subq_17.metric_time__day AS metric_time__day
+      , subq_16.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_22
+      FROM ***************************.mf_time_spine subq_18
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_21
+    ) subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_18
+      ) subq_14
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_20
+    ) subq_16
     ON
-      subq_21.metric_time__day = subq_20.metric_time__day
-  ) subq_23
+      subq_17.metric_time__day = subq_16.metric_time__day
+  ) subq_19
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_25
+) subq_21

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
-  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings
+    subq_9.metric_time__day
+    , subq_9.bookings
   FROM (
     -- Constrain Output with WHERE
     SELECT
-      subq_10.metric_time__day
-      , subq_10.bookings
+      subq_8.metric_time__day
+      , subq_8.bookings
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_8.metric_time__day AS metric_time__day
-        , subq_7.bookings AS bookings
+        subq_6.metric_time__day AS metric_time__day
+        , subq_5.bookings AS bookings
       FROM (
         -- Time Spine
         SELECT
-          subq_9.ds AS metric_time__day
-        FROM ***************************.mf_time_spine subq_9
-        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_8
+          subq_7.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_7
+        WHERE subq_7.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_6
       LEFT OUTER JOIN (
         -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , SUM(subq_6.bookings) AS bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.bookings) AS bookings
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.bookings
+            subq_3.metric_time__day
+            , subq_3.bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day
+              , subq_2.bookings
             FROM (
               -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -333,20 +333,20 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
-              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-            ) subq_4
-          ) subq_5
+                ) subq_0
+              ) subq_1
+              WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_2
+          ) subq_3
           WHERE metric_time__day > '2020-01-01'
-        ) subq_6
+        ) subq_4
         GROUP BY
-          subq_6.metric_time__day
-      ) subq_7
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        subq_8.metric_time__day = subq_7.metric_time__day
-    ) subq_10
+        subq_6.metric_time__day = subq_5.metric_time__day
+    ) subq_8
     WHERE metric_time__day > '2020-01-01'
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_12
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.metric_time__day AS metric_time__day
-      , subq_20.bookings AS bookings
+      subq_17.metric_time__day AS metric_time__day
+      , subq_16.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_22
+      FROM ***************************.mf_time_spine subq_18
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_21
+    ) subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_18
+      ) subq_14
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_20
+    ) subq_16
     ON
-      subq_21.metric_time__day = subq_20.metric_time__day
-  ) subq_23
+      subq_17.metric_time__day = subq_16.metric_time__day
+  ) subq_19
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_25
+) subq_21

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
-  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings
+    subq_9.metric_time__day
+    , subq_9.bookings
   FROM (
     -- Constrain Output with WHERE
     SELECT
-      subq_10.metric_time__day
-      , subq_10.bookings
+      subq_8.metric_time__day
+      , subq_8.bookings
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_8.metric_time__day AS metric_time__day
-        , subq_7.bookings AS bookings
+        subq_6.metric_time__day AS metric_time__day
+        , subq_5.bookings AS bookings
       FROM (
         -- Time Spine
         SELECT
-          subq_9.ds AS metric_time__day
-        FROM ***************************.mf_time_spine subq_9
-        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_8
+          subq_7.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_7
+        WHERE subq_7.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_6
       LEFT OUTER JOIN (
         -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , SUM(subq_6.bookings) AS bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.bookings) AS bookings
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.bookings
+            subq_3.metric_time__day
+            , subq_3.bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day
+              , subq_2.bookings
             FROM (
               -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -333,20 +333,20 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
-              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-            ) subq_4
-          ) subq_5
+                ) subq_0
+              ) subq_1
+              WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_2
+          ) subq_3
           WHERE metric_time__day > '2020-01-01'
-        ) subq_6
+        ) subq_4
         GROUP BY
-          subq_6.metric_time__day
-      ) subq_7
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        subq_8.metric_time__day = subq_7.metric_time__day
-    ) subq_10
+        subq_6.metric_time__day = subq_5.metric_time__day
+    ) subq_8
     WHERE metric_time__day > '2020-01-01'
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_12
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.metric_time__day AS metric_time__day
-      , subq_20.bookings AS bookings
+      subq_17.metric_time__day AS metric_time__day
+      , subq_16.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_22
+      FROM ***************************.mf_time_spine subq_18
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_21
+    ) subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_18
+      ) subq_14
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_20
+    ) subq_16
     ON
-      subq_21.metric_time__day = subq_20.metric_time__day
-  ) subq_23
+      subq_17.metric_time__day = subq_16.metric_time__day
+  ) subq_19
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_25
+) subq_21

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
-  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings
+    subq_9.metric_time__day
+    , subq_9.bookings
   FROM (
     -- Constrain Output with WHERE
     SELECT
-      subq_10.metric_time__day
-      , subq_10.bookings
+      subq_8.metric_time__day
+      , subq_8.bookings
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_8.metric_time__day AS metric_time__day
-        , subq_7.bookings AS bookings
+        subq_6.metric_time__day AS metric_time__day
+        , subq_5.bookings AS bookings
       FROM (
         -- Time Spine
         SELECT
-          subq_9.ds AS metric_time__day
-        FROM ***************************.mf_time_spine subq_9
-        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_8
+          subq_7.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_7
+        WHERE subq_7.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_6
       LEFT OUTER JOIN (
         -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , SUM(subq_6.bookings) AS bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.bookings) AS bookings
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.bookings
+            subq_3.metric_time__day
+            , subq_3.bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day
+              , subq_2.bookings
             FROM (
               -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -333,20 +333,20 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
-              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-            ) subq_4
-          ) subq_5
+                ) subq_0
+              ) subq_1
+              WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_2
+          ) subq_3
           WHERE metric_time__day > '2020-01-01'
-        ) subq_6
+        ) subq_4
         GROUP BY
-          subq_6.metric_time__day
-      ) subq_7
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        subq_8.metric_time__day = subq_7.metric_time__day
-    ) subq_10
+        subq_6.metric_time__day = subq_5.metric_time__day
+    ) subq_8
     WHERE metric_time__day > '2020-01-01'
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_12
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.metric_time__day AS metric_time__day
-      , subq_20.bookings AS bookings
+      subq_17.metric_time__day AS metric_time__day
+      , subq_16.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_22
+      FROM ***************************.mf_time_spine subq_18
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_21
+    ) subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_18
+      ) subq_14
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_20
+    ) subq_16
     ON
-      subq_21.metric_time__day = subq_20.metric_time__day
-  ) subq_23
+      subq_17.metric_time__day = subq_16.metric_time__day
+  ) subq_19
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_25
+) subq_21

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
-  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings
+    subq_9.metric_time__day
+    , subq_9.bookings
   FROM (
     -- Constrain Output with WHERE
     SELECT
-      subq_10.metric_time__day
-      , subq_10.bookings
+      subq_8.metric_time__day
+      , subq_8.bookings
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_8.metric_time__day AS metric_time__day
-        , subq_7.bookings AS bookings
+        subq_6.metric_time__day AS metric_time__day
+        , subq_5.bookings AS bookings
       FROM (
         -- Time Spine
         SELECT
-          subq_9.ds AS metric_time__day
-        FROM ***************************.mf_time_spine subq_9
-        WHERE subq_9.ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-      ) subq_8
+          subq_7.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_7
+        WHERE subq_7.ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+      ) subq_6
       LEFT OUTER JOIN (
         -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , SUM(subq_6.bookings) AS bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.bookings) AS bookings
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.bookings
+            subq_3.metric_time__day
+            , subq_3.bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day
+              , subq_2.bookings
             FROM (
               -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -333,20 +333,20 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
-              WHERE subq_3.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-            ) subq_4
-          ) subq_5
+                ) subq_0
+              ) subq_1
+              WHERE subq_1.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+            ) subq_2
+          ) subq_3
           WHERE metric_time__day > '2020-01-01'
-        ) subq_6
+        ) subq_4
         GROUP BY
-          subq_6.metric_time__day
-      ) subq_7
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        subq_8.metric_time__day = subq_7.metric_time__day
-    ) subq_10
+        subq_6.metric_time__day = subq_5.metric_time__day
+    ) subq_8
     WHERE metric_time__day > '2020-01-01'
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-) subq_12
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.metric_time__day AS metric_time__day
-      , subq_20.bookings AS bookings
+      subq_17.metric_time__day AS metric_time__day
+      , subq_16.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_22
+      FROM ***************************.mf_time_spine subq_18
       WHERE ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-    ) subq_21
+    ) subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-      ) subq_18
+      ) subq_14
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_20
+    ) subq_16
     ON
-      subq_21.metric_time__day = subq_20.metric_time__day
-  ) subq_23
+      subq_17.metric_time__day = subq_16.metric_time__day
+  ) subq_19
   WHERE (
     metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_25
+) subq_21

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -1,20 +1,20 @@
 -- Pass Only Elements: ['listing',]
 SELECT
-  subq_12.listing
+  subq_8.listing
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_11.listing
-    , subq_11.lux_listing
-    , subq_11.listing__lux_listing
-    , subq_11.listing__bookings
+    subq_7.listing
+    , subq_7.lux_listing
+    , subq_7.listing__lux_listing
+    , subq_7.listing__bookings
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_4.listing AS listing
-      , subq_4.lux_listing AS lux_listing
-      , subq_4.listing__lux_listing AS listing__lux_listing
-      , subq_10.listing__bookings AS listing__bookings
+      subq_0.listing AS listing
+      , subq_0.lux_listing AS lux_listing
+      , subq_0.listing__lux_listing AS listing__lux_listing
+      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT
@@ -22,128 +22,128 @@ FROM (
         , lux_listing_mapping_src_28000.lux_listing_id AS lux_listing
         , lux_listing_mapping_src_28000.lux_listing_id AS listing__lux_listing
       FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
-    ) subq_4
+    ) subq_0
     FULL OUTER JOIN (
       -- Pass Only Elements: ['listing', 'listing__bookings']
       SELECT
-        subq_9.listing
-        , subq_9.listing__bookings
+        subq_5.listing
+        , subq_5.listing__bookings
       FROM (
         -- Compute Metrics via Expressions
         SELECT
-          subq_8.listing
-          , subq_8.bookings AS listing__bookings
+          subq_4.listing
+          , subq_4.bookings AS listing__bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_7.listing
-            , SUM(subq_7.bookings) AS bookings
+            subq_3.listing
+            , SUM(subq_3.bookings) AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'listing']
             SELECT
-              subq_6.listing
-              , subq_6.bookings
+              subq_2.listing
+              , subq_2.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds__day
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.ds__extract_year
-                , subq_5.ds__extract_quarter
-                , subq_5.ds__extract_month
-                , subq_5.ds__extract_day
-                , subq_5.ds__extract_dow
-                , subq_5.ds__extract_doy
-                , subq_5.ds_partitioned__day
-                , subq_5.ds_partitioned__week
-                , subq_5.ds_partitioned__month
-                , subq_5.ds_partitioned__quarter
-                , subq_5.ds_partitioned__year
-                , subq_5.ds_partitioned__extract_year
-                , subq_5.ds_partitioned__extract_quarter
-                , subq_5.ds_partitioned__extract_month
-                , subq_5.ds_partitioned__extract_day
-                , subq_5.ds_partitioned__extract_dow
-                , subq_5.ds_partitioned__extract_doy
-                , subq_5.paid_at__day
-                , subq_5.paid_at__week
-                , subq_5.paid_at__month
-                , subq_5.paid_at__quarter
-                , subq_5.paid_at__year
-                , subq_5.paid_at__extract_year
-                , subq_5.paid_at__extract_quarter
-                , subq_5.paid_at__extract_month
-                , subq_5.paid_at__extract_day
-                , subq_5.paid_at__extract_dow
-                , subq_5.paid_at__extract_doy
-                , subq_5.booking__ds__day
-                , subq_5.booking__ds__week
-                , subq_5.booking__ds__month
-                , subq_5.booking__ds__quarter
-                , subq_5.booking__ds__year
-                , subq_5.booking__ds__extract_year
-                , subq_5.booking__ds__extract_quarter
-                , subq_5.booking__ds__extract_month
-                , subq_5.booking__ds__extract_day
-                , subq_5.booking__ds__extract_dow
-                , subq_5.booking__ds__extract_doy
-                , subq_5.booking__ds_partitioned__day
-                , subq_5.booking__ds_partitioned__week
-                , subq_5.booking__ds_partitioned__month
-                , subq_5.booking__ds_partitioned__quarter
-                , subq_5.booking__ds_partitioned__year
-                , subq_5.booking__ds_partitioned__extract_year
-                , subq_5.booking__ds_partitioned__extract_quarter
-                , subq_5.booking__ds_partitioned__extract_month
-                , subq_5.booking__ds_partitioned__extract_day
-                , subq_5.booking__ds_partitioned__extract_dow
-                , subq_5.booking__ds_partitioned__extract_doy
-                , subq_5.booking__paid_at__day
-                , subq_5.booking__paid_at__week
-                , subq_5.booking__paid_at__month
-                , subq_5.booking__paid_at__quarter
-                , subq_5.booking__paid_at__year
-                , subq_5.booking__paid_at__extract_year
-                , subq_5.booking__paid_at__extract_quarter
-                , subq_5.booking__paid_at__extract_month
-                , subq_5.booking__paid_at__extract_day
-                , subq_5.booking__paid_at__extract_dow
-                , subq_5.booking__paid_at__extract_doy
-                , subq_5.ds__day AS metric_time__day
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.ds__extract_year AS metric_time__extract_year
-                , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_5.ds__extract_month AS metric_time__extract_month
-                , subq_5.ds__extract_day AS metric_time__extract_day
-                , subq_5.ds__extract_dow AS metric_time__extract_dow
-                , subq_5.ds__extract_doy AS metric_time__extract_doy
-                , subq_5.listing
-                , subq_5.guest
-                , subq_5.host
-                , subq_5.booking__listing
-                , subq_5.booking__guest
-                , subq_5.booking__host
-                , subq_5.is_instant
-                , subq_5.booking__is_instant
-                , subq_5.bookings
-                , subq_5.instant_bookings
-                , subq_5.booking_value
-                , subq_5.max_booking_value
-                , subq_5.min_booking_value
-                , subq_5.bookers
-                , subq_5.average_booking_value
-                , subq_5.referred_bookings
-                , subq_5.median_booking_value
-                , subq_5.booking_value_p99
-                , subq_5.discrete_booking_value_p99
-                , subq_5.approximate_continuous_booking_value_p99
-                , subq_5.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.ds__day AS metric_time__day
+                , subq_1.ds__week AS metric_time__week
+                , subq_1.ds__month AS metric_time__month
+                , subq_1.ds__quarter AS metric_time__quarter
+                , subq_1.ds__year AS metric_time__year
+                , subq_1.ds__extract_year AS metric_time__extract_year
+                , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_1.ds__extract_month AS metric_time__extract_month
+                , subq_1.ds__extract_day AS metric_time__extract_day
+                , subq_1.ds__extract_dow AS metric_time__extract_dow
+                , subq_1.ds__extract_doy AS metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -236,18 +236,18 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_5
-            ) subq_6
-          ) subq_7
+              ) subq_1
+            ) subq_2
+          ) subq_3
           GROUP BY
             listing
-        ) subq_8
-      ) subq_9
-    ) subq_10
+        ) subq_4
+      ) subq_5
+    ) subq_6
     ON
-      subq_4.listing = subq_10.listing
-  ) subq_11
+      subq_0.listing = subq_6.listing
+  ) subq_7
   WHERE listing__bookings > 2
-) subq_12
+) subq_8
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_23.listing__bookings AS listing__bookings
+    , subq_15.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+    ) subq_12
     GROUP BY
       listing
-  ) subq_23
+  ) subq_15
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_23.listing
-) subq_24
+    lux_listing_mapping_src_28000.listing_id = subq_15.listing
+) subq_16
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.guest__booking_value
-        , subq_14.bookers
+        subq_10.guest__booking_value
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'guest__booking_value']
         SELECT
-          subq_13.guest__booking_value
-          , subq_13.bookers
+          subq_9.guest__booking_value
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.guest AS guest
-            , subq_12.guest__booking_value AS guest__booking_value
-            , subq_6.bookers AS bookers
+            subq_2.guest AS guest
+            , subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']
             SELECT
-              subq_5.guest
-              , subq_5.bookers
+              subq_1.guest
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['guest', 'guest__booking_value']
             SELECT
-              subq_11.guest
-              , subq_11.guest__booking_value
+              subq_7.guest
+              , subq_7.guest__booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.guest
-                , subq_10.booking_value AS guest__booking_value
+                subq_6.guest
+                , subq_6.booking_value AS guest__booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.guest
-                  , SUM(subq_9.booking_value) AS booking_value
+                  subq_5.guest
+                  , SUM(subq_5.booking_value) AS booking_value
                 FROM (
                   -- Pass Only Elements: ['booking_value', 'guest']
                   SELECT
-                    subq_8.guest
-                    , subq_8.booking_value
+                    subq_4.guest
+                    , subq_4.booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
                   guest
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.guest = subq_12.guest
-        ) subq_13
-      ) subq_14
+            subq_2.guest = subq_8.guest
+        ) subq_9
+      ) subq_10
       WHERE guest__booking_value > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_30.guest__booking_value AS guest__booking_value
-    , subq_24.bookers AS bookers
+    subq_22.guest__booking_value AS guest__booking_value
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.guest = subq_30.guest
-) subq_32
+    subq_16.guest = subq_22.guest
+) subq_24
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_39.listings
+  subq_24.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_38.listings) AS listings
+    SUM(subq_23.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_37.listings
+      subq_22.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_36.user__visit_buy_conversion_rate
-        , subq_36.listings
+        subq_21.user__visit_buy_conversion_rate
+        , subq_21.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
         SELECT
-          subq_35.user__visit_buy_conversion_rate
-          , subq_35.listings
+          subq_20.user__visit_buy_conversion_rate
+          , subq_20.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_17.user AS user
-            , subq_34.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
-            , subq_17.listings AS listings
+            subq_2.user AS user
+            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_16.user
-              , subq_16.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_15.ds__day
-                , subq_15.ds__week
-                , subq_15.ds__month
-                , subq_15.ds__quarter
-                , subq_15.ds__year
-                , subq_15.ds__extract_year
-                , subq_15.ds__extract_quarter
-                , subq_15.ds__extract_month
-                , subq_15.ds__extract_day
-                , subq_15.ds__extract_dow
-                , subq_15.ds__extract_doy
-                , subq_15.created_at__day
-                , subq_15.created_at__week
-                , subq_15.created_at__month
-                , subq_15.created_at__quarter
-                , subq_15.created_at__year
-                , subq_15.created_at__extract_year
-                , subq_15.created_at__extract_quarter
-                , subq_15.created_at__extract_month
-                , subq_15.created_at__extract_day
-                , subq_15.created_at__extract_dow
-                , subq_15.created_at__extract_doy
-                , subq_15.listing__ds__day
-                , subq_15.listing__ds__week
-                , subq_15.listing__ds__month
-                , subq_15.listing__ds__quarter
-                , subq_15.listing__ds__year
-                , subq_15.listing__ds__extract_year
-                , subq_15.listing__ds__extract_quarter
-                , subq_15.listing__ds__extract_month
-                , subq_15.listing__ds__extract_day
-                , subq_15.listing__ds__extract_dow
-                , subq_15.listing__ds__extract_doy
-                , subq_15.listing__created_at__day
-                , subq_15.listing__created_at__week
-                , subq_15.listing__created_at__month
-                , subq_15.listing__created_at__quarter
-                , subq_15.listing__created_at__year
-                , subq_15.listing__created_at__extract_year
-                , subq_15.listing__created_at__extract_quarter
-                , subq_15.listing__created_at__extract_month
-                , subq_15.listing__created_at__extract_day
-                , subq_15.listing__created_at__extract_dow
-                , subq_15.listing__created_at__extract_doy
-                , subq_15.ds__day AS metric_time__day
-                , subq_15.ds__week AS metric_time__week
-                , subq_15.ds__month AS metric_time__month
-                , subq_15.ds__quarter AS metric_time__quarter
-                , subq_15.ds__year AS metric_time__year
-                , subq_15.ds__extract_year AS metric_time__extract_year
-                , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_15.ds__extract_month AS metric_time__extract_month
-                , subq_15.ds__extract_day AS metric_time__extract_day
-                , subq_15.ds__extract_dow AS metric_time__extract_dow
-                , subq_15.ds__extract_doy AS metric_time__extract_doy
-                , subq_15.listing
-                , subq_15.user
-                , subq_15.listing__user
-                , subq_15.country_latest
-                , subq_15.is_lux_latest
-                , subq_15.capacity_latest
-                , subq_15.listing__country_latest
-                , subq_15.listing__is_lux_latest
-                , subq_15.listing__capacity_latest
-                , subq_15.listings
-                , subq_15.largest_listing
-                , subq_15.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,79 +160,79 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_15
-            ) subq_16
-          ) subq_17
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__visit_buy_conversion_rate']
             SELECT
-              subq_33.user
-              , subq_33.user__visit_buy_conversion_rate
+              subq_18.user
+              , subq_18.user__visit_buy_conversion_rate
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_32.user
-                , CAST(subq_32.buys AS FLOAT64) / CAST(NULLIF(subq_32.visits, 0) AS FLOAT64) AS user__visit_buy_conversion_rate
+                subq_17.user
+                , CAST(subq_17.buys AS FLOAT64) / CAST(NULLIF(subq_17.visits, 0) AS FLOAT64) AS user__visit_buy_conversion_rate
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_21.user, subq_31.user) AS user
-                  , MAX(subq_21.visits) AS visits
-                  , MAX(subq_31.buys) AS buys
+                  COALESCE(subq_6.user, subq_16.user) AS user
+                  , MAX(subq_6.visits) AS visits
+                  , MAX(subq_16.buys) AS buys
                 FROM (
                   -- Aggregate Measures
                   SELECT
-                    subq_20.user
-                    , SUM(subq_20.visits) AS visits
+                    subq_5.user
+                    , SUM(subq_5.visits) AS visits
                   FROM (
                     -- Pass Only Elements: ['visits', 'user']
                     SELECT
-                      subq_19.user
-                      , subq_19.visits
+                      subq_4.user
+                      , subq_4.visits
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_18.ds__day
-                        , subq_18.ds__week
-                        , subq_18.ds__month
-                        , subq_18.ds__quarter
-                        , subq_18.ds__year
-                        , subq_18.ds__extract_year
-                        , subq_18.ds__extract_quarter
-                        , subq_18.ds__extract_month
-                        , subq_18.ds__extract_day
-                        , subq_18.ds__extract_dow
-                        , subq_18.ds__extract_doy
-                        , subq_18.visit__ds__day
-                        , subq_18.visit__ds__week
-                        , subq_18.visit__ds__month
-                        , subq_18.visit__ds__quarter
-                        , subq_18.visit__ds__year
-                        , subq_18.visit__ds__extract_year
-                        , subq_18.visit__ds__extract_quarter
-                        , subq_18.visit__ds__extract_month
-                        , subq_18.visit__ds__extract_day
-                        , subq_18.visit__ds__extract_dow
-                        , subq_18.visit__ds__extract_doy
-                        , subq_18.ds__day AS metric_time__day
-                        , subq_18.ds__week AS metric_time__week
-                        , subq_18.ds__month AS metric_time__month
-                        , subq_18.ds__quarter AS metric_time__quarter
-                        , subq_18.ds__year AS metric_time__year
-                        , subq_18.ds__extract_year AS metric_time__extract_year
-                        , subq_18.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_18.ds__extract_month AS metric_time__extract_month
-                        , subq_18.ds__extract_day AS metric_time__extract_day
-                        , subq_18.ds__extract_dow AS metric_time__extract_dow
-                        , subq_18.ds__extract_doy AS metric_time__extract_doy
-                        , subq_18.user
-                        , subq_18.session
-                        , subq_18.visit__user
-                        , subq_18.visit__session
-                        , subq_18.referrer_id
-                        , subq_18.visit__referrer_id
-                        , subq_18.visits
-                        , subq_18.visitors
+                        subq_3.ds__day
+                        , subq_3.ds__week
+                        , subq_3.ds__month
+                        , subq_3.ds__quarter
+                        , subq_3.ds__year
+                        , subq_3.ds__extract_year
+                        , subq_3.ds__extract_quarter
+                        , subq_3.ds__extract_month
+                        , subq_3.ds__extract_day
+                        , subq_3.ds__extract_dow
+                        , subq_3.ds__extract_doy
+                        , subq_3.visit__ds__day
+                        , subq_3.visit__ds__week
+                        , subq_3.visit__ds__month
+                        , subq_3.visit__ds__quarter
+                        , subq_3.visit__ds__year
+                        , subq_3.visit__ds__extract_year
+                        , subq_3.visit__ds__extract_quarter
+                        , subq_3.visit__ds__extract_month
+                        , subq_3.visit__ds__extract_day
+                        , subq_3.visit__ds__extract_dow
+                        , subq_3.visit__ds__extract_doy
+                        , subq_3.ds__day AS metric_time__day
+                        , subq_3.ds__week AS metric_time__week
+                        , subq_3.ds__month AS metric_time__month
+                        , subq_3.ds__quarter AS metric_time__quarter
+                        , subq_3.ds__year AS metric_time__year
+                        , subq_3.ds__extract_year AS metric_time__extract_year
+                        , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_3.ds__extract_month AS metric_time__extract_month
+                        , subq_3.ds__extract_day AS metric_time__extract_day
+                        , subq_3.ds__extract_dow AS metric_time__extract_dow
+                        , subq_3.ds__extract_doy AS metric_time__extract_doy
+                        , subq_3.user
+                        , subq_3.session
+                        , subq_3.visit__user
+                        , subq_3.visit__session
+                        , subq_3.referrer_id
+                        , subq_3.visit__referrer_id
+                        , subq_3.visits
+                        , subq_3.visitors
                       FROM (
                         -- Read Elements From Semantic Model 'visits_source'
                         SELECT
@@ -267,108 +267,108 @@ FROM (
                           , visits_source_src_28000.user_id AS visit__user
                           , visits_source_src_28000.session_id AS visit__session
                         FROM ***************************.fct_visits visits_source_src_28000
-                      ) subq_18
-                    ) subq_19
-                  ) subq_20
+                      ) subq_3
+                    ) subq_4
+                  ) subq_5
                   GROUP BY
                     user
-                ) subq_21
+                ) subq_6
                 FULL OUTER JOIN (
                   -- Aggregate Measures
                   SELECT
-                    subq_30.user
-                    , SUM(subq_30.buys) AS buys
+                    subq_15.user
+                    , SUM(subq_15.buys) AS buys
                   FROM (
                     -- Pass Only Elements: ['buys', 'user']
                     SELECT
-                      subq_29.user
-                      , subq_29.buys
+                      subq_14.user
+                      , subq_14.buys
                     FROM (
                       -- Find conversions for user within the range of INF
                       SELECT
-                        subq_28.ds__day
-                        , subq_28.user
-                        , subq_28.buys
-                        , subq_28.visits
+                        subq_13.ds__day
+                        , subq_13.user
+                        , subq_13.buys
+                        , subq_13.visits
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          FIRST_VALUE(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_9.visits) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , FIRST_VALUE(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_9.ds__day) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , FIRST_VALUE(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_9.user) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS user
-                          , subq_27.mf_internal_uuid AS mf_internal_uuid
-                          , subq_27.buys AS buys
+                          , subq_12.mf_internal_uuid AS mf_internal_uuid
+                          , subq_12.buys AS buys
                         FROM (
                           -- Pass Only Elements: ['visits', 'ds__day', 'user']
                           SELECT
-                            subq_23.ds__day
-                            , subq_23.user
-                            , subq_23.visits
+                            subq_8.ds__day
+                            , subq_8.user
+                            , subq_8.visits
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_22.ds__day
-                              , subq_22.ds__week
-                              , subq_22.ds__month
-                              , subq_22.ds__quarter
-                              , subq_22.ds__year
-                              , subq_22.ds__extract_year
-                              , subq_22.ds__extract_quarter
-                              , subq_22.ds__extract_month
-                              , subq_22.ds__extract_day
-                              , subq_22.ds__extract_dow
-                              , subq_22.ds__extract_doy
-                              , subq_22.visit__ds__day
-                              , subq_22.visit__ds__week
-                              , subq_22.visit__ds__month
-                              , subq_22.visit__ds__quarter
-                              , subq_22.visit__ds__year
-                              , subq_22.visit__ds__extract_year
-                              , subq_22.visit__ds__extract_quarter
-                              , subq_22.visit__ds__extract_month
-                              , subq_22.visit__ds__extract_day
-                              , subq_22.visit__ds__extract_dow
-                              , subq_22.visit__ds__extract_doy
-                              , subq_22.ds__day AS metric_time__day
-                              , subq_22.ds__week AS metric_time__week
-                              , subq_22.ds__month AS metric_time__month
-                              , subq_22.ds__quarter AS metric_time__quarter
-                              , subq_22.ds__year AS metric_time__year
-                              , subq_22.ds__extract_year AS metric_time__extract_year
-                              , subq_22.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_22.ds__extract_month AS metric_time__extract_month
-                              , subq_22.ds__extract_day AS metric_time__extract_day
-                              , subq_22.ds__extract_dow AS metric_time__extract_dow
-                              , subq_22.ds__extract_doy AS metric_time__extract_doy
-                              , subq_22.user
-                              , subq_22.session
-                              , subq_22.visit__user
-                              , subq_22.visit__session
-                              , subq_22.referrer_id
-                              , subq_22.visit__referrer_id
-                              , subq_22.visits
-                              , subq_22.visitors
+                              subq_7.ds__day
+                              , subq_7.ds__week
+                              , subq_7.ds__month
+                              , subq_7.ds__quarter
+                              , subq_7.ds__year
+                              , subq_7.ds__extract_year
+                              , subq_7.ds__extract_quarter
+                              , subq_7.ds__extract_month
+                              , subq_7.ds__extract_day
+                              , subq_7.ds__extract_dow
+                              , subq_7.ds__extract_doy
+                              , subq_7.visit__ds__day
+                              , subq_7.visit__ds__week
+                              , subq_7.visit__ds__month
+                              , subq_7.visit__ds__quarter
+                              , subq_7.visit__ds__year
+                              , subq_7.visit__ds__extract_year
+                              , subq_7.visit__ds__extract_quarter
+                              , subq_7.visit__ds__extract_month
+                              , subq_7.visit__ds__extract_day
+                              , subq_7.visit__ds__extract_dow
+                              , subq_7.visit__ds__extract_doy
+                              , subq_7.ds__day AS metric_time__day
+                              , subq_7.ds__week AS metric_time__week
+                              , subq_7.ds__month AS metric_time__month
+                              , subq_7.ds__quarter AS metric_time__quarter
+                              , subq_7.ds__year AS metric_time__year
+                              , subq_7.ds__extract_year AS metric_time__extract_year
+                              , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_7.ds__extract_month AS metric_time__extract_month
+                              , subq_7.ds__extract_day AS metric_time__extract_day
+                              , subq_7.ds__extract_dow AS metric_time__extract_dow
+                              , subq_7.ds__extract_doy AS metric_time__extract_doy
+                              , subq_7.user
+                              , subq_7.session
+                              , subq_7.visit__user
+                              , subq_7.visit__session
+                              , subq_7.referrer_id
+                              , subq_7.visit__referrer_id
+                              , subq_7.visits
+                              , subq_7.visitors
                             FROM (
                               -- Read Elements From Semantic Model 'visits_source'
                               SELECT
@@ -403,94 +403,94 @@ FROM (
                                 , visits_source_src_28000.user_id AS visit__user
                                 , visits_source_src_28000.session_id AS visit__session
                               FROM ***************************.fct_visits visits_source_src_28000
-                            ) subq_22
-                          ) subq_23
-                        ) subq_24
+                            ) subq_7
+                          ) subq_8
+                        ) subq_9
                         INNER JOIN (
                           -- Add column with generated UUID
                           SELECT
-                            subq_26.ds__day
-                            , subq_26.ds__week
-                            , subq_26.ds__month
-                            , subq_26.ds__quarter
-                            , subq_26.ds__year
-                            , subq_26.ds__extract_year
-                            , subq_26.ds__extract_quarter
-                            , subq_26.ds__extract_month
-                            , subq_26.ds__extract_day
-                            , subq_26.ds__extract_dow
-                            , subq_26.ds__extract_doy
-                            , subq_26.buy__ds__day
-                            , subq_26.buy__ds__week
-                            , subq_26.buy__ds__month
-                            , subq_26.buy__ds__quarter
-                            , subq_26.buy__ds__year
-                            , subq_26.buy__ds__extract_year
-                            , subq_26.buy__ds__extract_quarter
-                            , subq_26.buy__ds__extract_month
-                            , subq_26.buy__ds__extract_day
-                            , subq_26.buy__ds__extract_dow
-                            , subq_26.buy__ds__extract_doy
-                            , subq_26.metric_time__day
-                            , subq_26.metric_time__week
-                            , subq_26.metric_time__month
-                            , subq_26.metric_time__quarter
-                            , subq_26.metric_time__year
-                            , subq_26.metric_time__extract_year
-                            , subq_26.metric_time__extract_quarter
-                            , subq_26.metric_time__extract_month
-                            , subq_26.metric_time__extract_day
-                            , subq_26.metric_time__extract_dow
-                            , subq_26.metric_time__extract_doy
-                            , subq_26.user
-                            , subq_26.session_id
-                            , subq_26.buy__user
-                            , subq_26.buy__session_id
-                            , subq_26.buys
-                            , subq_26.buyers
+                            subq_11.ds__day
+                            , subq_11.ds__week
+                            , subq_11.ds__month
+                            , subq_11.ds__quarter
+                            , subq_11.ds__year
+                            , subq_11.ds__extract_year
+                            , subq_11.ds__extract_quarter
+                            , subq_11.ds__extract_month
+                            , subq_11.ds__extract_day
+                            , subq_11.ds__extract_dow
+                            , subq_11.ds__extract_doy
+                            , subq_11.buy__ds__day
+                            , subq_11.buy__ds__week
+                            , subq_11.buy__ds__month
+                            , subq_11.buy__ds__quarter
+                            , subq_11.buy__ds__year
+                            , subq_11.buy__ds__extract_year
+                            , subq_11.buy__ds__extract_quarter
+                            , subq_11.buy__ds__extract_month
+                            , subq_11.buy__ds__extract_day
+                            , subq_11.buy__ds__extract_dow
+                            , subq_11.buy__ds__extract_doy
+                            , subq_11.metric_time__day
+                            , subq_11.metric_time__week
+                            , subq_11.metric_time__month
+                            , subq_11.metric_time__quarter
+                            , subq_11.metric_time__year
+                            , subq_11.metric_time__extract_year
+                            , subq_11.metric_time__extract_quarter
+                            , subq_11.metric_time__extract_month
+                            , subq_11.metric_time__extract_day
+                            , subq_11.metric_time__extract_dow
+                            , subq_11.metric_time__extract_doy
+                            , subq_11.user
+                            , subq_11.session_id
+                            , subq_11.buy__user
+                            , subq_11.buy__session_id
+                            , subq_11.buys
+                            , subq_11.buyers
                             , GENERATE_UUID() AS mf_internal_uuid
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_25.ds__day
-                              , subq_25.ds__week
-                              , subq_25.ds__month
-                              , subq_25.ds__quarter
-                              , subq_25.ds__year
-                              , subq_25.ds__extract_year
-                              , subq_25.ds__extract_quarter
-                              , subq_25.ds__extract_month
-                              , subq_25.ds__extract_day
-                              , subq_25.ds__extract_dow
-                              , subq_25.ds__extract_doy
-                              , subq_25.buy__ds__day
-                              , subq_25.buy__ds__week
-                              , subq_25.buy__ds__month
-                              , subq_25.buy__ds__quarter
-                              , subq_25.buy__ds__year
-                              , subq_25.buy__ds__extract_year
-                              , subq_25.buy__ds__extract_quarter
-                              , subq_25.buy__ds__extract_month
-                              , subq_25.buy__ds__extract_day
-                              , subq_25.buy__ds__extract_dow
-                              , subq_25.buy__ds__extract_doy
-                              , subq_25.ds__day AS metric_time__day
-                              , subq_25.ds__week AS metric_time__week
-                              , subq_25.ds__month AS metric_time__month
-                              , subq_25.ds__quarter AS metric_time__quarter
-                              , subq_25.ds__year AS metric_time__year
-                              , subq_25.ds__extract_year AS metric_time__extract_year
-                              , subq_25.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_25.ds__extract_month AS metric_time__extract_month
-                              , subq_25.ds__extract_day AS metric_time__extract_day
-                              , subq_25.ds__extract_dow AS metric_time__extract_dow
-                              , subq_25.ds__extract_doy AS metric_time__extract_doy
-                              , subq_25.user
-                              , subq_25.session_id
-                              , subq_25.buy__user
-                              , subq_25.buy__session_id
-                              , subq_25.buys
-                              , subq_25.buyers
+                              subq_10.ds__day
+                              , subq_10.ds__week
+                              , subq_10.ds__month
+                              , subq_10.ds__quarter
+                              , subq_10.ds__year
+                              , subq_10.ds__extract_year
+                              , subq_10.ds__extract_quarter
+                              , subq_10.ds__extract_month
+                              , subq_10.ds__extract_day
+                              , subq_10.ds__extract_dow
+                              , subq_10.ds__extract_doy
+                              , subq_10.buy__ds__day
+                              , subq_10.buy__ds__week
+                              , subq_10.buy__ds__month
+                              , subq_10.buy__ds__quarter
+                              , subq_10.buy__ds__year
+                              , subq_10.buy__ds__extract_year
+                              , subq_10.buy__ds__extract_quarter
+                              , subq_10.buy__ds__extract_month
+                              , subq_10.buy__ds__extract_day
+                              , subq_10.buy__ds__extract_dow
+                              , subq_10.buy__ds__extract_doy
+                              , subq_10.ds__day AS metric_time__day
+                              , subq_10.ds__week AS metric_time__week
+                              , subq_10.ds__month AS metric_time__month
+                              , subq_10.ds__quarter AS metric_time__quarter
+                              , subq_10.ds__year AS metric_time__year
+                              , subq_10.ds__extract_year AS metric_time__extract_year
+                              , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_10.ds__extract_month AS metric_time__extract_month
+                              , subq_10.ds__extract_day AS metric_time__extract_day
+                              , subq_10.ds__extract_dow AS metric_time__extract_dow
+                              , subq_10.ds__extract_doy AS metric_time__extract_doy
+                              , subq_10.user
+                              , subq_10.session_id
+                              , subq_10.buy__user
+                              , subq_10.buy__session_id
+                              , subq_10.buys
+                              , subq_10.buyers
                             FROM (
                               -- Read Elements From Semantic Model 'buys_source'
                               SELECT
@@ -523,33 +523,33 @@ FROM (
                                 , buys_source_src_28000.user_id AS buy__user
                                 , buys_source_src_28000.session_id AS buy__session_id
                               FROM ***************************.fct_buys buys_source_src_28000
-                            ) subq_25
-                          ) subq_26
-                        ) subq_27
+                            ) subq_10
+                          ) subq_11
+                        ) subq_12
                         ON
                           (
-                            subq_24.user = subq_27.user
+                            subq_9.user = subq_12.user
                           ) AND (
-                            (subq_24.ds__day <= subq_27.ds__day)
+                            (subq_9.ds__day <= subq_12.ds__day)
                           )
-                      ) subq_28
-                    ) subq_29
-                  ) subq_30
+                      ) subq_13
+                    ) subq_14
+                  ) subq_15
                   GROUP BY
                     user
-                ) subq_31
+                ) subq_16
                 ON
-                  subq_21.user = subq_31.user
+                  subq_6.user = subq_16.user
                 GROUP BY
                   user
-              ) subq_32
-            ) subq_33
-          ) subq_34
+              ) subq_17
+            ) subq_18
+          ) subq_19
           ON
-            subq_17.user = subq_34.user
-        ) subq_35
-      ) subq_36
+            subq_2.user = subq_19.user
+        ) subq_20
+      ) subq_21
       WHERE user__visit_buy_conversion_rate > 2
-    ) subq_37
-  ) subq_38
-) subq_39
+    ) subq_22
+  ) subq_23
+) subq_24

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_72.buys AS FLOAT64) / CAST(NULLIF(subq_72.visits, 0) AS FLOAT64) AS user__visit_buy_conversion_rate
-    , subq_57.listings AS listings
+    CAST(subq_42.buys AS FLOAT64) / CAST(NULLIF(subq_42.visits, 0) AS FLOAT64) AS user__visit_buy_conversion_rate
+    , subq_27.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_57
+  ) subq_27
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_61.user, subq_71.user) AS user
-      , MAX(subq_61.visits) AS visits
-      , MAX(subq_71.buys) AS buys
+      COALESCE(subq_31.user, subq_41.user) AS user
+      , MAX(subq_31.visits) AS visits
+      , MAX(subq_41.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_60.user
+        subq_30.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_60
+      ) subq_30
       GROUP BY
         user
-    ) subq_61
+    ) subq_31
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_68.user
+        subq_38.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_64.visits) OVER (
+          FIRST_VALUE(subq_34.visits) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_64.ds__day) OVER (
+          , FIRST_VALUE(subq_34.ds__day) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_64.user) OVER (
+          , FIRST_VALUE(subq_34.user) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_67.mf_internal_uuid AS mf_internal_uuid
-          , subq_67.buys AS buys
+          , subq_37.mf_internal_uuid AS mf_internal_uuid
+          , subq_37.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_64
+        ) subq_34
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , GENERATE_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_67
+        ) subq_37
         ON
           (
-            subq_64.user = subq_67.user
+            subq_34.user = subq_37.user
           ) AND (
-            (subq_64.ds__day <= subq_67.ds__day)
+            (subq_34.ds__day <= subq_37.ds__day)
           )
-      ) subq_68
+      ) subq_38
       GROUP BY
         user
-    ) subq_71
+    ) subq_41
     ON
-      subq_61.user = subq_71.user
+      subq_31.user = subq_41.user
     GROUP BY
       user
-  ) subq_72
+  ) subq_42
   ON
-    subq_57.user = subq_72.user
-) subq_76
+    subq_27.user = subq_42.user
+) subq_46
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0.sql
@@ -1,106 +1,106 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_18.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_17.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_16.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.user__listing__user__average_booking_value
-        , subq_24.listings
+        subq_15.user__listing__user__average_booking_value
+        , subq_15.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
         SELECT
-          subq_23.user__listing__user__average_booking_value
-          , subq_23.listings
+          subq_14.user__listing__user__average_booking_value
+          , subq_14.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.user AS user
-            , subq_22.listing__user AS user__listing__user
-            , subq_22.listing__user__average_booking_value AS user__listing__user__average_booking_value
-            , subq_11.listings AS listings
+            subq_2.user AS user
+            , subq_13.listing__user AS user__listing__user
+            , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_10.user
-              , subq_10.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds__day
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds__extract_year
-                , subq_9.ds__extract_quarter
-                , subq_9.ds__extract_month
-                , subq_9.ds__extract_day
-                , subq_9.ds__extract_dow
-                , subq_9.ds__extract_doy
-                , subq_9.created_at__day
-                , subq_9.created_at__week
-                , subq_9.created_at__month
-                , subq_9.created_at__quarter
-                , subq_9.created_at__year
-                , subq_9.created_at__extract_year
-                , subq_9.created_at__extract_quarter
-                , subq_9.created_at__extract_month
-                , subq_9.created_at__extract_day
-                , subq_9.created_at__extract_dow
-                , subq_9.created_at__extract_doy
-                , subq_9.listing__ds__day
-                , subq_9.listing__ds__week
-                , subq_9.listing__ds__month
-                , subq_9.listing__ds__quarter
-                , subq_9.listing__ds__year
-                , subq_9.listing__ds__extract_year
-                , subq_9.listing__ds__extract_quarter
-                , subq_9.listing__ds__extract_month
-                , subq_9.listing__ds__extract_day
-                , subq_9.listing__ds__extract_dow
-                , subq_9.listing__ds__extract_doy
-                , subq_9.listing__created_at__day
-                , subq_9.listing__created_at__week
-                , subq_9.listing__created_at__month
-                , subq_9.listing__created_at__quarter
-                , subq_9.listing__created_at__year
-                , subq_9.listing__created_at__extract_year
-                , subq_9.listing__created_at__extract_quarter
-                , subq_9.listing__created_at__extract_month
-                , subq_9.listing__created_at__extract_day
-                , subq_9.listing__created_at__extract_dow
-                , subq_9.listing__created_at__extract_doy
-                , subq_9.ds__day AS metric_time__day
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.ds__extract_year AS metric_time__extract_year
-                , subq_9.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.ds__extract_month AS metric_time__extract_month
-                , subq_9.ds__extract_day AS metric_time__extract_day
-                , subq_9.ds__extract_dow AS metric_time__extract_dow
-                , subq_9.ds__extract_doy AS metric_time__extract_doy
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.listing__user
-                , subq_9.country_latest
-                , subq_9.is_lux_latest
-                , subq_9.capacity_latest
-                , subq_9.listing__country_latest
-                , subq_9.listing__is_lux_latest
-                , subq_9.listing__capacity_latest
-                , subq_9.listings
-                , subq_9.largest_listing
-                , subq_9.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -161,141 +161,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
             SELECT
-              subq_21.listing__user
-              , subq_21.listing__user__average_booking_value
+              subq_12.listing__user
+              , subq_12.listing__user__average_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing__user
-                , subq_20.average_booking_value AS listing__user__average_booking_value
+                subq_11.listing__user
+                , subq_11.average_booking_value AS listing__user__average_booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing__user
-                  , AVG(subq_19.average_booking_value) AS average_booking_value
+                  subq_10.listing__user
+                  , AVG(subq_10.average_booking_value) AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'listing__user']
                   SELECT
-                    subq_18.listing__user
-                    , subq_18.average_booking_value
+                    subq_9.listing__user
+                    , subq_9.average_booking_value
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_14.listing AS listing
-                      , subq_17.user AS listing__user
-                      , subq_14.average_booking_value AS average_booking_value
+                      subq_5.listing AS listing
+                      , subq_8.user AS listing__user
+                      , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']
                       SELECT
-                        subq_13.listing
-                        , subq_13.average_booking_value
+                        subq_4.listing
+                        , subq_4.average_booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_12.ds__day
-                          , subq_12.ds__week
-                          , subq_12.ds__month
-                          , subq_12.ds__quarter
-                          , subq_12.ds__year
-                          , subq_12.ds__extract_year
-                          , subq_12.ds__extract_quarter
-                          , subq_12.ds__extract_month
-                          , subq_12.ds__extract_day
-                          , subq_12.ds__extract_dow
-                          , subq_12.ds__extract_doy
-                          , subq_12.ds_partitioned__day
-                          , subq_12.ds_partitioned__week
-                          , subq_12.ds_partitioned__month
-                          , subq_12.ds_partitioned__quarter
-                          , subq_12.ds_partitioned__year
-                          , subq_12.ds_partitioned__extract_year
-                          , subq_12.ds_partitioned__extract_quarter
-                          , subq_12.ds_partitioned__extract_month
-                          , subq_12.ds_partitioned__extract_day
-                          , subq_12.ds_partitioned__extract_dow
-                          , subq_12.ds_partitioned__extract_doy
-                          , subq_12.paid_at__day
-                          , subq_12.paid_at__week
-                          , subq_12.paid_at__month
-                          , subq_12.paid_at__quarter
-                          , subq_12.paid_at__year
-                          , subq_12.paid_at__extract_year
-                          , subq_12.paid_at__extract_quarter
-                          , subq_12.paid_at__extract_month
-                          , subq_12.paid_at__extract_day
-                          , subq_12.paid_at__extract_dow
-                          , subq_12.paid_at__extract_doy
-                          , subq_12.booking__ds__day
-                          , subq_12.booking__ds__week
-                          , subq_12.booking__ds__month
-                          , subq_12.booking__ds__quarter
-                          , subq_12.booking__ds__year
-                          , subq_12.booking__ds__extract_year
-                          , subq_12.booking__ds__extract_quarter
-                          , subq_12.booking__ds__extract_month
-                          , subq_12.booking__ds__extract_day
-                          , subq_12.booking__ds__extract_dow
-                          , subq_12.booking__ds__extract_doy
-                          , subq_12.booking__ds_partitioned__day
-                          , subq_12.booking__ds_partitioned__week
-                          , subq_12.booking__ds_partitioned__month
-                          , subq_12.booking__ds_partitioned__quarter
-                          , subq_12.booking__ds_partitioned__year
-                          , subq_12.booking__ds_partitioned__extract_year
-                          , subq_12.booking__ds_partitioned__extract_quarter
-                          , subq_12.booking__ds_partitioned__extract_month
-                          , subq_12.booking__ds_partitioned__extract_day
-                          , subq_12.booking__ds_partitioned__extract_dow
-                          , subq_12.booking__ds_partitioned__extract_doy
-                          , subq_12.booking__paid_at__day
-                          , subq_12.booking__paid_at__week
-                          , subq_12.booking__paid_at__month
-                          , subq_12.booking__paid_at__quarter
-                          , subq_12.booking__paid_at__year
-                          , subq_12.booking__paid_at__extract_year
-                          , subq_12.booking__paid_at__extract_quarter
-                          , subq_12.booking__paid_at__extract_month
-                          , subq_12.booking__paid_at__extract_day
-                          , subq_12.booking__paid_at__extract_dow
-                          , subq_12.booking__paid_at__extract_doy
-                          , subq_12.ds__day AS metric_time__day
-                          , subq_12.ds__week AS metric_time__week
-                          , subq_12.ds__month AS metric_time__month
-                          , subq_12.ds__quarter AS metric_time__quarter
-                          , subq_12.ds__year AS metric_time__year
-                          , subq_12.ds__extract_year AS metric_time__extract_year
-                          , subq_12.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_12.ds__extract_month AS metric_time__extract_month
-                          , subq_12.ds__extract_day AS metric_time__extract_day
-                          , subq_12.ds__extract_dow AS metric_time__extract_dow
-                          , subq_12.ds__extract_doy AS metric_time__extract_doy
-                          , subq_12.listing
-                          , subq_12.guest
-                          , subq_12.host
-                          , subq_12.booking__listing
-                          , subq_12.booking__guest
-                          , subq_12.booking__host
-                          , subq_12.is_instant
-                          , subq_12.booking__is_instant
-                          , subq_12.bookings
-                          , subq_12.instant_bookings
-                          , subq_12.booking_value
-                          , subq_12.max_booking_value
-                          , subq_12.min_booking_value
-                          , subq_12.bookers
-                          , subq_12.average_booking_value
-                          , subq_12.referred_bookings
-                          , subq_12.median_booking_value
-                          , subq_12.booking_value_p99
-                          , subq_12.discrete_booking_value_p99
-                          , subq_12.approximate_continuous_booking_value_p99
-                          , subq_12.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -388,84 +388,84 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_12
-                      ) subq_13
-                    ) subq_14
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['listing', 'user']
                       SELECT
-                        subq_16.listing
-                        , subq_16.user
+                        subq_7.listing
+                        , subq_7.user
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_15.ds__day
-                          , subq_15.ds__week
-                          , subq_15.ds__month
-                          , subq_15.ds__quarter
-                          , subq_15.ds__year
-                          , subq_15.ds__extract_year
-                          , subq_15.ds__extract_quarter
-                          , subq_15.ds__extract_month
-                          , subq_15.ds__extract_day
-                          , subq_15.ds__extract_dow
-                          , subq_15.ds__extract_doy
-                          , subq_15.created_at__day
-                          , subq_15.created_at__week
-                          , subq_15.created_at__month
-                          , subq_15.created_at__quarter
-                          , subq_15.created_at__year
-                          , subq_15.created_at__extract_year
-                          , subq_15.created_at__extract_quarter
-                          , subq_15.created_at__extract_month
-                          , subq_15.created_at__extract_day
-                          , subq_15.created_at__extract_dow
-                          , subq_15.created_at__extract_doy
-                          , subq_15.listing__ds__day
-                          , subq_15.listing__ds__week
-                          , subq_15.listing__ds__month
-                          , subq_15.listing__ds__quarter
-                          , subq_15.listing__ds__year
-                          , subq_15.listing__ds__extract_year
-                          , subq_15.listing__ds__extract_quarter
-                          , subq_15.listing__ds__extract_month
-                          , subq_15.listing__ds__extract_day
-                          , subq_15.listing__ds__extract_dow
-                          , subq_15.listing__ds__extract_doy
-                          , subq_15.listing__created_at__day
-                          , subq_15.listing__created_at__week
-                          , subq_15.listing__created_at__month
-                          , subq_15.listing__created_at__quarter
-                          , subq_15.listing__created_at__year
-                          , subq_15.listing__created_at__extract_year
-                          , subq_15.listing__created_at__extract_quarter
-                          , subq_15.listing__created_at__extract_month
-                          , subq_15.listing__created_at__extract_day
-                          , subq_15.listing__created_at__extract_dow
-                          , subq_15.listing__created_at__extract_doy
-                          , subq_15.ds__day AS metric_time__day
-                          , subq_15.ds__week AS metric_time__week
-                          , subq_15.ds__month AS metric_time__month
-                          , subq_15.ds__quarter AS metric_time__quarter
-                          , subq_15.ds__year AS metric_time__year
-                          , subq_15.ds__extract_year AS metric_time__extract_year
-                          , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_15.ds__extract_month AS metric_time__extract_month
-                          , subq_15.ds__extract_day AS metric_time__extract_day
-                          , subq_15.ds__extract_dow AS metric_time__extract_dow
-                          , subq_15.ds__extract_doy AS metric_time__extract_doy
-                          , subq_15.listing
-                          , subq_15.user
-                          , subq_15.listing__user
-                          , subq_15.country_latest
-                          , subq_15.is_lux_latest
-                          , subq_15.capacity_latest
-                          , subq_15.listing__country_latest
-                          , subq_15.listing__is_lux_latest
-                          , subq_15.listing__capacity_latest
-                          , subq_15.listings
-                          , subq_15.largest_listing
-                          , subq_15.smallest_listing
+                          subq_6.ds__day
+                          , subq_6.ds__week
+                          , subq_6.ds__month
+                          , subq_6.ds__quarter
+                          , subq_6.ds__year
+                          , subq_6.ds__extract_year
+                          , subq_6.ds__extract_quarter
+                          , subq_6.ds__extract_month
+                          , subq_6.ds__extract_day
+                          , subq_6.ds__extract_dow
+                          , subq_6.ds__extract_doy
+                          , subq_6.created_at__day
+                          , subq_6.created_at__week
+                          , subq_6.created_at__month
+                          , subq_6.created_at__quarter
+                          , subq_6.created_at__year
+                          , subq_6.created_at__extract_year
+                          , subq_6.created_at__extract_quarter
+                          , subq_6.created_at__extract_month
+                          , subq_6.created_at__extract_day
+                          , subq_6.created_at__extract_dow
+                          , subq_6.created_at__extract_doy
+                          , subq_6.listing__ds__day
+                          , subq_6.listing__ds__week
+                          , subq_6.listing__ds__month
+                          , subq_6.listing__ds__quarter
+                          , subq_6.listing__ds__year
+                          , subq_6.listing__ds__extract_year
+                          , subq_6.listing__ds__extract_quarter
+                          , subq_6.listing__ds__extract_month
+                          , subq_6.listing__ds__extract_day
+                          , subq_6.listing__ds__extract_dow
+                          , subq_6.listing__ds__extract_doy
+                          , subq_6.listing__created_at__day
+                          , subq_6.listing__created_at__week
+                          , subq_6.listing__created_at__month
+                          , subq_6.listing__created_at__quarter
+                          , subq_6.listing__created_at__year
+                          , subq_6.listing__created_at__extract_year
+                          , subq_6.listing__created_at__extract_quarter
+                          , subq_6.listing__created_at__extract_month
+                          , subq_6.listing__created_at__extract_day
+                          , subq_6.listing__created_at__extract_dow
+                          , subq_6.listing__created_at__extract_doy
+                          , subq_6.ds__day AS metric_time__day
+                          , subq_6.ds__week AS metric_time__week
+                          , subq_6.ds__month AS metric_time__month
+                          , subq_6.ds__quarter AS metric_time__quarter
+                          , subq_6.ds__year AS metric_time__year
+                          , subq_6.ds__extract_year AS metric_time__extract_year
+                          , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_6.ds__extract_month AS metric_time__extract_month
+                          , subq_6.ds__extract_day AS metric_time__extract_day
+                          , subq_6.ds__extract_dow AS metric_time__extract_dow
+                          , subq_6.ds__extract_doy AS metric_time__extract_doy
+                          , subq_6.listing
+                          , subq_6.user
+                          , subq_6.listing__user
+                          , subq_6.country_latest
+                          , subq_6.is_lux_latest
+                          , subq_6.capacity_latest
+                          , subq_6.listing__country_latest
+                          , subq_6.listing__is_lux_latest
+                          , subq_6.listing__capacity_latest
+                          , subq_6.listings
+                          , subq_6.largest_listing
+                          , subq_6.smallest_listing
                         FROM (
                           -- Read Elements From Semantic Model 'listings_latest'
                           SELECT
@@ -526,23 +526,23 @@ FROM (
                             , listings_latest_src_28000.user_id AS user
                             , listings_latest_src_28000.user_id AS listing__user
                           FROM ***************************.dim_listings_latest listings_latest_src_28000
-                        ) subq_15
-                      ) subq_16
-                    ) subq_17
+                        ) subq_6
+                      ) subq_7
+                    ) subq_8
                     ON
-                      subq_14.listing = subq_17.listing
-                  ) subq_18
-                ) subq_19
+                      subq_5.listing = subq_8.listing
+                  ) subq_9
+                ) subq_10
                 GROUP BY
                   listing__user
-              ) subq_20
-            ) subq_21
-          ) subq_22
+              ) subq_11
+            ) subq_12
+          ) subq_13
           ON
-            subq_11.user = subq_22.listing__user
-        ) subq_23
-      ) subq_24
+            subq_2.user = subq_13.listing__user
+        ) subq_14
+      ) subq_15
       WHERE user__listing__user__average_booking_value > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_16
+  ) subq_17
+) subq_18

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_39.listings AS listings
+    subq_32.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_21.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_39
+  ) subq_21
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listing__user
-  ) subq_50
+  ) subq_32
   ON
-    subq_39.user = subq_50.listing__user
-) subq_52
+    subq_21.user = subq_32.listing__user
+) subq_34
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_multi_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_40.third_hop_count
+  subq_22.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_39.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_21.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_38.third_hop_count
+      subq_20.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_37.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-        , subq_37.third_hop_count
+        subq_19.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+        , subq_19.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
         SELECT
-          subq_36.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-          , subq_36.third_hop_count
+          subq_18.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+          , subq_18.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_20.customer_third_hop_id AS customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-            , subq_20.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_19.customer_third_hop_id
-              , subq_19.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_18.third_hop_ds__day
-                , subq_18.third_hop_ds__week
-                , subq_18.third_hop_ds__month
-                , subq_18.third_hop_ds__quarter
-                , subq_18.third_hop_ds__year
-                , subq_18.third_hop_ds__extract_year
-                , subq_18.third_hop_ds__extract_quarter
-                , subq_18.third_hop_ds__extract_month
-                , subq_18.third_hop_ds__extract_day
-                , subq_18.third_hop_ds__extract_dow
-                , subq_18.third_hop_ds__extract_doy
-                , subq_18.customer_third_hop_id__third_hop_ds__day
-                , subq_18.customer_third_hop_id__third_hop_ds__week
-                , subq_18.customer_third_hop_id__third_hop_ds__month
-                , subq_18.customer_third_hop_id__third_hop_ds__quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_18.third_hop_ds__day AS metric_time__day
-                , subq_18.third_hop_ds__week AS metric_time__week
-                , subq_18.third_hop_ds__month AS metric_time__month
-                , subq_18.third_hop_ds__quarter AS metric_time__quarter
-                , subq_18.third_hop_ds__year AS metric_time__year
-                , subq_18.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_18.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_18.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_18.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_18.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_18.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_18.customer_third_hop_id
-                , subq_18.value
-                , subq_18.customer_third_hop_id__value
-                , subq_18.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,105 +101,105 @@ FROM (
                   , EXTRACT(dayofyear FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_18
-            ) subq_19
-          ) subq_20
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
             SELECT
-              subq_34.account_id__customer_id__customer_third_hop_id
-              , subq_34.account_id__customer_id__customer_third_hop_id__txn_count
+              subq_16.account_id__customer_id__customer_third_hop_id
+              , subq_16.account_id__customer_id__customer_third_hop_id__txn_count
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_33.account_id__customer_id__customer_third_hop_id
-                , subq_33.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
+                subq_15.account_id__customer_id__customer_third_hop_id
+                , subq_15.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_32.account_id__customer_id__customer_third_hop_id
-                  , SUM(subq_32.txn_count) AS txn_count
+                  subq_14.account_id__customer_id__customer_third_hop_id
+                  , SUM(subq_14.txn_count) AS txn_count
                 FROM (
                   -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_third_hop_id']
                   SELECT
-                    subq_31.account_id__customer_id__customer_third_hop_id
-                    , subq_31.txn_count
+                    subq_13.account_id__customer_id__customer_third_hop_id
+                    , subq_13.txn_count
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_23.ds_partitioned__day AS ds_partitioned__day
-                      , subq_30.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_23.account_id AS account_id
-                      , subq_30.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
-                      , subq_23.txn_count AS txn_count
+                      subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
+                      , subq_5.account_id AS account_id
+                      , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
                       SELECT
-                        subq_22.ds_partitioned__day
-                        , subq_22.account_id
-                        , subq_22.txn_count
+                        subq_4.ds_partitioned__day
+                        , subq_4.account_id
+                        , subq_4.txn_count
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_21.ds_partitioned__day
-                          , subq_21.ds_partitioned__week
-                          , subq_21.ds_partitioned__month
-                          , subq_21.ds_partitioned__quarter
-                          , subq_21.ds_partitioned__year
-                          , subq_21.ds_partitioned__extract_year
-                          , subq_21.ds_partitioned__extract_quarter
-                          , subq_21.ds_partitioned__extract_month
-                          , subq_21.ds_partitioned__extract_day
-                          , subq_21.ds_partitioned__extract_dow
-                          , subq_21.ds_partitioned__extract_doy
-                          , subq_21.ds__day
-                          , subq_21.ds__week
-                          , subq_21.ds__month
-                          , subq_21.ds__quarter
-                          , subq_21.ds__year
-                          , subq_21.ds__extract_year
-                          , subq_21.ds__extract_quarter
-                          , subq_21.ds__extract_month
-                          , subq_21.ds__extract_day
-                          , subq_21.ds__extract_dow
-                          , subq_21.ds__extract_doy
-                          , subq_21.account_id__ds_partitioned__day
-                          , subq_21.account_id__ds_partitioned__week
-                          , subq_21.account_id__ds_partitioned__month
-                          , subq_21.account_id__ds_partitioned__quarter
-                          , subq_21.account_id__ds_partitioned__year
-                          , subq_21.account_id__ds_partitioned__extract_year
-                          , subq_21.account_id__ds_partitioned__extract_quarter
-                          , subq_21.account_id__ds_partitioned__extract_month
-                          , subq_21.account_id__ds_partitioned__extract_day
-                          , subq_21.account_id__ds_partitioned__extract_dow
-                          , subq_21.account_id__ds_partitioned__extract_doy
-                          , subq_21.account_id__ds__day
-                          , subq_21.account_id__ds__week
-                          , subq_21.account_id__ds__month
-                          , subq_21.account_id__ds__quarter
-                          , subq_21.account_id__ds__year
-                          , subq_21.account_id__ds__extract_year
-                          , subq_21.account_id__ds__extract_quarter
-                          , subq_21.account_id__ds__extract_month
-                          , subq_21.account_id__ds__extract_day
-                          , subq_21.account_id__ds__extract_dow
-                          , subq_21.account_id__ds__extract_doy
-                          , subq_21.ds__day AS metric_time__day
-                          , subq_21.ds__week AS metric_time__week
-                          , subq_21.ds__month AS metric_time__month
-                          , subq_21.ds__quarter AS metric_time__quarter
-                          , subq_21.ds__year AS metric_time__year
-                          , subq_21.ds__extract_year AS metric_time__extract_year
-                          , subq_21.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_21.ds__extract_month AS metric_time__extract_month
-                          , subq_21.ds__extract_day AS metric_time__extract_day
-                          , subq_21.ds__extract_dow AS metric_time__extract_dow
-                          , subq_21.ds__extract_doy AS metric_time__extract_doy
-                          , subq_21.account_id
-                          , subq_21.account_month
-                          , subq_21.account_id__account_month
-                          , subq_21.txn_count
+                          subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.account_id__ds_partitioned__day
+                          , subq_3.account_id__ds_partitioned__week
+                          , subq_3.account_id__ds_partitioned__month
+                          , subq_3.account_id__ds_partitioned__quarter
+                          , subq_3.account_id__ds_partitioned__year
+                          , subq_3.account_id__ds_partitioned__extract_year
+                          , subq_3.account_id__ds_partitioned__extract_quarter
+                          , subq_3.account_id__ds_partitioned__extract_month
+                          , subq_3.account_id__ds_partitioned__extract_day
+                          , subq_3.account_id__ds_partitioned__extract_dow
+                          , subq_3.account_id__ds_partitioned__extract_doy
+                          , subq_3.account_id__ds__day
+                          , subq_3.account_id__ds__week
+                          , subq_3.account_id__ds__month
+                          , subq_3.account_id__ds__quarter
+                          , subq_3.account_id__ds__year
+                          , subq_3.account_id__ds__extract_year
+                          , subq_3.account_id__ds__extract_quarter
+                          , subq_3.account_id__ds__extract_month
+                          , subq_3.account_id__ds__extract_day
+                          , subq_3.account_id__ds__extract_dow
+                          , subq_3.account_id__ds__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.account_id
+                          , subq_3.account_month
+                          , subq_3.account_id__account_month
+                          , subq_3.txn_count
                         FROM (
                           -- Read Elements From Semantic Model 'account_month_txns'
                           SELECT
@@ -252,164 +252,164 @@ FROM (
                             , account_month_txns_src_22000.account_month AS account_id__account_month
                             , account_month_txns_src_22000.account_id
                           FROM ***************************.account_month_txns account_month_txns_src_22000
-                        ) subq_21
-                      ) subq_22
-                    ) subq_23
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['ds_partitioned__day', 'account_id', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_29.ds_partitioned__day
-                        , subq_29.account_id
-                        , subq_29.customer_id__customer_third_hop_id
+                        subq_11.ds_partitioned__day
+                        , subq_11.account_id
+                        , subq_11.customer_id__customer_third_hop_id
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_25.ds_partitioned__day AS ds_partitioned__day
-                          , subq_25.ds_partitioned__week AS ds_partitioned__week
-                          , subq_25.ds_partitioned__month AS ds_partitioned__month
-                          , subq_25.ds_partitioned__quarter AS ds_partitioned__quarter
-                          , subq_25.ds_partitioned__year AS ds_partitioned__year
-                          , subq_25.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                          , subq_25.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                          , subq_25.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                          , subq_25.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                          , subq_25.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                          , subq_25.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                          , subq_25.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-                          , subq_25.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-                          , subq_25.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-                          , subq_25.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-                          , subq_25.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-                          , subq_25.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-                          , subq_25.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-                          , subq_25.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-                          , subq_25.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-                          , subq_25.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-                          , subq_25.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-                          , subq_25.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-                          , subq_25.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-                          , subq_25.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-                          , subq_25.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-                          , subq_25.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-                          , subq_25.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-                          , subq_25.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-                          , subq_25.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-                          , subq_25.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-                          , subq_25.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-                          , subq_25.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-                          , subq_25.metric_time__day AS metric_time__day
-                          , subq_25.metric_time__week AS metric_time__week
-                          , subq_25.metric_time__month AS metric_time__month
-                          , subq_25.metric_time__quarter AS metric_time__quarter
-                          , subq_25.metric_time__year AS metric_time__year
-                          , subq_25.metric_time__extract_year AS metric_time__extract_year
-                          , subq_25.metric_time__extract_quarter AS metric_time__extract_quarter
-                          , subq_25.metric_time__extract_month AS metric_time__extract_month
-                          , subq_25.metric_time__extract_day AS metric_time__extract_day
-                          , subq_25.metric_time__extract_dow AS metric_time__extract_dow
-                          , subq_25.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_28.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_28.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_28.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_28.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_28.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_28.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_28.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_28.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_28.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_28.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_28.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_28.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_28.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_28.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_28.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_28.metric_time__day AS customer_id__metric_time__day
-                          , subq_28.metric_time__week AS customer_id__metric_time__week
-                          , subq_28.metric_time__month AS customer_id__metric_time__month
-                          , subq_28.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_28.metric_time__year AS customer_id__metric_time__year
-                          , subq_28.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_28.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_28.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_28.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_28.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_28.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-                          , subq_25.account_id AS account_id
-                          , subq_25.customer_id AS customer_id
-                          , subq_25.account_id__customer_id AS account_id__customer_id
-                          , subq_25.bridge_account__account_id AS bridge_account__account_id
-                          , subq_25.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_28.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_28.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
-                          , subq_25.extra_dim AS extra_dim
-                          , subq_25.account_id__extra_dim AS account_id__extra_dim
-                          , subq_25.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_28.country AS customer_id__country
-                          , subq_28.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
-                          , subq_25.account_customer_combos AS account_customer_combos
+                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          , subq_7.ds_partitioned__week AS ds_partitioned__week
+                          , subq_7.ds_partitioned__month AS ds_partitioned__month
+                          , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+                          , subq_7.ds_partitioned__year AS ds_partitioned__year
+                          , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                          , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                          , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                          , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                          , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                          , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                          , subq_7.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+                          , subq_7.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+                          , subq_7.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+                          , subq_7.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+                          , subq_7.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+                          , subq_7.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+                          , subq_7.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+                          , subq_7.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+                          , subq_7.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+                          , subq_7.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+                          , subq_7.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+                          , subq_7.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+                          , subq_7.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+                          , subq_7.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+                          , subq_7.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+                          , subq_7.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+                          , subq_7.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+                          , subq_7.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+                          , subq_7.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+                          , subq_7.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+                          , subq_7.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+                          , subq_7.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+                          , subq_7.metric_time__day AS metric_time__day
+                          , subq_7.metric_time__week AS metric_time__week
+                          , subq_7.metric_time__month AS metric_time__month
+                          , subq_7.metric_time__quarter AS metric_time__quarter
+                          , subq_7.metric_time__year AS metric_time__year
+                          , subq_7.metric_time__extract_year AS metric_time__extract_year
+                          , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+                          , subq_7.metric_time__extract_month AS metric_time__extract_month
+                          , subq_7.metric_time__extract_day AS metric_time__extract_day
+                          , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+                          , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_7.account_id AS account_id
+                          , subq_7.customer_id AS customer_id
+                          , subq_7.account_id__customer_id AS account_id__customer_id
+                          , subq_7.bridge_account__account_id AS bridge_account__account_id
+                          , subq_7.bridge_account__customer_id AS bridge_account__customer_id
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.extra_dim AS extra_dim
+                          , subq_7.account_id__extra_dim AS account_id__extra_dim
+                          , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
+                          , subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'
                           SELECT
-                            subq_24.ds_partitioned__day
-                            , subq_24.ds_partitioned__week
-                            , subq_24.ds_partitioned__month
-                            , subq_24.ds_partitioned__quarter
-                            , subq_24.ds_partitioned__year
-                            , subq_24.ds_partitioned__extract_year
-                            , subq_24.ds_partitioned__extract_quarter
-                            , subq_24.ds_partitioned__extract_month
-                            , subq_24.ds_partitioned__extract_day
-                            , subq_24.ds_partitioned__extract_dow
-                            , subq_24.ds_partitioned__extract_doy
-                            , subq_24.account_id__ds_partitioned__day
-                            , subq_24.account_id__ds_partitioned__week
-                            , subq_24.account_id__ds_partitioned__month
-                            , subq_24.account_id__ds_partitioned__quarter
-                            , subq_24.account_id__ds_partitioned__year
-                            , subq_24.account_id__ds_partitioned__extract_year
-                            , subq_24.account_id__ds_partitioned__extract_quarter
-                            , subq_24.account_id__ds_partitioned__extract_month
-                            , subq_24.account_id__ds_partitioned__extract_day
-                            , subq_24.account_id__ds_partitioned__extract_dow
-                            , subq_24.account_id__ds_partitioned__extract_doy
-                            , subq_24.bridge_account__ds_partitioned__day
-                            , subq_24.bridge_account__ds_partitioned__week
-                            , subq_24.bridge_account__ds_partitioned__month
-                            , subq_24.bridge_account__ds_partitioned__quarter
-                            , subq_24.bridge_account__ds_partitioned__year
-                            , subq_24.bridge_account__ds_partitioned__extract_year
-                            , subq_24.bridge_account__ds_partitioned__extract_quarter
-                            , subq_24.bridge_account__ds_partitioned__extract_month
-                            , subq_24.bridge_account__ds_partitioned__extract_day
-                            , subq_24.bridge_account__ds_partitioned__extract_dow
-                            , subq_24.bridge_account__ds_partitioned__extract_doy
-                            , subq_24.ds_partitioned__day AS metric_time__day
-                            , subq_24.ds_partitioned__week AS metric_time__week
-                            , subq_24.ds_partitioned__month AS metric_time__month
-                            , subq_24.ds_partitioned__quarter AS metric_time__quarter
-                            , subq_24.ds_partitioned__year AS metric_time__year
-                            , subq_24.ds_partitioned__extract_year AS metric_time__extract_year
-                            , subq_24.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                            , subq_24.ds_partitioned__extract_month AS metric_time__extract_month
-                            , subq_24.ds_partitioned__extract_day AS metric_time__extract_day
-                            , subq_24.ds_partitioned__extract_dow AS metric_time__extract_dow
-                            , subq_24.ds_partitioned__extract_doy AS metric_time__extract_doy
-                            , subq_24.account_id
-                            , subq_24.customer_id
-                            , subq_24.account_id__customer_id
-                            , subq_24.bridge_account__account_id
-                            , subq_24.bridge_account__customer_id
-                            , subq_24.extra_dim
-                            , subq_24.account_id__extra_dim
-                            , subq_24.bridge_account__extra_dim
-                            , subq_24.account_customer_combos
+                            subq_6.ds_partitioned__day
+                            , subq_6.ds_partitioned__week
+                            , subq_6.ds_partitioned__month
+                            , subq_6.ds_partitioned__quarter
+                            , subq_6.ds_partitioned__year
+                            , subq_6.ds_partitioned__extract_year
+                            , subq_6.ds_partitioned__extract_quarter
+                            , subq_6.ds_partitioned__extract_month
+                            , subq_6.ds_partitioned__extract_day
+                            , subq_6.ds_partitioned__extract_dow
+                            , subq_6.ds_partitioned__extract_doy
+                            , subq_6.account_id__ds_partitioned__day
+                            , subq_6.account_id__ds_partitioned__week
+                            , subq_6.account_id__ds_partitioned__month
+                            , subq_6.account_id__ds_partitioned__quarter
+                            , subq_6.account_id__ds_partitioned__year
+                            , subq_6.account_id__ds_partitioned__extract_year
+                            , subq_6.account_id__ds_partitioned__extract_quarter
+                            , subq_6.account_id__ds_partitioned__extract_month
+                            , subq_6.account_id__ds_partitioned__extract_day
+                            , subq_6.account_id__ds_partitioned__extract_dow
+                            , subq_6.account_id__ds_partitioned__extract_doy
+                            , subq_6.bridge_account__ds_partitioned__day
+                            , subq_6.bridge_account__ds_partitioned__week
+                            , subq_6.bridge_account__ds_partitioned__month
+                            , subq_6.bridge_account__ds_partitioned__quarter
+                            , subq_6.bridge_account__ds_partitioned__year
+                            , subq_6.bridge_account__ds_partitioned__extract_year
+                            , subq_6.bridge_account__ds_partitioned__extract_quarter
+                            , subq_6.bridge_account__ds_partitioned__extract_month
+                            , subq_6.bridge_account__ds_partitioned__extract_day
+                            , subq_6.bridge_account__ds_partitioned__extract_dow
+                            , subq_6.bridge_account__ds_partitioned__extract_doy
+                            , subq_6.ds_partitioned__day AS metric_time__day
+                            , subq_6.ds_partitioned__week AS metric_time__week
+                            , subq_6.ds_partitioned__month AS metric_time__month
+                            , subq_6.ds_partitioned__quarter AS metric_time__quarter
+                            , subq_6.ds_partitioned__year AS metric_time__year
+                            , subq_6.ds_partitioned__extract_year AS metric_time__extract_year
+                            , subq_6.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                            , subq_6.ds_partitioned__extract_month AS metric_time__extract_month
+                            , subq_6.ds_partitioned__extract_day AS metric_time__extract_day
+                            , subq_6.ds_partitioned__extract_dow AS metric_time__extract_dow
+                            , subq_6.ds_partitioned__extract_doy AS metric_time__extract_doy
+                            , subq_6.account_id
+                            , subq_6.customer_id
+                            , subq_6.account_id__customer_id
+                            , subq_6.bridge_account__account_id
+                            , subq_6.bridge_account__customer_id
+                            , subq_6.extra_dim
+                            , subq_6.account_id__extra_dim
+                            , subq_6.bridge_account__extra_dim
+                            , subq_6.account_customer_combos
                           FROM (
                             -- Read Elements From Semantic Model 'bridge_table'
                             SELECT
@@ -456,8 +456,8 @@ FROM (
                               , bridge_table_src_22000.account_id AS bridge_account__account_id
                               , bridge_table_src_22000.customer_id AS bridge_account__customer_id
                             FROM ***************************.bridge_table bridge_table_src_22000
-                          ) subq_24
-                        ) subq_25
+                          ) subq_6
+                        ) subq_7
                         LEFT OUTER JOIN (
                           -- Pass Only Elements: [
                           --   'country',
@@ -513,112 +513,112 @@ FROM (
                           --   'customer_third_hop_id__customer_id',
                           -- ]
                           SELECT
-                            subq_27.acquired_ds__day
-                            , subq_27.acquired_ds__week
-                            , subq_27.acquired_ds__month
-                            , subq_27.acquired_ds__quarter
-                            , subq_27.acquired_ds__year
-                            , subq_27.acquired_ds__extract_year
-                            , subq_27.acquired_ds__extract_quarter
-                            , subq_27.acquired_ds__extract_month
-                            , subq_27.acquired_ds__extract_day
-                            , subq_27.acquired_ds__extract_dow
-                            , subq_27.acquired_ds__extract_doy
-                            , subq_27.customer_id__acquired_ds__day
-                            , subq_27.customer_id__acquired_ds__week
-                            , subq_27.customer_id__acquired_ds__month
-                            , subq_27.customer_id__acquired_ds__quarter
-                            , subq_27.customer_id__acquired_ds__year
-                            , subq_27.customer_id__acquired_ds__extract_year
-                            , subq_27.customer_id__acquired_ds__extract_quarter
-                            , subq_27.customer_id__acquired_ds__extract_month
-                            , subq_27.customer_id__acquired_ds__extract_day
-                            , subq_27.customer_id__acquired_ds__extract_dow
-                            , subq_27.customer_id__acquired_ds__extract_doy
-                            , subq_27.customer_third_hop_id__acquired_ds__day
-                            , subq_27.customer_third_hop_id__acquired_ds__week
-                            , subq_27.customer_third_hop_id__acquired_ds__month
-                            , subq_27.customer_third_hop_id__acquired_ds__quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_27.metric_time__day
-                            , subq_27.metric_time__week
-                            , subq_27.metric_time__month
-                            , subq_27.metric_time__quarter
-                            , subq_27.metric_time__year
-                            , subq_27.metric_time__extract_year
-                            , subq_27.metric_time__extract_quarter
-                            , subq_27.metric_time__extract_month
-                            , subq_27.metric_time__extract_day
-                            , subq_27.metric_time__extract_dow
-                            , subq_27.metric_time__extract_doy
-                            , subq_27.customer_id
-                            , subq_27.customer_third_hop_id
-                            , subq_27.customer_id__customer_third_hop_id
-                            , subq_27.customer_third_hop_id__customer_id
-                            , subq_27.country
-                            , subq_27.customer_id__country
-                            , subq_27.customer_third_hop_id__country
+                            subq_9.acquired_ds__day
+                            , subq_9.acquired_ds__week
+                            , subq_9.acquired_ds__month
+                            , subq_9.acquired_ds__quarter
+                            , subq_9.acquired_ds__year
+                            , subq_9.acquired_ds__extract_year
+                            , subq_9.acquired_ds__extract_quarter
+                            , subq_9.acquired_ds__extract_month
+                            , subq_9.acquired_ds__extract_day
+                            , subq_9.acquired_ds__extract_dow
+                            , subq_9.acquired_ds__extract_doy
+                            , subq_9.customer_id__acquired_ds__day
+                            , subq_9.customer_id__acquired_ds__week
+                            , subq_9.customer_id__acquired_ds__month
+                            , subq_9.customer_id__acquired_ds__quarter
+                            , subq_9.customer_id__acquired_ds__year
+                            , subq_9.customer_id__acquired_ds__extract_year
+                            , subq_9.customer_id__acquired_ds__extract_quarter
+                            , subq_9.customer_id__acquired_ds__extract_month
+                            , subq_9.customer_id__acquired_ds__extract_day
+                            , subq_9.customer_id__acquired_ds__extract_dow
+                            , subq_9.customer_id__acquired_ds__extract_doy
+                            , subq_9.customer_third_hop_id__acquired_ds__day
+                            , subq_9.customer_third_hop_id__acquired_ds__week
+                            , subq_9.customer_third_hop_id__acquired_ds__month
+                            , subq_9.customer_third_hop_id__acquired_ds__quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_9.metric_time__day
+                            , subq_9.metric_time__week
+                            , subq_9.metric_time__month
+                            , subq_9.metric_time__quarter
+                            , subq_9.metric_time__year
+                            , subq_9.metric_time__extract_year
+                            , subq_9.metric_time__extract_quarter
+                            , subq_9.metric_time__extract_month
+                            , subq_9.metric_time__extract_day
+                            , subq_9.metric_time__extract_dow
+                            , subq_9.metric_time__extract_doy
+                            , subq_9.customer_id
+                            , subq_9.customer_third_hop_id
+                            , subq_9.customer_id__customer_third_hop_id
+                            , subq_9.customer_third_hop_id__customer_id
+                            , subq_9.country
+                            , subq_9.customer_id__country
+                            , subq_9.customer_third_hop_id__country
                           FROM (
                             -- Metric Time Dimension 'acquired_ds'
                             SELECT
-                              subq_26.acquired_ds__day
-                              , subq_26.acquired_ds__week
-                              , subq_26.acquired_ds__month
-                              , subq_26.acquired_ds__quarter
-                              , subq_26.acquired_ds__year
-                              , subq_26.acquired_ds__extract_year
-                              , subq_26.acquired_ds__extract_quarter
-                              , subq_26.acquired_ds__extract_month
-                              , subq_26.acquired_ds__extract_day
-                              , subq_26.acquired_ds__extract_dow
-                              , subq_26.acquired_ds__extract_doy
-                              , subq_26.customer_id__acquired_ds__day
-                              , subq_26.customer_id__acquired_ds__week
-                              , subq_26.customer_id__acquired_ds__month
-                              , subq_26.customer_id__acquired_ds__quarter
-                              , subq_26.customer_id__acquired_ds__year
-                              , subq_26.customer_id__acquired_ds__extract_year
-                              , subq_26.customer_id__acquired_ds__extract_quarter
-                              , subq_26.customer_id__acquired_ds__extract_month
-                              , subq_26.customer_id__acquired_ds__extract_day
-                              , subq_26.customer_id__acquired_ds__extract_dow
-                              , subq_26.customer_id__acquired_ds__extract_doy
-                              , subq_26.customer_third_hop_id__acquired_ds__day
-                              , subq_26.customer_third_hop_id__acquired_ds__week
-                              , subq_26.customer_third_hop_id__acquired_ds__month
-                              , subq_26.customer_third_hop_id__acquired_ds__quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_month
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_day
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_dow
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_doy
-                              , subq_26.acquired_ds__day AS metric_time__day
-                              , subq_26.acquired_ds__week AS metric_time__week
-                              , subq_26.acquired_ds__month AS metric_time__month
-                              , subq_26.acquired_ds__quarter AS metric_time__quarter
-                              , subq_26.acquired_ds__year AS metric_time__year
-                              , subq_26.acquired_ds__extract_year AS metric_time__extract_year
-                              , subq_26.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_26.acquired_ds__extract_month AS metric_time__extract_month
-                              , subq_26.acquired_ds__extract_day AS metric_time__extract_day
-                              , subq_26.acquired_ds__extract_dow AS metric_time__extract_dow
-                              , subq_26.acquired_ds__extract_doy AS metric_time__extract_doy
-                              , subq_26.customer_id
-                              , subq_26.customer_third_hop_id
-                              , subq_26.customer_id__customer_third_hop_id
-                              , subq_26.customer_third_hop_id__customer_id
-                              , subq_26.country
-                              , subq_26.customer_id__country
-                              , subq_26.customer_third_hop_id__country
-                              , subq_26.customers_with_other_data
+                              subq_8.acquired_ds__day
+                              , subq_8.acquired_ds__week
+                              , subq_8.acquired_ds__month
+                              , subq_8.acquired_ds__quarter
+                              , subq_8.acquired_ds__year
+                              , subq_8.acquired_ds__extract_year
+                              , subq_8.acquired_ds__extract_quarter
+                              , subq_8.acquired_ds__extract_month
+                              , subq_8.acquired_ds__extract_day
+                              , subq_8.acquired_ds__extract_dow
+                              , subq_8.acquired_ds__extract_doy
+                              , subq_8.customer_id__acquired_ds__day
+                              , subq_8.customer_id__acquired_ds__week
+                              , subq_8.customer_id__acquired_ds__month
+                              , subq_8.customer_id__acquired_ds__quarter
+                              , subq_8.customer_id__acquired_ds__year
+                              , subq_8.customer_id__acquired_ds__extract_year
+                              , subq_8.customer_id__acquired_ds__extract_quarter
+                              , subq_8.customer_id__acquired_ds__extract_month
+                              , subq_8.customer_id__acquired_ds__extract_day
+                              , subq_8.customer_id__acquired_ds__extract_dow
+                              , subq_8.customer_id__acquired_ds__extract_doy
+                              , subq_8.customer_third_hop_id__acquired_ds__day
+                              , subq_8.customer_third_hop_id__acquired_ds__week
+                              , subq_8.customer_third_hop_id__acquired_ds__month
+                              , subq_8.customer_third_hop_id__acquired_ds__quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_month
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_day
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_dow
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_doy
+                              , subq_8.acquired_ds__day AS metric_time__day
+                              , subq_8.acquired_ds__week AS metric_time__week
+                              , subq_8.acquired_ds__month AS metric_time__month
+                              , subq_8.acquired_ds__quarter AS metric_time__quarter
+                              , subq_8.acquired_ds__year AS metric_time__year
+                              , subq_8.acquired_ds__extract_year AS metric_time__extract_year
+                              , subq_8.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_8.acquired_ds__extract_month AS metric_time__extract_month
+                              , subq_8.acquired_ds__extract_day AS metric_time__extract_day
+                              , subq_8.acquired_ds__extract_dow AS metric_time__extract_dow
+                              , subq_8.acquired_ds__extract_doy AS metric_time__extract_doy
+                              , subq_8.customer_id
+                              , subq_8.customer_third_hop_id
+                              , subq_8.customer_id__customer_third_hop_id
+                              , subq_8.customer_third_hop_id__customer_id
+                              , subq_8.country
+                              , subq_8.customer_id__country
+                              , subq_8.customer_third_hop_id__country
+                              , subq_8.customers_with_other_data
                             FROM (
                               -- Read Elements From Semantic Model 'customer_other_data'
                               SELECT
@@ -664,31 +664,31 @@ FROM (
                                 , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                                 , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                               FROM ***************************.customer_other_data customer_other_data_src_22000
-                            ) subq_26
-                          ) subq_27
-                        ) subq_28
+                            ) subq_8
+                          ) subq_9
+                        ) subq_10
                         ON
-                          subq_25.customer_id = subq_28.customer_id
-                      ) subq_29
-                    ) subq_30
+                          subq_7.customer_id = subq_10.customer_id
+                      ) subq_11
+                    ) subq_12
                     ON
                       (
-                        subq_23.account_id = subq_30.account_id
+                        subq_5.account_id = subq_12.account_id
                       ) AND (
-                        subq_23.ds_partitioned__day = subq_30.ds_partitioned__day
+                        subq_5.ds_partitioned__day = subq_12.ds_partitioned__day
                       )
-                  ) subq_31
-                ) subq_32
+                  ) subq_13
+                ) subq_14
                 GROUP BY
                   account_id__customer_id__customer_third_hop_id
-              ) subq_33
-            ) subq_34
-          ) subq_35
+              ) subq_15
+            ) subq_16
+          ) subq_17
           ON
-            subq_20.customer_third_hop_id = subq_35.account_id__customer_id__customer_third_hop_id
-        ) subq_36
-      ) subq_37
+            subq_2.customer_third_hop_id = subq_17.account_id__customer_id__customer_third_hop_id
+        ) subq_18
+      ) subq_19
       WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2
-    ) subq_38
-  ) subq_39
-) subq_40
+    ) subq_20
+  ) subq_21
+) subq_22

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_40.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_35.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_71
+    ) subq_35
     ON
       (
-        account_month_txns_src_22000.account_id = subq_71.account_id
+        account_month_txns_src_22000.account_id = subq_35.account_id
       ) AND (
-        DATETIME_TRUNC(account_month_txns_src_22000.ds_partitioned, day) = subq_71.ds_partitioned__day
+        DATETIME_TRUNC(account_month_txns_src_22000.ds_partitioned, day) = subq_35.ds_partitioned__day
       )
     GROUP BY
       account_id__customer_id__customer_third_hop_id
-  ) subq_76
+  ) subq_40
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
-) subq_78
+    third_hop_table_src_22000.customer_third_hop_id = subq_40.account_id__customer_id__customer_third_hop_id
+) subq_42
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_25.third_hop_count
+  subq_16.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_24.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_23.third_hop_count
+      subq_14.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_22.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_22.third_hop_count
+        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_13.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_21.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_21.third_hop_count
+          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_12.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.customer_third_hop_id AS customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-            , subq_11.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_10.customer_third_hop_id
-              , subq_10.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_9.third_hop_ds__day
-                , subq_9.third_hop_ds__week
-                , subq_9.third_hop_ds__month
-                , subq_9.third_hop_ds__quarter
-                , subq_9.third_hop_ds__year
-                , subq_9.third_hop_ds__extract_year
-                , subq_9.third_hop_ds__extract_quarter
-                , subq_9.third_hop_ds__extract_month
-                , subq_9.third_hop_ds__extract_day
-                , subq_9.third_hop_ds__extract_dow
-                , subq_9.third_hop_ds__extract_doy
-                , subq_9.customer_third_hop_id__third_hop_ds__day
-                , subq_9.customer_third_hop_id__third_hop_ds__week
-                , subq_9.customer_third_hop_id__third_hop_ds__month
-                , subq_9.customer_third_hop_id__third_hop_ds__quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_9.third_hop_ds__day AS metric_time__day
-                , subq_9.third_hop_ds__week AS metric_time__week
-                , subq_9.third_hop_ds__month AS metric_time__month
-                , subq_9.third_hop_ds__quarter AS metric_time__quarter
-                , subq_9.third_hop_ds__year AS metric_time__year
-                , subq_9.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_9.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_9.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_9.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_9.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_9.customer_third_hop_id
-                , subq_9.value
-                , subq_9.customer_third_hop_id__value
-                , subq_9.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,151 +101,151 @@ FROM (
                   , EXTRACT(dayofyear FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_19.customer_id__customer_third_hop_id
-              , subq_19.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_10.customer_id__customer_third_hop_id
+              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_18.customer_id__customer_third_hop_id
-                , subq_18.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_9.customer_id__customer_third_hop_id
+                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_17.customer_id__customer_third_hop_id
-                  , SUM(subq_17.customers_with_other_data) AS customers_with_other_data
+                  subq_8.customer_id__customer_third_hop_id
+                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_16.customer_id__customer_third_hop_id
-                    , subq_16.customers_with_other_data
+                    subq_7.customer_id__customer_third_hop_id
+                    , subq_7.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_15.customer_id__customer_third_hop_id
-                      , subq_15.customer_id__country
-                      , subq_15.customers_with_other_data
+                      subq_6.customer_id__customer_third_hop_id
+                      , subq_6.customer_id__country
+                      , subq_6.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_14.customer_id__customer_third_hop_id
-                        , subq_14.customer_id__country
-                        , subq_14.customers_with_other_data
+                        subq_5.customer_id__customer_third_hop_id
+                        , subq_5.customer_id__country
+                        , subq_5.customers_with_other_data
                       FROM (
                         -- Constrain Output with WHERE
                         SELECT
-                          subq_13.acquired_ds__day
-                          , subq_13.acquired_ds__week
-                          , subq_13.acquired_ds__month
-                          , subq_13.acquired_ds__quarter
-                          , subq_13.acquired_ds__year
-                          , subq_13.acquired_ds__extract_year
-                          , subq_13.acquired_ds__extract_quarter
-                          , subq_13.acquired_ds__extract_month
-                          , subq_13.acquired_ds__extract_day
-                          , subq_13.acquired_ds__extract_dow
-                          , subq_13.acquired_ds__extract_doy
-                          , subq_13.customer_id__acquired_ds__day
-                          , subq_13.customer_id__acquired_ds__week
-                          , subq_13.customer_id__acquired_ds__month
-                          , subq_13.customer_id__acquired_ds__quarter
-                          , subq_13.customer_id__acquired_ds__year
-                          , subq_13.customer_id__acquired_ds__extract_year
-                          , subq_13.customer_id__acquired_ds__extract_quarter
-                          , subq_13.customer_id__acquired_ds__extract_month
-                          , subq_13.customer_id__acquired_ds__extract_day
-                          , subq_13.customer_id__acquired_ds__extract_dow
-                          , subq_13.customer_id__acquired_ds__extract_doy
-                          , subq_13.customer_third_hop_id__acquired_ds__day
-                          , subq_13.customer_third_hop_id__acquired_ds__week
-                          , subq_13.customer_third_hop_id__acquired_ds__month
-                          , subq_13.customer_third_hop_id__acquired_ds__quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_13.metric_time__day
-                          , subq_13.metric_time__week
-                          , subq_13.metric_time__month
-                          , subq_13.metric_time__quarter
-                          , subq_13.metric_time__year
-                          , subq_13.metric_time__extract_year
-                          , subq_13.metric_time__extract_quarter
-                          , subq_13.metric_time__extract_month
-                          , subq_13.metric_time__extract_day
-                          , subq_13.metric_time__extract_dow
-                          , subq_13.metric_time__extract_doy
-                          , subq_13.customer_id
-                          , subq_13.customer_third_hop_id
-                          , subq_13.customer_id__customer_third_hop_id
-                          , subq_13.customer_third_hop_id__customer_id
-                          , subq_13.country
-                          , subq_13.customer_id__country
-                          , subq_13.customer_third_hop_id__country
-                          , subq_13.customers_with_other_data
+                          subq_4.acquired_ds__day
+                          , subq_4.acquired_ds__week
+                          , subq_4.acquired_ds__month
+                          , subq_4.acquired_ds__quarter
+                          , subq_4.acquired_ds__year
+                          , subq_4.acquired_ds__extract_year
+                          , subq_4.acquired_ds__extract_quarter
+                          , subq_4.acquired_ds__extract_month
+                          , subq_4.acquired_ds__extract_day
+                          , subq_4.acquired_ds__extract_dow
+                          , subq_4.acquired_ds__extract_doy
+                          , subq_4.customer_id__acquired_ds__day
+                          , subq_4.customer_id__acquired_ds__week
+                          , subq_4.customer_id__acquired_ds__month
+                          , subq_4.customer_id__acquired_ds__quarter
+                          , subq_4.customer_id__acquired_ds__year
+                          , subq_4.customer_id__acquired_ds__extract_year
+                          , subq_4.customer_id__acquired_ds__extract_quarter
+                          , subq_4.customer_id__acquired_ds__extract_month
+                          , subq_4.customer_id__acquired_ds__extract_day
+                          , subq_4.customer_id__acquired_ds__extract_dow
+                          , subq_4.customer_id__acquired_ds__extract_doy
+                          , subq_4.customer_third_hop_id__acquired_ds__day
+                          , subq_4.customer_third_hop_id__acquired_ds__week
+                          , subq_4.customer_third_hop_id__acquired_ds__month
+                          , subq_4.customer_third_hop_id__acquired_ds__quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_4.metric_time__day
+                          , subq_4.metric_time__week
+                          , subq_4.metric_time__month
+                          , subq_4.metric_time__quarter
+                          , subq_4.metric_time__year
+                          , subq_4.metric_time__extract_year
+                          , subq_4.metric_time__extract_quarter
+                          , subq_4.metric_time__extract_month
+                          , subq_4.metric_time__extract_day
+                          , subq_4.metric_time__extract_dow
+                          , subq_4.metric_time__extract_doy
+                          , subq_4.customer_id
+                          , subq_4.customer_third_hop_id
+                          , subq_4.customer_id__customer_third_hop_id
+                          , subq_4.customer_third_hop_id__customer_id
+                          , subq_4.country
+                          , subq_4.customer_id__country
+                          , subq_4.customer_third_hop_id__country
+                          , subq_4.customers_with_other_data
                         FROM (
                           -- Metric Time Dimension 'acquired_ds'
                           SELECT
-                            subq_12.acquired_ds__day
-                            , subq_12.acquired_ds__week
-                            , subq_12.acquired_ds__month
-                            , subq_12.acquired_ds__quarter
-                            , subq_12.acquired_ds__year
-                            , subq_12.acquired_ds__extract_year
-                            , subq_12.acquired_ds__extract_quarter
-                            , subq_12.acquired_ds__extract_month
-                            , subq_12.acquired_ds__extract_day
-                            , subq_12.acquired_ds__extract_dow
-                            , subq_12.acquired_ds__extract_doy
-                            , subq_12.customer_id__acquired_ds__day
-                            , subq_12.customer_id__acquired_ds__week
-                            , subq_12.customer_id__acquired_ds__month
-                            , subq_12.customer_id__acquired_ds__quarter
-                            , subq_12.customer_id__acquired_ds__year
-                            , subq_12.customer_id__acquired_ds__extract_year
-                            , subq_12.customer_id__acquired_ds__extract_quarter
-                            , subq_12.customer_id__acquired_ds__extract_month
-                            , subq_12.customer_id__acquired_ds__extract_day
-                            , subq_12.customer_id__acquired_ds__extract_dow
-                            , subq_12.customer_id__acquired_ds__extract_doy
-                            , subq_12.customer_third_hop_id__acquired_ds__day
-                            , subq_12.customer_third_hop_id__acquired_ds__week
-                            , subq_12.customer_third_hop_id__acquired_ds__month
-                            , subq_12.customer_third_hop_id__acquired_ds__quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_12.acquired_ds__day AS metric_time__day
-                            , subq_12.acquired_ds__week AS metric_time__week
-                            , subq_12.acquired_ds__month AS metric_time__month
-                            , subq_12.acquired_ds__quarter AS metric_time__quarter
-                            , subq_12.acquired_ds__year AS metric_time__year
-                            , subq_12.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_12.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_12.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_12.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_12.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_12.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_12.customer_id
-                            , subq_12.customer_third_hop_id
-                            , subq_12.customer_id__customer_third_hop_id
-                            , subq_12.customer_third_hop_id__customer_id
-                            , subq_12.country
-                            , subq_12.customer_id__country
-                            , subq_12.customer_third_hop_id__country
-                            , subq_12.customers_with_other_data
+                            subq_3.acquired_ds__day
+                            , subq_3.acquired_ds__week
+                            , subq_3.acquired_ds__month
+                            , subq_3.acquired_ds__quarter
+                            , subq_3.acquired_ds__year
+                            , subq_3.acquired_ds__extract_year
+                            , subq_3.acquired_ds__extract_quarter
+                            , subq_3.acquired_ds__extract_month
+                            , subq_3.acquired_ds__extract_day
+                            , subq_3.acquired_ds__extract_dow
+                            , subq_3.acquired_ds__extract_doy
+                            , subq_3.customer_id__acquired_ds__day
+                            , subq_3.customer_id__acquired_ds__week
+                            , subq_3.customer_id__acquired_ds__month
+                            , subq_3.customer_id__acquired_ds__quarter
+                            , subq_3.customer_id__acquired_ds__year
+                            , subq_3.customer_id__acquired_ds__extract_year
+                            , subq_3.customer_id__acquired_ds__extract_quarter
+                            , subq_3.customer_id__acquired_ds__extract_month
+                            , subq_3.customer_id__acquired_ds__extract_day
+                            , subq_3.customer_id__acquired_ds__extract_dow
+                            , subq_3.customer_id__acquired_ds__extract_doy
+                            , subq_3.customer_third_hop_id__acquired_ds__day
+                            , subq_3.customer_third_hop_id__acquired_ds__week
+                            , subq_3.customer_third_hop_id__acquired_ds__month
+                            , subq_3.customer_third_hop_id__acquired_ds__quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_3.acquired_ds__day AS metric_time__day
+                            , subq_3.acquired_ds__week AS metric_time__week
+                            , subq_3.acquired_ds__month AS metric_time__month
+                            , subq_3.acquired_ds__quarter AS metric_time__quarter
+                            , subq_3.acquired_ds__year AS metric_time__year
+                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                            , subq_3.customer_id
+                            , subq_3.customer_third_hop_id
+                            , subq_3.customer_id__customer_third_hop_id
+                            , subq_3.customer_third_hop_id__customer_id
+                            , subq_3.country
+                            , subq_3.customer_id__country
+                            , subq_3.customer_third_hop_id__country
+                            , subq_3.customers_with_other_data
                           FROM (
                             -- Read Elements From Semantic Model 'customer_other_data'
                             SELECT
@@ -291,24 +291,24 @@ FROM (
                               , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                               , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                             FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_12
-                        ) subq_13
+                          ) subq_3
+                        ) subq_4
                         WHERE customer_id__country = 'paraguay'
-                      ) subq_14
-                    ) subq_15
+                      ) subq_5
+                    ) subq_6
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_16
-                ) subq_17
+                  ) subq_7
+                ) subq_8
                 GROUP BY
                   customer_id__customer_third_hop_id
-              ) subq_18
-            ) subq_19
-          ) subq_20
+              ) subq_9
+            ) subq_10
+          ) subq_11
           ON
-            subq_11.customer_third_hop_id = subq_20.customer_id__customer_third_hop_id
-        ) subq_21
-      ) subq_22
+            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
+        ) subq_12
+      ) subq_13
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_23
-  ) subq_24
-) subq_25
+    ) subq_14
+  ) subq_15
+) subq_16

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_39
+      ) subq_21
       WHERE customer_id__country = 'paraguay'
-    ) subq_41
+    ) subq_23
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_46
+  ) subq_28
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
-) subq_48
+    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
+) subq_30
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookers
-        , subq_14.bookers
+        subq_10.listing__bookers
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'listing__bookers']
         SELECT
-          subq_13.listing__bookers
-          , subq_13.bookers
+          subq_9.listing__bookers
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookers AS listing__bookers
-            , subq_6.bookers AS bookers
+            subq_2.listing AS listing
+            , subq_8.listing__bookers AS listing__bookers
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.bookers
+              subq_1.listing
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookers
+              subq_7.listing
+              , subq_7.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookers AS listing__bookers
+                subq_6.listing
+                , subq_6.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , COUNT(DISTINCT subq_9.bookers) AS bookers
+                  subq_5.listing
+                  , COUNT(DISTINCT subq_5.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookers
+                    subq_4.listing
+                    , subq_4.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
                   listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookers > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_30.listing__bookers AS listing__bookers
-    , subq_24.bookers AS bookers
+    subq_22.listing__bookers AS listing__bookers
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_with_metric_in_where_filter__plan0.sql
@@ -1,112 +1,112 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time__day
-  , subq_17.listings AS active_listings
+  subq_13.metric_time__day
+  , subq_13.listings AS active_listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.metric_time__day
-    , SUM(subq_16.listings) AS listings
+    subq_12.metric_time__day
+    , SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'metric_time__day']
     SELECT
-      subq_15.metric_time__day
-      , subq_15.listings
+      subq_11.metric_time__day
+      , subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.metric_time__day
-        , subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.metric_time__day
+        , subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
         SELECT
-          subq_13.metric_time__day
-          , subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.metric_time__day
+          , subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.metric_time__day AS metric_time__day
-            , subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']
             SELECT
-              subq_5.metric_time__day
-              , subq_5.listing
-              , subq_5.listings
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -167,130 +167,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -383,21 +383,21 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
                   listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
+    ) subq_11
+  ) subq_12
   GROUP BY
     metric_time__day
-) subq_17
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_24.metric_time__day AS metric_time__day
-    , subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_16.metric_time__day AS metric_time__day
+    , subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.user__revenue_all_time
-        , subq_14.listings
+        subq_10.user__revenue_all_time
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__revenue_all_time']
         SELECT
-          subq_13.user__revenue_all_time
-          , subq_13.listings
+          subq_9.user__revenue_all_time
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.user AS user
-            , subq_12.user__revenue_all_time AS user__revenue_all_time
-            , subq_6.listings AS listings
+            subq_2.user AS user
+            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_5.user
-              , subq_5.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,68 +160,68 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__revenue_all_time']
             SELECT
-              subq_11.user
-              , subq_11.user__revenue_all_time
+              subq_7.user
+              , subq_7.user__revenue_all_time
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.user
-                , subq_10.txn_revenue AS user__revenue_all_time
+                subq_6.user
+                , subq_6.txn_revenue AS user__revenue_all_time
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.user
-                  , SUM(subq_9.txn_revenue) AS txn_revenue
+                  subq_5.user
+                  , SUM(subq_5.txn_revenue) AS txn_revenue
                 FROM (
                   -- Pass Only Elements: ['txn_revenue', 'user']
                   SELECT
-                    subq_8.user
-                    , subq_8.txn_revenue
+                    subq_4.user
+                    , subq_4.txn_revenue
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.revenue_instance__ds__day
-                      , subq_7.revenue_instance__ds__week
-                      , subq_7.revenue_instance__ds__month
-                      , subq_7.revenue_instance__ds__quarter
-                      , subq_7.revenue_instance__ds__year
-                      , subq_7.revenue_instance__ds__extract_year
-                      , subq_7.revenue_instance__ds__extract_quarter
-                      , subq_7.revenue_instance__ds__extract_month
-                      , subq_7.revenue_instance__ds__extract_day
-                      , subq_7.revenue_instance__ds__extract_dow
-                      , subq_7.revenue_instance__ds__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.user
-                      , subq_7.revenue_instance__user
-                      , subq_7.txn_revenue
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.revenue_instance__ds__day
+                      , subq_3.revenue_instance__ds__week
+                      , subq_3.revenue_instance__ds__month
+                      , subq_3.revenue_instance__ds__quarter
+                      , subq_3.revenue_instance__ds__year
+                      , subq_3.revenue_instance__ds__extract_year
+                      , subq_3.revenue_instance__ds__extract_quarter
+                      , subq_3.revenue_instance__ds__extract_month
+                      , subq_3.revenue_instance__ds__extract_day
+                      , subq_3.revenue_instance__ds__extract_dow
+                      , subq_3.revenue_instance__ds__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.user
+                      , subq_3.revenue_instance__user
+                      , subq_3.txn_revenue
                     FROM (
                       -- Read Elements From Semantic Model 'revenue'
                       SELECT
@@ -251,19 +251,19 @@ FROM (
                         , revenue_src_28000.user_id AS user
                         , revenue_src_28000.user_id AS revenue_instance__user
                       FROM ***************************.fct_revenue revenue_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
                   user
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.user = subq_12.user
-        ) subq_13
-      ) subq_14
+            subq_2.user = subq_8.user
+        ) subq_9
+      ) subq_10
       WHERE user__revenue_all_time > 1
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_30.user__revenue_all_time AS user__revenue_all_time
-    , subq_24.listings AS listings
+    subq_22.user__revenue_all_time AS user__revenue_all_time
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.user = subq_30.user
-) subq_32
+    subq_16.user = subq_22.user
+) subq_24
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__views_times_booking_value
-        , subq_28.listings
+        subq_17.listing__views_times_booking_value
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
         SELECT
-          subq_27.listing__views_times_booking_value
-          , subq_27.listings
+          subq_16.listing__views_times_booking_value
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__views_times_booking_value AS listing__views_times_booking_value
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
             SELECT
-              subq_25.listing
-              , subq_25.listing__views_times_booking_value
+              subq_14.listing
+              , subq_14.listing__views_times_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
+                subq_13.listing
                 , booking_value * views AS listing__views_times_booking_value
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.booking_value) AS booking_value
-                  , MAX(subq_23.views) AS views
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.booking_value) AS booking_value
+                  , MAX(subq_12.views) AS views
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.booking_value
+                    subq_6.listing
+                    , subq_6.booking_value
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.booking_value) AS booking_value
+                      subq_5.listing
+                      , SUM(subq_5.booking_value) AS booking_value
                     FROM (
                       -- Pass Only Elements: ['booking_value', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.booking_value
+                        subq_4.listing
+                        , subq_4.booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,91 +387,91 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
                       listing
-                  ) subq_17
-                ) subq_18
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.views
+                    subq_11.listing
+                    , subq_11.views
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , SUM(subq_21.views) AS views
+                      subq_10.listing
+                      , SUM(subq_10.views) AS views
                     FROM (
                       -- Pass Only Elements: ['views', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.views
+                        subq_9.listing
+                        , subq_9.views
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.view__ds__day
-                          , subq_19.view__ds__week
-                          , subq_19.view__ds__month
-                          , subq_19.view__ds__quarter
-                          , subq_19.view__ds__year
-                          , subq_19.view__ds__extract_year
-                          , subq_19.view__ds__extract_quarter
-                          , subq_19.view__ds__extract_month
-                          , subq_19.view__ds__extract_day
-                          , subq_19.view__ds__extract_dow
-                          , subq_19.view__ds__extract_doy
-                          , subq_19.view__ds_partitioned__day
-                          , subq_19.view__ds_partitioned__week
-                          , subq_19.view__ds_partitioned__month
-                          , subq_19.view__ds_partitioned__quarter
-                          , subq_19.view__ds_partitioned__year
-                          , subq_19.view__ds_partitioned__extract_year
-                          , subq_19.view__ds_partitioned__extract_quarter
-                          , subq_19.view__ds_partitioned__extract_month
-                          , subq_19.view__ds_partitioned__extract_day
-                          , subq_19.view__ds_partitioned__extract_dow
-                          , subq_19.view__ds_partitioned__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.user
-                          , subq_19.view__listing
-                          , subq_19.view__user
-                          , subq_19.views
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.view__ds__day
+                          , subq_8.view__ds__week
+                          , subq_8.view__ds__month
+                          , subq_8.view__ds__quarter
+                          , subq_8.view__ds__year
+                          , subq_8.view__ds__extract_year
+                          , subq_8.view__ds__extract_quarter
+                          , subq_8.view__ds__extract_month
+                          , subq_8.view__ds__extract_day
+                          , subq_8.view__ds__extract_dow
+                          , subq_8.view__ds__extract_doy
+                          , subq_8.view__ds_partitioned__day
+                          , subq_8.view__ds_partitioned__week
+                          , subq_8.view__ds_partitioned__month
+                          , subq_8.view__ds_partitioned__quarter
+                          , subq_8.view__ds_partitioned__year
+                          , subq_8.view__ds_partitioned__extract_year
+                          , subq_8.view__ds_partitioned__extract_quarter
+                          , subq_8.view__ds_partitioned__extract_month
+                          , subq_8.view__ds_partitioned__extract_day
+                          , subq_8.view__ds_partitioned__extract_dow
+                          , subq_8.view__ds_partitioned__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.user
+                          , subq_8.view__listing
+                          , subq_8.view__user
+                          , subq_8.views
                         FROM (
                           -- Read Elements From Semantic Model 'views_source'
                           SELECT
@@ -525,25 +525,25 @@ FROM (
                             , views_source_src_28000.listing_id AS view__listing
                             , views_source_src_28000.user_id AS view__user
                           FROM ***************************.fct_views views_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
                       listing
-                  ) subq_22
-                ) subq_23
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
                   listing
-              ) subq_24
-            ) subq_25
-          ) subq_26
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__views_times_booking_value > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_45.listings AS listings
+    subq_36.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_50.listing, subq_55.listing) AS listing
-        , MAX(subq_50.booking_value) AS booking_value
-        , MAX(subq_55.views) AS views
+        COALESCE(subq_28.listing, subq_33.listing) AS listing
+        , MAX(subq_28.booking_value) AS booking_value
+        , MAX(subq_33.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing
-      ) subq_50
+      ) subq_28
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_53
+        ) subq_31
         GROUP BY
           listing
-      ) subq_55
+      ) subq_33
       ON
-        subq_50.listing = subq_55.listing
+        subq_28.listing = subq_33.listing
       GROUP BY
         listing
-    ) subq_56
-  ) subq_58
+    ) subq_34
+  ) subq_36
   ON
-    subq_45.listing = subq_58.listing
-) subq_60
+    subq_23.listing = subq_36.listing
+) subq_38
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -1,108 +1,108 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_19.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_18.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_17.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.listing__bookings
-        , subq_24.listing__bookers
-        , subq_24.listings
+        subq_16.listing__bookings
+        , subq_16.listing__bookers
+        , subq_16.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
         SELECT
-          subq_23.listing__bookings
-          , subq_23.listing__bookers
-          , subq_23.listings
+          subq_15.listing__bookings
+          , subq_15.listing__bookers
+          , subq_15.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_10.listing AS listing
-            , subq_16.listing__bookings AS listing__bookings
-            , subq_22.listing__bookers AS listing__bookers
-            , subq_10.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']
             SELECT
-              subq_9.listing
-              , subq_9.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_8.ds__day
-                , subq_8.ds__week
-                , subq_8.ds__month
-                , subq_8.ds__quarter
-                , subq_8.ds__year
-                , subq_8.ds__extract_year
-                , subq_8.ds__extract_quarter
-                , subq_8.ds__extract_month
-                , subq_8.ds__extract_day
-                , subq_8.ds__extract_dow
-                , subq_8.ds__extract_doy
-                , subq_8.created_at__day
-                , subq_8.created_at__week
-                , subq_8.created_at__month
-                , subq_8.created_at__quarter
-                , subq_8.created_at__year
-                , subq_8.created_at__extract_year
-                , subq_8.created_at__extract_quarter
-                , subq_8.created_at__extract_month
-                , subq_8.created_at__extract_day
-                , subq_8.created_at__extract_dow
-                , subq_8.created_at__extract_doy
-                , subq_8.listing__ds__day
-                , subq_8.listing__ds__week
-                , subq_8.listing__ds__month
-                , subq_8.listing__ds__quarter
-                , subq_8.listing__ds__year
-                , subq_8.listing__ds__extract_year
-                , subq_8.listing__ds__extract_quarter
-                , subq_8.listing__ds__extract_month
-                , subq_8.listing__ds__extract_day
-                , subq_8.listing__ds__extract_dow
-                , subq_8.listing__ds__extract_doy
-                , subq_8.listing__created_at__day
-                , subq_8.listing__created_at__week
-                , subq_8.listing__created_at__month
-                , subq_8.listing__created_at__quarter
-                , subq_8.listing__created_at__year
-                , subq_8.listing__created_at__extract_year
-                , subq_8.listing__created_at__extract_quarter
-                , subq_8.listing__created_at__extract_month
-                , subq_8.listing__created_at__extract_day
-                , subq_8.listing__created_at__extract_dow
-                , subq_8.listing__created_at__extract_doy
-                , subq_8.ds__day AS metric_time__day
-                , subq_8.ds__week AS metric_time__week
-                , subq_8.ds__month AS metric_time__month
-                , subq_8.ds__quarter AS metric_time__quarter
-                , subq_8.ds__year AS metric_time__year
-                , subq_8.ds__extract_year AS metric_time__extract_year
-                , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_8.ds__extract_month AS metric_time__extract_month
-                , subq_8.ds__extract_day AS metric_time__extract_day
-                , subq_8.ds__extract_dow AS metric_time__extract_dow
-                , subq_8.ds__extract_doy AS metric_time__extract_doy
-                , subq_8.listing
-                , subq_8.user
-                , subq_8.listing__user
-                , subq_8.country_latest
-                , subq_8.is_lux_latest
-                , subq_8.capacity_latest
-                , subq_8.listing__country_latest
-                , subq_8.listing__is_lux_latest
-                , subq_8.listing__capacity_latest
-                , subq_8.listings
-                , subq_8.largest_listing
-                , subq_8.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -163,130 +163,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_8
-            ) subq_9
-          ) subq_10
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_15.listing
-              , subq_15.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_14.listing
-                , subq_14.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_13.listing
-                  , SUM(subq_13.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_12.listing
-                    , subq_12.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_11.ds__day
-                      , subq_11.ds__week
-                      , subq_11.ds__month
-                      , subq_11.ds__quarter
-                      , subq_11.ds__year
-                      , subq_11.ds__extract_year
-                      , subq_11.ds__extract_quarter
-                      , subq_11.ds__extract_month
-                      , subq_11.ds__extract_day
-                      , subq_11.ds__extract_dow
-                      , subq_11.ds__extract_doy
-                      , subq_11.ds_partitioned__day
-                      , subq_11.ds_partitioned__week
-                      , subq_11.ds_partitioned__month
-                      , subq_11.ds_partitioned__quarter
-                      , subq_11.ds_partitioned__year
-                      , subq_11.ds_partitioned__extract_year
-                      , subq_11.ds_partitioned__extract_quarter
-                      , subq_11.ds_partitioned__extract_month
-                      , subq_11.ds_partitioned__extract_day
-                      , subq_11.ds_partitioned__extract_dow
-                      , subq_11.ds_partitioned__extract_doy
-                      , subq_11.paid_at__day
-                      , subq_11.paid_at__week
-                      , subq_11.paid_at__month
-                      , subq_11.paid_at__quarter
-                      , subq_11.paid_at__year
-                      , subq_11.paid_at__extract_year
-                      , subq_11.paid_at__extract_quarter
-                      , subq_11.paid_at__extract_month
-                      , subq_11.paid_at__extract_day
-                      , subq_11.paid_at__extract_dow
-                      , subq_11.paid_at__extract_doy
-                      , subq_11.booking__ds__day
-                      , subq_11.booking__ds__week
-                      , subq_11.booking__ds__month
-                      , subq_11.booking__ds__quarter
-                      , subq_11.booking__ds__year
-                      , subq_11.booking__ds__extract_year
-                      , subq_11.booking__ds__extract_quarter
-                      , subq_11.booking__ds__extract_month
-                      , subq_11.booking__ds__extract_day
-                      , subq_11.booking__ds__extract_dow
-                      , subq_11.booking__ds__extract_doy
-                      , subq_11.booking__ds_partitioned__day
-                      , subq_11.booking__ds_partitioned__week
-                      , subq_11.booking__ds_partitioned__month
-                      , subq_11.booking__ds_partitioned__quarter
-                      , subq_11.booking__ds_partitioned__year
-                      , subq_11.booking__ds_partitioned__extract_year
-                      , subq_11.booking__ds_partitioned__extract_quarter
-                      , subq_11.booking__ds_partitioned__extract_month
-                      , subq_11.booking__ds_partitioned__extract_day
-                      , subq_11.booking__ds_partitioned__extract_dow
-                      , subq_11.booking__ds_partitioned__extract_doy
-                      , subq_11.booking__paid_at__day
-                      , subq_11.booking__paid_at__week
-                      , subq_11.booking__paid_at__month
-                      , subq_11.booking__paid_at__quarter
-                      , subq_11.booking__paid_at__year
-                      , subq_11.booking__paid_at__extract_year
-                      , subq_11.booking__paid_at__extract_quarter
-                      , subq_11.booking__paid_at__extract_month
-                      , subq_11.booking__paid_at__extract_day
-                      , subq_11.booking__paid_at__extract_dow
-                      , subq_11.booking__paid_at__extract_doy
-                      , subq_11.ds__day AS metric_time__day
-                      , subq_11.ds__week AS metric_time__week
-                      , subq_11.ds__month AS metric_time__month
-                      , subq_11.ds__quarter AS metric_time__quarter
-                      , subq_11.ds__year AS metric_time__year
-                      , subq_11.ds__extract_year AS metric_time__extract_year
-                      , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_11.ds__extract_month AS metric_time__extract_month
-                      , subq_11.ds__extract_day AS metric_time__extract_day
-                      , subq_11.ds__extract_dow AS metric_time__extract_dow
-                      , subq_11.ds__extract_doy AS metric_time__extract_doy
-                      , subq_11.listing
-                      , subq_11.guest
-                      , subq_11.host
-                      , subq_11.booking__listing
-                      , subq_11.booking__guest
-                      , subq_11.booking__host
-                      , subq_11.is_instant
-                      , subq_11.booking__is_instant
-                      , subq_11.bookings
-                      , subq_11.instant_bookings
-                      , subq_11.booking_value
-                      , subq_11.max_booking_value
-                      , subq_11.min_booking_value
-                      , subq_11.bookers
-                      , subq_11.average_booking_value
-                      , subq_11.referred_bookings
-                      , subq_11.median_booking_value
-                      , subq_11.booking_value_p99
-                      , subq_11.discrete_booking_value_p99
-                      , subq_11.approximate_continuous_booking_value_p99
-                      , subq_11.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -379,137 +379,137 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_11
-                  ) subq_12
-                ) subq_13
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
                   listing
-              ) subq_14
-            ) subq_15
-          ) subq_16
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_10.listing = subq_16.listing
+            subq_2.listing = subq_8.listing
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_21.listing
-              , subq_21.listing__bookers
+              subq_13.listing
+              , subq_13.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing
-                , subq_20.bookers AS listing__bookers
+                subq_12.listing
+                , subq_12.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing
-                  , COUNT(DISTINCT subq_19.bookers) AS bookers
+                  subq_11.listing
+                  , COUNT(DISTINCT subq_11.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_18.listing
-                    , subq_18.bookers
+                    subq_10.listing
+                    , subq_10.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.ds_partitioned__day
-                      , subq_17.ds_partitioned__week
-                      , subq_17.ds_partitioned__month
-                      , subq_17.ds_partitioned__quarter
-                      , subq_17.ds_partitioned__year
-                      , subq_17.ds_partitioned__extract_year
-                      , subq_17.ds_partitioned__extract_quarter
-                      , subq_17.ds_partitioned__extract_month
-                      , subq_17.ds_partitioned__extract_day
-                      , subq_17.ds_partitioned__extract_dow
-                      , subq_17.ds_partitioned__extract_doy
-                      , subq_17.paid_at__day
-                      , subq_17.paid_at__week
-                      , subq_17.paid_at__month
-                      , subq_17.paid_at__quarter
-                      , subq_17.paid_at__year
-                      , subq_17.paid_at__extract_year
-                      , subq_17.paid_at__extract_quarter
-                      , subq_17.paid_at__extract_month
-                      , subq_17.paid_at__extract_day
-                      , subq_17.paid_at__extract_dow
-                      , subq_17.paid_at__extract_doy
-                      , subq_17.booking__ds__day
-                      , subq_17.booking__ds__week
-                      , subq_17.booking__ds__month
-                      , subq_17.booking__ds__quarter
-                      , subq_17.booking__ds__year
-                      , subq_17.booking__ds__extract_year
-                      , subq_17.booking__ds__extract_quarter
-                      , subq_17.booking__ds__extract_month
-                      , subq_17.booking__ds__extract_day
-                      , subq_17.booking__ds__extract_dow
-                      , subq_17.booking__ds__extract_doy
-                      , subq_17.booking__ds_partitioned__day
-                      , subq_17.booking__ds_partitioned__week
-                      , subq_17.booking__ds_partitioned__month
-                      , subq_17.booking__ds_partitioned__quarter
-                      , subq_17.booking__ds_partitioned__year
-                      , subq_17.booking__ds_partitioned__extract_year
-                      , subq_17.booking__ds_partitioned__extract_quarter
-                      , subq_17.booking__ds_partitioned__extract_month
-                      , subq_17.booking__ds_partitioned__extract_day
-                      , subq_17.booking__ds_partitioned__extract_dow
-                      , subq_17.booking__ds_partitioned__extract_doy
-                      , subq_17.booking__paid_at__day
-                      , subq_17.booking__paid_at__week
-                      , subq_17.booking__paid_at__month
-                      , subq_17.booking__paid_at__quarter
-                      , subq_17.booking__paid_at__year
-                      , subq_17.booking__paid_at__extract_year
-                      , subq_17.booking__paid_at__extract_quarter
-                      , subq_17.booking__paid_at__extract_month
-                      , subq_17.booking__paid_at__extract_day
-                      , subq_17.booking__paid_at__extract_dow
-                      , subq_17.booking__paid_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.guest
-                      , subq_17.host
-                      , subq_17.booking__listing
-                      , subq_17.booking__guest
-                      , subq_17.booking__host
-                      , subq_17.is_instant
-                      , subq_17.booking__is_instant
-                      , subq_17.bookings
-                      , subq_17.instant_bookings
-                      , subq_17.booking_value
-                      , subq_17.max_booking_value
-                      , subq_17.min_booking_value
-                      , subq_17.bookers
-                      , subq_17.average_booking_value
-                      , subq_17.referred_bookings
-                      , subq_17.median_booking_value
-                      , subq_17.booking_value_p99
-                      , subq_17.discrete_booking_value_p99
-                      , subq_17.approximate_continuous_booking_value_p99
-                      , subq_17.approximate_discrete_booking_value_p99
+                      subq_9.ds__day
+                      , subq_9.ds__week
+                      , subq_9.ds__month
+                      , subq_9.ds__quarter
+                      , subq_9.ds__year
+                      , subq_9.ds__extract_year
+                      , subq_9.ds__extract_quarter
+                      , subq_9.ds__extract_month
+                      , subq_9.ds__extract_day
+                      , subq_9.ds__extract_dow
+                      , subq_9.ds__extract_doy
+                      , subq_9.ds_partitioned__day
+                      , subq_9.ds_partitioned__week
+                      , subq_9.ds_partitioned__month
+                      , subq_9.ds_partitioned__quarter
+                      , subq_9.ds_partitioned__year
+                      , subq_9.ds_partitioned__extract_year
+                      , subq_9.ds_partitioned__extract_quarter
+                      , subq_9.ds_partitioned__extract_month
+                      , subq_9.ds_partitioned__extract_day
+                      , subq_9.ds_partitioned__extract_dow
+                      , subq_9.ds_partitioned__extract_doy
+                      , subq_9.paid_at__day
+                      , subq_9.paid_at__week
+                      , subq_9.paid_at__month
+                      , subq_9.paid_at__quarter
+                      , subq_9.paid_at__year
+                      , subq_9.paid_at__extract_year
+                      , subq_9.paid_at__extract_quarter
+                      , subq_9.paid_at__extract_month
+                      , subq_9.paid_at__extract_day
+                      , subq_9.paid_at__extract_dow
+                      , subq_9.paid_at__extract_doy
+                      , subq_9.booking__ds__day
+                      , subq_9.booking__ds__week
+                      , subq_9.booking__ds__month
+                      , subq_9.booking__ds__quarter
+                      , subq_9.booking__ds__year
+                      , subq_9.booking__ds__extract_year
+                      , subq_9.booking__ds__extract_quarter
+                      , subq_9.booking__ds__extract_month
+                      , subq_9.booking__ds__extract_day
+                      , subq_9.booking__ds__extract_dow
+                      , subq_9.booking__ds__extract_doy
+                      , subq_9.booking__ds_partitioned__day
+                      , subq_9.booking__ds_partitioned__week
+                      , subq_9.booking__ds_partitioned__month
+                      , subq_9.booking__ds_partitioned__quarter
+                      , subq_9.booking__ds_partitioned__year
+                      , subq_9.booking__ds_partitioned__extract_year
+                      , subq_9.booking__ds_partitioned__extract_quarter
+                      , subq_9.booking__ds_partitioned__extract_month
+                      , subq_9.booking__ds_partitioned__extract_day
+                      , subq_9.booking__ds_partitioned__extract_dow
+                      , subq_9.booking__ds_partitioned__extract_doy
+                      , subq_9.booking__paid_at__day
+                      , subq_9.booking__paid_at__week
+                      , subq_9.booking__paid_at__month
+                      , subq_9.booking__paid_at__quarter
+                      , subq_9.booking__paid_at__year
+                      , subq_9.booking__paid_at__extract_year
+                      , subq_9.booking__paid_at__extract_quarter
+                      , subq_9.booking__paid_at__extract_month
+                      , subq_9.booking__paid_at__extract_day
+                      , subq_9.booking__paid_at__extract_dow
+                      , subq_9.booking__paid_at__extract_doy
+                      , subq_9.ds__day AS metric_time__day
+                      , subq_9.ds__week AS metric_time__week
+                      , subq_9.ds__month AS metric_time__month
+                      , subq_9.ds__quarter AS metric_time__quarter
+                      , subq_9.ds__year AS metric_time__year
+                      , subq_9.ds__extract_year AS metric_time__extract_year
+                      , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_9.ds__extract_month AS metric_time__extract_month
+                      , subq_9.ds__extract_day AS metric_time__extract_day
+                      , subq_9.ds__extract_dow AS metric_time__extract_dow
+                      , subq_9.ds__extract_doy AS metric_time__extract_doy
+                      , subq_9.listing
+                      , subq_9.guest
+                      , subq_9.host
+                      , subq_9.booking__listing
+                      , subq_9.booking__guest
+                      , subq_9.booking__host
+                      , subq_9.is_instant
+                      , subq_9.booking__is_instant
+                      , subq_9.bookings
+                      , subq_9.instant_bookings
+                      , subq_9.booking_value
+                      , subq_9.max_booking_value
+                      , subq_9.min_booking_value
+                      , subq_9.bookers
+                      , subq_9.average_booking_value
+                      , subq_9.referred_bookings
+                      , subq_9.median_booking_value
+                      , subq_9.booking_value_p99
+                      , subq_9.discrete_booking_value_p99
+                      , subq_9.approximate_continuous_booking_value_p99
+                      , subq_9.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -602,19 +602,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_9
+                  ) subq_10
+                ) subq_11
                 GROUP BY
                   listing
-              ) subq_20
-            ) subq_21
-          ) subq_22
+              ) subq_12
+            ) subq_13
+          ) subq_14
           ON
-            subq_10.listing = subq_22.listing
-        ) subq_23
-      ) subq_24
+            subq_2.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       WHERE listing__bookings > 2 AND listing__bookers > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_17
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_44.listing__bookings AS listing__bookings
-    , subq_50.listing__bookers AS listing__bookers
-    , subq_38.listings AS listings
+    subq_28.listing__bookings AS listing__bookings
+    , subq_34.listing__bookers AS listing__bookers
+    , subq_22.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_38
+  ) subq_22
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_41
+    ) subq_25
     GROUP BY
       listing
-  ) subq_44
+  ) subq_28
   ON
-    subq_38.listing = subq_44.listing
+    subq_22.listing = subq_28.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing
-  ) subq_50
+  ) subq_34
   ON
-    subq_38.listing = subq_50.listing
-) subq_52
+    subq_22.listing = subq_34.listing
+) subq_36
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__bookings_per_booker
-        , subq_28.listings
+        subq_17.listing__bookings_per_booker
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
         SELECT
-          subq_27.listing__bookings_per_booker
-          , subq_27.listings
+          subq_16.listing__bookings_per_booker
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__bookings_per_booker AS listing__bookings_per_booker
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings_per_booker']
             SELECT
-              subq_25.listing
-              , subq_25.listing__bookings_per_booker
+              subq_14.listing
+              , subq_14.listing__bookings_per_booker
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
-                , CAST(subq_24.bookings AS FLOAT64) / CAST(NULLIF(subq_24.bookers, 0) AS FLOAT64) AS listing__bookings_per_booker
+                subq_13.listing
+                , CAST(subq_13.bookings AS FLOAT64) / CAST(NULLIF(subq_13.bookers, 0) AS FLOAT64) AS listing__bookings_per_booker
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.bookings) AS bookings
-                  , MAX(subq_23.bookers) AS bookers
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.bookings) AS bookings
+                  , MAX(subq_12.bookers) AS bookers
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.bookings
+                    subq_6.listing
+                    , subq_6.bookings
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.bookings) AS bookings
+                      subq_5.listing
+                      , SUM(subq_5.bookings) AS bookings
                     FROM (
                       -- Pass Only Elements: ['bookings', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.bookings
+                        subq_4.listing
+                        , subq_4.bookings
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,129 +387,129 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
                       listing
-                  ) subq_17
-                ) subq_18
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.bookers
+                    subq_11.listing
+                    , subq_11.bookers
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , COUNT(DISTINCT subq_21.bookers) AS bookers
+                      subq_10.listing
+                      , COUNT(DISTINCT subq_10.bookers) AS bookers
                     FROM (
                       -- Pass Only Elements: ['bookers', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.bookers
+                        subq_9.listing
+                        , subq_9.bookers
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.paid_at__day
-                          , subq_19.paid_at__week
-                          , subq_19.paid_at__month
-                          , subq_19.paid_at__quarter
-                          , subq_19.paid_at__year
-                          , subq_19.paid_at__extract_year
-                          , subq_19.paid_at__extract_quarter
-                          , subq_19.paid_at__extract_month
-                          , subq_19.paid_at__extract_day
-                          , subq_19.paid_at__extract_dow
-                          , subq_19.paid_at__extract_doy
-                          , subq_19.booking__ds__day
-                          , subq_19.booking__ds__week
-                          , subq_19.booking__ds__month
-                          , subq_19.booking__ds__quarter
-                          , subq_19.booking__ds__year
-                          , subq_19.booking__ds__extract_year
-                          , subq_19.booking__ds__extract_quarter
-                          , subq_19.booking__ds__extract_month
-                          , subq_19.booking__ds__extract_day
-                          , subq_19.booking__ds__extract_dow
-                          , subq_19.booking__ds__extract_doy
-                          , subq_19.booking__ds_partitioned__day
-                          , subq_19.booking__ds_partitioned__week
-                          , subq_19.booking__ds_partitioned__month
-                          , subq_19.booking__ds_partitioned__quarter
-                          , subq_19.booking__ds_partitioned__year
-                          , subq_19.booking__ds_partitioned__extract_year
-                          , subq_19.booking__ds_partitioned__extract_quarter
-                          , subq_19.booking__ds_partitioned__extract_month
-                          , subq_19.booking__ds_partitioned__extract_day
-                          , subq_19.booking__ds_partitioned__extract_dow
-                          , subq_19.booking__ds_partitioned__extract_doy
-                          , subq_19.booking__paid_at__day
-                          , subq_19.booking__paid_at__week
-                          , subq_19.booking__paid_at__month
-                          , subq_19.booking__paid_at__quarter
-                          , subq_19.booking__paid_at__year
-                          , subq_19.booking__paid_at__extract_year
-                          , subq_19.booking__paid_at__extract_quarter
-                          , subq_19.booking__paid_at__extract_month
-                          , subq_19.booking__paid_at__extract_day
-                          , subq_19.booking__paid_at__extract_dow
-                          , subq_19.booking__paid_at__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.guest
-                          , subq_19.host
-                          , subq_19.booking__listing
-                          , subq_19.booking__guest
-                          , subq_19.booking__host
-                          , subq_19.is_instant
-                          , subq_19.booking__is_instant
-                          , subq_19.bookings
-                          , subq_19.instant_bookings
-                          , subq_19.booking_value
-                          , subq_19.max_booking_value
-                          , subq_19.min_booking_value
-                          , subq_19.bookers
-                          , subq_19.average_booking_value
-                          , subq_19.referred_bookings
-                          , subq_19.median_booking_value
-                          , subq_19.booking_value_p99
-                          , subq_19.discrete_booking_value_p99
-                          , subq_19.approximate_continuous_booking_value_p99
-                          , subq_19.approximate_discrete_booking_value_p99
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.paid_at__day
+                          , subq_8.paid_at__week
+                          , subq_8.paid_at__month
+                          , subq_8.paid_at__quarter
+                          , subq_8.paid_at__year
+                          , subq_8.paid_at__extract_year
+                          , subq_8.paid_at__extract_quarter
+                          , subq_8.paid_at__extract_month
+                          , subq_8.paid_at__extract_day
+                          , subq_8.paid_at__extract_dow
+                          , subq_8.paid_at__extract_doy
+                          , subq_8.booking__ds__day
+                          , subq_8.booking__ds__week
+                          , subq_8.booking__ds__month
+                          , subq_8.booking__ds__quarter
+                          , subq_8.booking__ds__year
+                          , subq_8.booking__ds__extract_year
+                          , subq_8.booking__ds__extract_quarter
+                          , subq_8.booking__ds__extract_month
+                          , subq_8.booking__ds__extract_day
+                          , subq_8.booking__ds__extract_dow
+                          , subq_8.booking__ds__extract_doy
+                          , subq_8.booking__ds_partitioned__day
+                          , subq_8.booking__ds_partitioned__week
+                          , subq_8.booking__ds_partitioned__month
+                          , subq_8.booking__ds_partitioned__quarter
+                          , subq_8.booking__ds_partitioned__year
+                          , subq_8.booking__ds_partitioned__extract_year
+                          , subq_8.booking__ds_partitioned__extract_quarter
+                          , subq_8.booking__ds_partitioned__extract_month
+                          , subq_8.booking__ds_partitioned__extract_day
+                          , subq_8.booking__ds_partitioned__extract_dow
+                          , subq_8.booking__ds_partitioned__extract_doy
+                          , subq_8.booking__paid_at__day
+                          , subq_8.booking__paid_at__week
+                          , subq_8.booking__paid_at__month
+                          , subq_8.booking__paid_at__quarter
+                          , subq_8.booking__paid_at__year
+                          , subq_8.booking__paid_at__extract_year
+                          , subq_8.booking__paid_at__extract_quarter
+                          , subq_8.booking__paid_at__extract_month
+                          , subq_8.booking__paid_at__extract_day
+                          , subq_8.booking__paid_at__extract_dow
+                          , subq_8.booking__paid_at__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.guest
+                          , subq_8.host
+                          , subq_8.booking__listing
+                          , subq_8.booking__guest
+                          , subq_8.booking__host
+                          , subq_8.is_instant
+                          , subq_8.booking__is_instant
+                          , subq_8.bookings
+                          , subq_8.instant_bookings
+                          , subq_8.booking_value
+                          , subq_8.max_booking_value
+                          , subq_8.min_booking_value
+                          , subq_8.bookers
+                          , subq_8.average_booking_value
+                          , subq_8.referred_bookings
+                          , subq_8.median_booking_value
+                          , subq_8.booking_value_p99
+                          , subq_8.discrete_booking_value_p99
+                          , subq_8.approximate_continuous_booking_value_p99
+                          , subq_8.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -602,25 +602,25 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
                       listing
-                  ) subq_22
-                ) subq_23
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
                   listing
-              ) subq_24
-            ) subq_25
-          ) subq_26
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__bookings_per_booker > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_56.bookings AS FLOAT64) / CAST(NULLIF(subq_56.bookers, 0) AS FLOAT64) AS listing__bookings_per_booker
-    , subq_45.listings AS listings
+    CAST(subq_34.bookings AS FLOAT64) / CAST(NULLIF(subq_34.bookers, 0) AS FLOAT64) AS listing__bookings_per_booker
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_50.listing, subq_55.listing) AS listing
-      , MAX(subq_50.bookings) AS bookings
-      , MAX(subq_55.bookers) AS bookers
+      COALESCE(subq_28.listing, subq_33.listing) AS listing
+      , MAX(subq_28.bookings) AS bookings
+      , MAX(subq_33.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_48
+      ) subq_26
       GROUP BY
         listing
-    ) subq_50
+    ) subq_28
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing
-    ) subq_55
+    ) subq_33
     ON
-      subq_50.listing = subq_55.listing
+      subq_28.listing = subq_33.listing
     GROUP BY
       listing
-  ) subq_56
+  ) subq_34
   ON
-    subq_45.listing = subq_56.listing
-) subq_60
+    subq_23.listing = subq_34.listing
+) subq_38
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings']
         SELECT
-          subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,130 +160,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -376,19 +376,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
                   listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -1,20 +1,20 @@
 -- Pass Only Elements: ['listing',]
 SELECT
-  subq_12.listing
+  subq_8.listing
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_11.listing
-    , subq_11.lux_listing
-    , subq_11.listing__lux_listing
-    , subq_11.listing__bookings
+    subq_7.listing
+    , subq_7.lux_listing
+    , subq_7.listing__lux_listing
+    , subq_7.listing__bookings
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_4.listing AS listing
-      , subq_4.lux_listing AS lux_listing
-      , subq_4.listing__lux_listing AS listing__lux_listing
-      , subq_10.listing__bookings AS listing__bookings
+      subq_0.listing AS listing
+      , subq_0.lux_listing AS lux_listing
+      , subq_0.listing__lux_listing AS listing__lux_listing
+      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT
@@ -22,128 +22,128 @@ FROM (
         , lux_listing_mapping_src_28000.lux_listing_id AS lux_listing
         , lux_listing_mapping_src_28000.lux_listing_id AS listing__lux_listing
       FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
-    ) subq_4
+    ) subq_0
     FULL OUTER JOIN (
       -- Pass Only Elements: ['listing', 'listing__bookings']
       SELECT
-        subq_9.listing
-        , subq_9.listing__bookings
+        subq_5.listing
+        , subq_5.listing__bookings
       FROM (
         -- Compute Metrics via Expressions
         SELECT
-          subq_8.listing
-          , subq_8.bookings AS listing__bookings
+          subq_4.listing
+          , subq_4.bookings AS listing__bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_7.listing
-            , SUM(subq_7.bookings) AS bookings
+            subq_3.listing
+            , SUM(subq_3.bookings) AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'listing']
             SELECT
-              subq_6.listing
-              , subq_6.bookings
+              subq_2.listing
+              , subq_2.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds__day
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.ds__extract_year
-                , subq_5.ds__extract_quarter
-                , subq_5.ds__extract_month
-                , subq_5.ds__extract_day
-                , subq_5.ds__extract_dow
-                , subq_5.ds__extract_doy
-                , subq_5.ds_partitioned__day
-                , subq_5.ds_partitioned__week
-                , subq_5.ds_partitioned__month
-                , subq_5.ds_partitioned__quarter
-                , subq_5.ds_partitioned__year
-                , subq_5.ds_partitioned__extract_year
-                , subq_5.ds_partitioned__extract_quarter
-                , subq_5.ds_partitioned__extract_month
-                , subq_5.ds_partitioned__extract_day
-                , subq_5.ds_partitioned__extract_dow
-                , subq_5.ds_partitioned__extract_doy
-                , subq_5.paid_at__day
-                , subq_5.paid_at__week
-                , subq_5.paid_at__month
-                , subq_5.paid_at__quarter
-                , subq_5.paid_at__year
-                , subq_5.paid_at__extract_year
-                , subq_5.paid_at__extract_quarter
-                , subq_5.paid_at__extract_month
-                , subq_5.paid_at__extract_day
-                , subq_5.paid_at__extract_dow
-                , subq_5.paid_at__extract_doy
-                , subq_5.booking__ds__day
-                , subq_5.booking__ds__week
-                , subq_5.booking__ds__month
-                , subq_5.booking__ds__quarter
-                , subq_5.booking__ds__year
-                , subq_5.booking__ds__extract_year
-                , subq_5.booking__ds__extract_quarter
-                , subq_5.booking__ds__extract_month
-                , subq_5.booking__ds__extract_day
-                , subq_5.booking__ds__extract_dow
-                , subq_5.booking__ds__extract_doy
-                , subq_5.booking__ds_partitioned__day
-                , subq_5.booking__ds_partitioned__week
-                , subq_5.booking__ds_partitioned__month
-                , subq_5.booking__ds_partitioned__quarter
-                , subq_5.booking__ds_partitioned__year
-                , subq_5.booking__ds_partitioned__extract_year
-                , subq_5.booking__ds_partitioned__extract_quarter
-                , subq_5.booking__ds_partitioned__extract_month
-                , subq_5.booking__ds_partitioned__extract_day
-                , subq_5.booking__ds_partitioned__extract_dow
-                , subq_5.booking__ds_partitioned__extract_doy
-                , subq_5.booking__paid_at__day
-                , subq_5.booking__paid_at__week
-                , subq_5.booking__paid_at__month
-                , subq_5.booking__paid_at__quarter
-                , subq_5.booking__paid_at__year
-                , subq_5.booking__paid_at__extract_year
-                , subq_5.booking__paid_at__extract_quarter
-                , subq_5.booking__paid_at__extract_month
-                , subq_5.booking__paid_at__extract_day
-                , subq_5.booking__paid_at__extract_dow
-                , subq_5.booking__paid_at__extract_doy
-                , subq_5.ds__day AS metric_time__day
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.ds__extract_year AS metric_time__extract_year
-                , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_5.ds__extract_month AS metric_time__extract_month
-                , subq_5.ds__extract_day AS metric_time__extract_day
-                , subq_5.ds__extract_dow AS metric_time__extract_dow
-                , subq_5.ds__extract_doy AS metric_time__extract_doy
-                , subq_5.listing
-                , subq_5.guest
-                , subq_5.host
-                , subq_5.booking__listing
-                , subq_5.booking__guest
-                , subq_5.booking__host
-                , subq_5.is_instant
-                , subq_5.booking__is_instant
-                , subq_5.bookings
-                , subq_5.instant_bookings
-                , subq_5.booking_value
-                , subq_5.max_booking_value
-                , subq_5.min_booking_value
-                , subq_5.bookers
-                , subq_5.average_booking_value
-                , subq_5.referred_bookings
-                , subq_5.median_booking_value
-                , subq_5.booking_value_p99
-                , subq_5.discrete_booking_value_p99
-                , subq_5.approximate_continuous_booking_value_p99
-                , subq_5.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.ds__day AS metric_time__day
+                , subq_1.ds__week AS metric_time__week
+                , subq_1.ds__month AS metric_time__month
+                , subq_1.ds__quarter AS metric_time__quarter
+                , subq_1.ds__year AS metric_time__year
+                , subq_1.ds__extract_year AS metric_time__extract_year
+                , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_1.ds__extract_month AS metric_time__extract_month
+                , subq_1.ds__extract_day AS metric_time__extract_day
+                , subq_1.ds__extract_dow AS metric_time__extract_dow
+                , subq_1.ds__extract_doy AS metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -236,18 +236,18 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_5
-            ) subq_6
-          ) subq_7
+              ) subq_1
+            ) subq_2
+          ) subq_3
           GROUP BY
-            subq_7.listing
-        ) subq_8
-      ) subq_9
-    ) subq_10
+            subq_3.listing
+        ) subq_4
+      ) subq_5
+    ) subq_6
     ON
-      subq_4.listing = subq_10.listing
-  ) subq_11
+      subq_0.listing = subq_6.listing
+  ) subq_7
   WHERE listing__bookings > 2
-) subq_12
+) subq_8
 GROUP BY
-  subq_12.listing
+  subq_8.listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_23.listing__bookings AS listing__bookings
+    , subq_15.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+    ) subq_12
     GROUP BY
       listing
-  ) subq_23
+  ) subq_15
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_23.listing
-) subq_24
+    lux_listing_mapping_src_28000.listing_id = subq_15.listing
+) subq_16
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.guest__booking_value
-        , subq_14.bookers
+        subq_10.guest__booking_value
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'guest__booking_value']
         SELECT
-          subq_13.guest__booking_value
-          , subq_13.bookers
+          subq_9.guest__booking_value
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.guest AS guest
-            , subq_12.guest__booking_value AS guest__booking_value
-            , subq_6.bookers AS bookers
+            subq_2.guest AS guest
+            , subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']
             SELECT
-              subq_5.guest
-              , subq_5.bookers
+              subq_1.guest
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['guest', 'guest__booking_value']
             SELECT
-              subq_11.guest
-              , subq_11.guest__booking_value
+              subq_7.guest
+              , subq_7.guest__booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.guest
-                , subq_10.booking_value AS guest__booking_value
+                subq_6.guest
+                , subq_6.booking_value AS guest__booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.guest
-                  , SUM(subq_9.booking_value) AS booking_value
+                  subq_5.guest
+                  , SUM(subq_5.booking_value) AS booking_value
                 FROM (
                   -- Pass Only Elements: ['booking_value', 'guest']
                   SELECT
-                    subq_8.guest
-                    , subq_8.booking_value
+                    subq_4.guest
+                    , subq_4.booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.guest
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.guest
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.guest = subq_12.guest
-        ) subq_13
-      ) subq_14
+            subq_2.guest = subq_8.guest
+        ) subq_9
+      ) subq_10
       WHERE guest__booking_value > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_30.guest__booking_value AS guest__booking_value
-    , subq_24.bookers AS bookers
+    subq_22.guest__booking_value AS guest__booking_value
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.guest = subq_30.guest
-) subq_32
+    subq_16.guest = subq_22.guest
+) subq_24
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_39.listings
+  subq_24.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_38.listings) AS listings
+    SUM(subq_23.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_37.listings
+      subq_22.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_36.user__visit_buy_conversion_rate
-        , subq_36.listings
+        subq_21.user__visit_buy_conversion_rate
+        , subq_21.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
         SELECT
-          subq_35.user__visit_buy_conversion_rate
-          , subq_35.listings
+          subq_20.user__visit_buy_conversion_rate
+          , subq_20.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_17.user AS user
-            , subq_34.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
-            , subq_17.listings AS listings
+            subq_2.user AS user
+            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_16.user
-              , subq_16.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_15.ds__day
-                , subq_15.ds__week
-                , subq_15.ds__month
-                , subq_15.ds__quarter
-                , subq_15.ds__year
-                , subq_15.ds__extract_year
-                , subq_15.ds__extract_quarter
-                , subq_15.ds__extract_month
-                , subq_15.ds__extract_day
-                , subq_15.ds__extract_dow
-                , subq_15.ds__extract_doy
-                , subq_15.created_at__day
-                , subq_15.created_at__week
-                , subq_15.created_at__month
-                , subq_15.created_at__quarter
-                , subq_15.created_at__year
-                , subq_15.created_at__extract_year
-                , subq_15.created_at__extract_quarter
-                , subq_15.created_at__extract_month
-                , subq_15.created_at__extract_day
-                , subq_15.created_at__extract_dow
-                , subq_15.created_at__extract_doy
-                , subq_15.listing__ds__day
-                , subq_15.listing__ds__week
-                , subq_15.listing__ds__month
-                , subq_15.listing__ds__quarter
-                , subq_15.listing__ds__year
-                , subq_15.listing__ds__extract_year
-                , subq_15.listing__ds__extract_quarter
-                , subq_15.listing__ds__extract_month
-                , subq_15.listing__ds__extract_day
-                , subq_15.listing__ds__extract_dow
-                , subq_15.listing__ds__extract_doy
-                , subq_15.listing__created_at__day
-                , subq_15.listing__created_at__week
-                , subq_15.listing__created_at__month
-                , subq_15.listing__created_at__quarter
-                , subq_15.listing__created_at__year
-                , subq_15.listing__created_at__extract_year
-                , subq_15.listing__created_at__extract_quarter
-                , subq_15.listing__created_at__extract_month
-                , subq_15.listing__created_at__extract_day
-                , subq_15.listing__created_at__extract_dow
-                , subq_15.listing__created_at__extract_doy
-                , subq_15.ds__day AS metric_time__day
-                , subq_15.ds__week AS metric_time__week
-                , subq_15.ds__month AS metric_time__month
-                , subq_15.ds__quarter AS metric_time__quarter
-                , subq_15.ds__year AS metric_time__year
-                , subq_15.ds__extract_year AS metric_time__extract_year
-                , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_15.ds__extract_month AS metric_time__extract_month
-                , subq_15.ds__extract_day AS metric_time__extract_day
-                , subq_15.ds__extract_dow AS metric_time__extract_dow
-                , subq_15.ds__extract_doy AS metric_time__extract_doy
-                , subq_15.listing
-                , subq_15.user
-                , subq_15.listing__user
-                , subq_15.country_latest
-                , subq_15.is_lux_latest
-                , subq_15.capacity_latest
-                , subq_15.listing__country_latest
-                , subq_15.listing__is_lux_latest
-                , subq_15.listing__capacity_latest
-                , subq_15.listings
-                , subq_15.largest_listing
-                , subq_15.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,79 +160,79 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_15
-            ) subq_16
-          ) subq_17
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__visit_buy_conversion_rate']
             SELECT
-              subq_33.user
-              , subq_33.user__visit_buy_conversion_rate
+              subq_18.user
+              , subq_18.user__visit_buy_conversion_rate
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_32.user
-                , CAST(subq_32.buys AS DOUBLE) / CAST(NULLIF(subq_32.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+                subq_17.user
+                , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_21.user, subq_31.user) AS user
-                  , MAX(subq_21.visits) AS visits
-                  , MAX(subq_31.buys) AS buys
+                  COALESCE(subq_6.user, subq_16.user) AS user
+                  , MAX(subq_6.visits) AS visits
+                  , MAX(subq_16.buys) AS buys
                 FROM (
                   -- Aggregate Measures
                   SELECT
-                    subq_20.user
-                    , SUM(subq_20.visits) AS visits
+                    subq_5.user
+                    , SUM(subq_5.visits) AS visits
                   FROM (
                     -- Pass Only Elements: ['visits', 'user']
                     SELECT
-                      subq_19.user
-                      , subq_19.visits
+                      subq_4.user
+                      , subq_4.visits
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_18.ds__day
-                        , subq_18.ds__week
-                        , subq_18.ds__month
-                        , subq_18.ds__quarter
-                        , subq_18.ds__year
-                        , subq_18.ds__extract_year
-                        , subq_18.ds__extract_quarter
-                        , subq_18.ds__extract_month
-                        , subq_18.ds__extract_day
-                        , subq_18.ds__extract_dow
-                        , subq_18.ds__extract_doy
-                        , subq_18.visit__ds__day
-                        , subq_18.visit__ds__week
-                        , subq_18.visit__ds__month
-                        , subq_18.visit__ds__quarter
-                        , subq_18.visit__ds__year
-                        , subq_18.visit__ds__extract_year
-                        , subq_18.visit__ds__extract_quarter
-                        , subq_18.visit__ds__extract_month
-                        , subq_18.visit__ds__extract_day
-                        , subq_18.visit__ds__extract_dow
-                        , subq_18.visit__ds__extract_doy
-                        , subq_18.ds__day AS metric_time__day
-                        , subq_18.ds__week AS metric_time__week
-                        , subq_18.ds__month AS metric_time__month
-                        , subq_18.ds__quarter AS metric_time__quarter
-                        , subq_18.ds__year AS metric_time__year
-                        , subq_18.ds__extract_year AS metric_time__extract_year
-                        , subq_18.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_18.ds__extract_month AS metric_time__extract_month
-                        , subq_18.ds__extract_day AS metric_time__extract_day
-                        , subq_18.ds__extract_dow AS metric_time__extract_dow
-                        , subq_18.ds__extract_doy AS metric_time__extract_doy
-                        , subq_18.user
-                        , subq_18.session
-                        , subq_18.visit__user
-                        , subq_18.visit__session
-                        , subq_18.referrer_id
-                        , subq_18.visit__referrer_id
-                        , subq_18.visits
-                        , subq_18.visitors
+                        subq_3.ds__day
+                        , subq_3.ds__week
+                        , subq_3.ds__month
+                        , subq_3.ds__quarter
+                        , subq_3.ds__year
+                        , subq_3.ds__extract_year
+                        , subq_3.ds__extract_quarter
+                        , subq_3.ds__extract_month
+                        , subq_3.ds__extract_day
+                        , subq_3.ds__extract_dow
+                        , subq_3.ds__extract_doy
+                        , subq_3.visit__ds__day
+                        , subq_3.visit__ds__week
+                        , subq_3.visit__ds__month
+                        , subq_3.visit__ds__quarter
+                        , subq_3.visit__ds__year
+                        , subq_3.visit__ds__extract_year
+                        , subq_3.visit__ds__extract_quarter
+                        , subq_3.visit__ds__extract_month
+                        , subq_3.visit__ds__extract_day
+                        , subq_3.visit__ds__extract_dow
+                        , subq_3.visit__ds__extract_doy
+                        , subq_3.ds__day AS metric_time__day
+                        , subq_3.ds__week AS metric_time__week
+                        , subq_3.ds__month AS metric_time__month
+                        , subq_3.ds__quarter AS metric_time__quarter
+                        , subq_3.ds__year AS metric_time__year
+                        , subq_3.ds__extract_year AS metric_time__extract_year
+                        , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_3.ds__extract_month AS metric_time__extract_month
+                        , subq_3.ds__extract_day AS metric_time__extract_day
+                        , subq_3.ds__extract_dow AS metric_time__extract_dow
+                        , subq_3.ds__extract_doy AS metric_time__extract_doy
+                        , subq_3.user
+                        , subq_3.session
+                        , subq_3.visit__user
+                        , subq_3.visit__session
+                        , subq_3.referrer_id
+                        , subq_3.visit__referrer_id
+                        , subq_3.visits
+                        , subq_3.visitors
                       FROM (
                         -- Read Elements From Semantic Model 'visits_source'
                         SELECT
@@ -267,108 +267,108 @@ FROM (
                           , visits_source_src_28000.user_id AS visit__user
                           , visits_source_src_28000.session_id AS visit__session
                         FROM ***************************.fct_visits visits_source_src_28000
-                      ) subq_18
-                    ) subq_19
-                  ) subq_20
+                      ) subq_3
+                    ) subq_4
+                  ) subq_5
                   GROUP BY
-                    subq_20.user
-                ) subq_21
+                    subq_5.user
+                ) subq_6
                 FULL OUTER JOIN (
                   -- Aggregate Measures
                   SELECT
-                    subq_30.user
-                    , SUM(subq_30.buys) AS buys
+                    subq_15.user
+                    , SUM(subq_15.buys) AS buys
                   FROM (
                     -- Pass Only Elements: ['buys', 'user']
                     SELECT
-                      subq_29.user
-                      , subq_29.buys
+                      subq_14.user
+                      , subq_14.buys
                     FROM (
                       -- Find conversions for user within the range of INF
                       SELECT
-                        subq_28.ds__day
-                        , subq_28.user
-                        , subq_28.buys
-                        , subq_28.visits
+                        subq_13.ds__day
+                        , subq_13.user
+                        , subq_13.buys
+                        , subq_13.visits
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          FIRST_VALUE(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_9.visits) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , FIRST_VALUE(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_9.ds__day) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , FIRST_VALUE(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_9.user) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS user
-                          , subq_27.mf_internal_uuid AS mf_internal_uuid
-                          , subq_27.buys AS buys
+                          , subq_12.mf_internal_uuid AS mf_internal_uuid
+                          , subq_12.buys AS buys
                         FROM (
                           -- Pass Only Elements: ['visits', 'ds__day', 'user']
                           SELECT
-                            subq_23.ds__day
-                            , subq_23.user
-                            , subq_23.visits
+                            subq_8.ds__day
+                            , subq_8.user
+                            , subq_8.visits
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_22.ds__day
-                              , subq_22.ds__week
-                              , subq_22.ds__month
-                              , subq_22.ds__quarter
-                              , subq_22.ds__year
-                              , subq_22.ds__extract_year
-                              , subq_22.ds__extract_quarter
-                              , subq_22.ds__extract_month
-                              , subq_22.ds__extract_day
-                              , subq_22.ds__extract_dow
-                              , subq_22.ds__extract_doy
-                              , subq_22.visit__ds__day
-                              , subq_22.visit__ds__week
-                              , subq_22.visit__ds__month
-                              , subq_22.visit__ds__quarter
-                              , subq_22.visit__ds__year
-                              , subq_22.visit__ds__extract_year
-                              , subq_22.visit__ds__extract_quarter
-                              , subq_22.visit__ds__extract_month
-                              , subq_22.visit__ds__extract_day
-                              , subq_22.visit__ds__extract_dow
-                              , subq_22.visit__ds__extract_doy
-                              , subq_22.ds__day AS metric_time__day
-                              , subq_22.ds__week AS metric_time__week
-                              , subq_22.ds__month AS metric_time__month
-                              , subq_22.ds__quarter AS metric_time__quarter
-                              , subq_22.ds__year AS metric_time__year
-                              , subq_22.ds__extract_year AS metric_time__extract_year
-                              , subq_22.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_22.ds__extract_month AS metric_time__extract_month
-                              , subq_22.ds__extract_day AS metric_time__extract_day
-                              , subq_22.ds__extract_dow AS metric_time__extract_dow
-                              , subq_22.ds__extract_doy AS metric_time__extract_doy
-                              , subq_22.user
-                              , subq_22.session
-                              , subq_22.visit__user
-                              , subq_22.visit__session
-                              , subq_22.referrer_id
-                              , subq_22.visit__referrer_id
-                              , subq_22.visits
-                              , subq_22.visitors
+                              subq_7.ds__day
+                              , subq_7.ds__week
+                              , subq_7.ds__month
+                              , subq_7.ds__quarter
+                              , subq_7.ds__year
+                              , subq_7.ds__extract_year
+                              , subq_7.ds__extract_quarter
+                              , subq_7.ds__extract_month
+                              , subq_7.ds__extract_day
+                              , subq_7.ds__extract_dow
+                              , subq_7.ds__extract_doy
+                              , subq_7.visit__ds__day
+                              , subq_7.visit__ds__week
+                              , subq_7.visit__ds__month
+                              , subq_7.visit__ds__quarter
+                              , subq_7.visit__ds__year
+                              , subq_7.visit__ds__extract_year
+                              , subq_7.visit__ds__extract_quarter
+                              , subq_7.visit__ds__extract_month
+                              , subq_7.visit__ds__extract_day
+                              , subq_7.visit__ds__extract_dow
+                              , subq_7.visit__ds__extract_doy
+                              , subq_7.ds__day AS metric_time__day
+                              , subq_7.ds__week AS metric_time__week
+                              , subq_7.ds__month AS metric_time__month
+                              , subq_7.ds__quarter AS metric_time__quarter
+                              , subq_7.ds__year AS metric_time__year
+                              , subq_7.ds__extract_year AS metric_time__extract_year
+                              , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_7.ds__extract_month AS metric_time__extract_month
+                              , subq_7.ds__extract_day AS metric_time__extract_day
+                              , subq_7.ds__extract_dow AS metric_time__extract_dow
+                              , subq_7.ds__extract_doy AS metric_time__extract_doy
+                              , subq_7.user
+                              , subq_7.session
+                              , subq_7.visit__user
+                              , subq_7.visit__session
+                              , subq_7.referrer_id
+                              , subq_7.visit__referrer_id
+                              , subq_7.visits
+                              , subq_7.visitors
                             FROM (
                               -- Read Elements From Semantic Model 'visits_source'
                               SELECT
@@ -403,94 +403,94 @@ FROM (
                                 , visits_source_src_28000.user_id AS visit__user
                                 , visits_source_src_28000.session_id AS visit__session
                               FROM ***************************.fct_visits visits_source_src_28000
-                            ) subq_22
-                          ) subq_23
-                        ) subq_24
+                            ) subq_7
+                          ) subq_8
+                        ) subq_9
                         INNER JOIN (
                           -- Add column with generated UUID
                           SELECT
-                            subq_26.ds__day
-                            , subq_26.ds__week
-                            , subq_26.ds__month
-                            , subq_26.ds__quarter
-                            , subq_26.ds__year
-                            , subq_26.ds__extract_year
-                            , subq_26.ds__extract_quarter
-                            , subq_26.ds__extract_month
-                            , subq_26.ds__extract_day
-                            , subq_26.ds__extract_dow
-                            , subq_26.ds__extract_doy
-                            , subq_26.buy__ds__day
-                            , subq_26.buy__ds__week
-                            , subq_26.buy__ds__month
-                            , subq_26.buy__ds__quarter
-                            , subq_26.buy__ds__year
-                            , subq_26.buy__ds__extract_year
-                            , subq_26.buy__ds__extract_quarter
-                            , subq_26.buy__ds__extract_month
-                            , subq_26.buy__ds__extract_day
-                            , subq_26.buy__ds__extract_dow
-                            , subq_26.buy__ds__extract_doy
-                            , subq_26.metric_time__day
-                            , subq_26.metric_time__week
-                            , subq_26.metric_time__month
-                            , subq_26.metric_time__quarter
-                            , subq_26.metric_time__year
-                            , subq_26.metric_time__extract_year
-                            , subq_26.metric_time__extract_quarter
-                            , subq_26.metric_time__extract_month
-                            , subq_26.metric_time__extract_day
-                            , subq_26.metric_time__extract_dow
-                            , subq_26.metric_time__extract_doy
-                            , subq_26.user
-                            , subq_26.session_id
-                            , subq_26.buy__user
-                            , subq_26.buy__session_id
-                            , subq_26.buys
-                            , subq_26.buyers
+                            subq_11.ds__day
+                            , subq_11.ds__week
+                            , subq_11.ds__month
+                            , subq_11.ds__quarter
+                            , subq_11.ds__year
+                            , subq_11.ds__extract_year
+                            , subq_11.ds__extract_quarter
+                            , subq_11.ds__extract_month
+                            , subq_11.ds__extract_day
+                            , subq_11.ds__extract_dow
+                            , subq_11.ds__extract_doy
+                            , subq_11.buy__ds__day
+                            , subq_11.buy__ds__week
+                            , subq_11.buy__ds__month
+                            , subq_11.buy__ds__quarter
+                            , subq_11.buy__ds__year
+                            , subq_11.buy__ds__extract_year
+                            , subq_11.buy__ds__extract_quarter
+                            , subq_11.buy__ds__extract_month
+                            , subq_11.buy__ds__extract_day
+                            , subq_11.buy__ds__extract_dow
+                            , subq_11.buy__ds__extract_doy
+                            , subq_11.metric_time__day
+                            , subq_11.metric_time__week
+                            , subq_11.metric_time__month
+                            , subq_11.metric_time__quarter
+                            , subq_11.metric_time__year
+                            , subq_11.metric_time__extract_year
+                            , subq_11.metric_time__extract_quarter
+                            , subq_11.metric_time__extract_month
+                            , subq_11.metric_time__extract_day
+                            , subq_11.metric_time__extract_dow
+                            , subq_11.metric_time__extract_doy
+                            , subq_11.user
+                            , subq_11.session_id
+                            , subq_11.buy__user
+                            , subq_11.buy__session_id
+                            , subq_11.buys
+                            , subq_11.buyers
                             , UUID() AS mf_internal_uuid
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_25.ds__day
-                              , subq_25.ds__week
-                              , subq_25.ds__month
-                              , subq_25.ds__quarter
-                              , subq_25.ds__year
-                              , subq_25.ds__extract_year
-                              , subq_25.ds__extract_quarter
-                              , subq_25.ds__extract_month
-                              , subq_25.ds__extract_day
-                              , subq_25.ds__extract_dow
-                              , subq_25.ds__extract_doy
-                              , subq_25.buy__ds__day
-                              , subq_25.buy__ds__week
-                              , subq_25.buy__ds__month
-                              , subq_25.buy__ds__quarter
-                              , subq_25.buy__ds__year
-                              , subq_25.buy__ds__extract_year
-                              , subq_25.buy__ds__extract_quarter
-                              , subq_25.buy__ds__extract_month
-                              , subq_25.buy__ds__extract_day
-                              , subq_25.buy__ds__extract_dow
-                              , subq_25.buy__ds__extract_doy
-                              , subq_25.ds__day AS metric_time__day
-                              , subq_25.ds__week AS metric_time__week
-                              , subq_25.ds__month AS metric_time__month
-                              , subq_25.ds__quarter AS metric_time__quarter
-                              , subq_25.ds__year AS metric_time__year
-                              , subq_25.ds__extract_year AS metric_time__extract_year
-                              , subq_25.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_25.ds__extract_month AS metric_time__extract_month
-                              , subq_25.ds__extract_day AS metric_time__extract_day
-                              , subq_25.ds__extract_dow AS metric_time__extract_dow
-                              , subq_25.ds__extract_doy AS metric_time__extract_doy
-                              , subq_25.user
-                              , subq_25.session_id
-                              , subq_25.buy__user
-                              , subq_25.buy__session_id
-                              , subq_25.buys
-                              , subq_25.buyers
+                              subq_10.ds__day
+                              , subq_10.ds__week
+                              , subq_10.ds__month
+                              , subq_10.ds__quarter
+                              , subq_10.ds__year
+                              , subq_10.ds__extract_year
+                              , subq_10.ds__extract_quarter
+                              , subq_10.ds__extract_month
+                              , subq_10.ds__extract_day
+                              , subq_10.ds__extract_dow
+                              , subq_10.ds__extract_doy
+                              , subq_10.buy__ds__day
+                              , subq_10.buy__ds__week
+                              , subq_10.buy__ds__month
+                              , subq_10.buy__ds__quarter
+                              , subq_10.buy__ds__year
+                              , subq_10.buy__ds__extract_year
+                              , subq_10.buy__ds__extract_quarter
+                              , subq_10.buy__ds__extract_month
+                              , subq_10.buy__ds__extract_day
+                              , subq_10.buy__ds__extract_dow
+                              , subq_10.buy__ds__extract_doy
+                              , subq_10.ds__day AS metric_time__day
+                              , subq_10.ds__week AS metric_time__week
+                              , subq_10.ds__month AS metric_time__month
+                              , subq_10.ds__quarter AS metric_time__quarter
+                              , subq_10.ds__year AS metric_time__year
+                              , subq_10.ds__extract_year AS metric_time__extract_year
+                              , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_10.ds__extract_month AS metric_time__extract_month
+                              , subq_10.ds__extract_day AS metric_time__extract_day
+                              , subq_10.ds__extract_dow AS metric_time__extract_dow
+                              , subq_10.ds__extract_doy AS metric_time__extract_doy
+                              , subq_10.user
+                              , subq_10.session_id
+                              , subq_10.buy__user
+                              , subq_10.buy__session_id
+                              , subq_10.buys
+                              , subq_10.buyers
                             FROM (
                               -- Read Elements From Semantic Model 'buys_source'
                               SELECT
@@ -523,33 +523,33 @@ FROM (
                                 , buys_source_src_28000.user_id AS buy__user
                                 , buys_source_src_28000.session_id AS buy__session_id
                               FROM ***************************.fct_buys buys_source_src_28000
-                            ) subq_25
-                          ) subq_26
-                        ) subq_27
+                            ) subq_10
+                          ) subq_11
+                        ) subq_12
                         ON
                           (
-                            subq_24.user = subq_27.user
+                            subq_9.user = subq_12.user
                           ) AND (
-                            (subq_24.ds__day <= subq_27.ds__day)
+                            (subq_9.ds__day <= subq_12.ds__day)
                           )
-                      ) subq_28
-                    ) subq_29
-                  ) subq_30
+                      ) subq_13
+                    ) subq_14
+                  ) subq_15
                   GROUP BY
-                    subq_30.user
-                ) subq_31
+                    subq_15.user
+                ) subq_16
                 ON
-                  subq_21.user = subq_31.user
+                  subq_6.user = subq_16.user
                 GROUP BY
-                  COALESCE(subq_21.user, subq_31.user)
-              ) subq_32
-            ) subq_33
-          ) subq_34
+                  COALESCE(subq_6.user, subq_16.user)
+              ) subq_17
+            ) subq_18
+          ) subq_19
           ON
-            subq_17.user = subq_34.user
-        ) subq_35
-      ) subq_36
+            subq_2.user = subq_19.user
+        ) subq_20
+      ) subq_21
       WHERE user__visit_buy_conversion_rate > 2
-    ) subq_37
-  ) subq_38
-) subq_39
+    ) subq_22
+  ) subq_23
+) subq_24

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_72.buys AS DOUBLE) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
-    , subq_57.listings AS listings
+    CAST(subq_42.buys AS DOUBLE) / CAST(NULLIF(subq_42.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    , subq_27.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_57
+  ) subq_27
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_61.user, subq_71.user) AS user
-      , MAX(subq_61.visits) AS visits
-      , MAX(subq_71.buys) AS buys
+      COALESCE(subq_31.user, subq_41.user) AS user
+      , MAX(subq_31.visits) AS visits
+      , MAX(subq_41.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_60.user
+        subq_30.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_60
+      ) subq_30
       GROUP BY
-        subq_60.user
-    ) subq_61
+        subq_30.user
+    ) subq_31
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_68.user
+        subq_38.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_64.visits) OVER (
+          FIRST_VALUE(subq_34.visits) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_64.ds__day) OVER (
+          , FIRST_VALUE(subq_34.ds__day) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_64.user) OVER (
+          , FIRST_VALUE(subq_34.user) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_67.mf_internal_uuid AS mf_internal_uuid
-          , subq_67.buys AS buys
+          , subq_37.mf_internal_uuid AS mf_internal_uuid
+          , subq_37.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_64
+        ) subq_34
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_67
+        ) subq_37
         ON
           (
-            subq_64.user = subq_67.user
+            subq_34.user = subq_37.user
           ) AND (
-            (subq_64.ds__day <= subq_67.ds__day)
+            (subq_34.ds__day <= subq_37.ds__day)
           )
-      ) subq_68
+      ) subq_38
       GROUP BY
-        subq_68.user
-    ) subq_71
+        subq_38.user
+    ) subq_41
     ON
-      subq_61.user = subq_71.user
+      subq_31.user = subq_41.user
     GROUP BY
-      COALESCE(subq_61.user, subq_71.user)
-  ) subq_72
+      COALESCE(subq_31.user, subq_41.user)
+  ) subq_42
   ON
-    subq_57.user = subq_72.user
-) subq_76
+    subq_27.user = subq_42.user
+) subq_46
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0.sql
@@ -1,106 +1,106 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_18.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_17.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_16.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.user__listing__user__average_booking_value
-        , subq_24.listings
+        subq_15.user__listing__user__average_booking_value
+        , subq_15.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
         SELECT
-          subq_23.user__listing__user__average_booking_value
-          , subq_23.listings
+          subq_14.user__listing__user__average_booking_value
+          , subq_14.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.user AS user
-            , subq_22.listing__user AS user__listing__user
-            , subq_22.listing__user__average_booking_value AS user__listing__user__average_booking_value
-            , subq_11.listings AS listings
+            subq_2.user AS user
+            , subq_13.listing__user AS user__listing__user
+            , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_10.user
-              , subq_10.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds__day
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds__extract_year
-                , subq_9.ds__extract_quarter
-                , subq_9.ds__extract_month
-                , subq_9.ds__extract_day
-                , subq_9.ds__extract_dow
-                , subq_9.ds__extract_doy
-                , subq_9.created_at__day
-                , subq_9.created_at__week
-                , subq_9.created_at__month
-                , subq_9.created_at__quarter
-                , subq_9.created_at__year
-                , subq_9.created_at__extract_year
-                , subq_9.created_at__extract_quarter
-                , subq_9.created_at__extract_month
-                , subq_9.created_at__extract_day
-                , subq_9.created_at__extract_dow
-                , subq_9.created_at__extract_doy
-                , subq_9.listing__ds__day
-                , subq_9.listing__ds__week
-                , subq_9.listing__ds__month
-                , subq_9.listing__ds__quarter
-                , subq_9.listing__ds__year
-                , subq_9.listing__ds__extract_year
-                , subq_9.listing__ds__extract_quarter
-                , subq_9.listing__ds__extract_month
-                , subq_9.listing__ds__extract_day
-                , subq_9.listing__ds__extract_dow
-                , subq_9.listing__ds__extract_doy
-                , subq_9.listing__created_at__day
-                , subq_9.listing__created_at__week
-                , subq_9.listing__created_at__month
-                , subq_9.listing__created_at__quarter
-                , subq_9.listing__created_at__year
-                , subq_9.listing__created_at__extract_year
-                , subq_9.listing__created_at__extract_quarter
-                , subq_9.listing__created_at__extract_month
-                , subq_9.listing__created_at__extract_day
-                , subq_9.listing__created_at__extract_dow
-                , subq_9.listing__created_at__extract_doy
-                , subq_9.ds__day AS metric_time__day
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.ds__extract_year AS metric_time__extract_year
-                , subq_9.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.ds__extract_month AS metric_time__extract_month
-                , subq_9.ds__extract_day AS metric_time__extract_day
-                , subq_9.ds__extract_dow AS metric_time__extract_dow
-                , subq_9.ds__extract_doy AS metric_time__extract_doy
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.listing__user
-                , subq_9.country_latest
-                , subq_9.is_lux_latest
-                , subq_9.capacity_latest
-                , subq_9.listing__country_latest
-                , subq_9.listing__is_lux_latest
-                , subq_9.listing__capacity_latest
-                , subq_9.listings
-                , subq_9.largest_listing
-                , subq_9.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -161,141 +161,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
             SELECT
-              subq_21.listing__user
-              , subq_21.listing__user__average_booking_value
+              subq_12.listing__user
+              , subq_12.listing__user__average_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing__user
-                , subq_20.average_booking_value AS listing__user__average_booking_value
+                subq_11.listing__user
+                , subq_11.average_booking_value AS listing__user__average_booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing__user
-                  , AVG(subq_19.average_booking_value) AS average_booking_value
+                  subq_10.listing__user
+                  , AVG(subq_10.average_booking_value) AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'listing__user']
                   SELECT
-                    subq_18.listing__user
-                    , subq_18.average_booking_value
+                    subq_9.listing__user
+                    , subq_9.average_booking_value
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_14.listing AS listing
-                      , subq_17.user AS listing__user
-                      , subq_14.average_booking_value AS average_booking_value
+                      subq_5.listing AS listing
+                      , subq_8.user AS listing__user
+                      , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']
                       SELECT
-                        subq_13.listing
-                        , subq_13.average_booking_value
+                        subq_4.listing
+                        , subq_4.average_booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_12.ds__day
-                          , subq_12.ds__week
-                          , subq_12.ds__month
-                          , subq_12.ds__quarter
-                          , subq_12.ds__year
-                          , subq_12.ds__extract_year
-                          , subq_12.ds__extract_quarter
-                          , subq_12.ds__extract_month
-                          , subq_12.ds__extract_day
-                          , subq_12.ds__extract_dow
-                          , subq_12.ds__extract_doy
-                          , subq_12.ds_partitioned__day
-                          , subq_12.ds_partitioned__week
-                          , subq_12.ds_partitioned__month
-                          , subq_12.ds_partitioned__quarter
-                          , subq_12.ds_partitioned__year
-                          , subq_12.ds_partitioned__extract_year
-                          , subq_12.ds_partitioned__extract_quarter
-                          , subq_12.ds_partitioned__extract_month
-                          , subq_12.ds_partitioned__extract_day
-                          , subq_12.ds_partitioned__extract_dow
-                          , subq_12.ds_partitioned__extract_doy
-                          , subq_12.paid_at__day
-                          , subq_12.paid_at__week
-                          , subq_12.paid_at__month
-                          , subq_12.paid_at__quarter
-                          , subq_12.paid_at__year
-                          , subq_12.paid_at__extract_year
-                          , subq_12.paid_at__extract_quarter
-                          , subq_12.paid_at__extract_month
-                          , subq_12.paid_at__extract_day
-                          , subq_12.paid_at__extract_dow
-                          , subq_12.paid_at__extract_doy
-                          , subq_12.booking__ds__day
-                          , subq_12.booking__ds__week
-                          , subq_12.booking__ds__month
-                          , subq_12.booking__ds__quarter
-                          , subq_12.booking__ds__year
-                          , subq_12.booking__ds__extract_year
-                          , subq_12.booking__ds__extract_quarter
-                          , subq_12.booking__ds__extract_month
-                          , subq_12.booking__ds__extract_day
-                          , subq_12.booking__ds__extract_dow
-                          , subq_12.booking__ds__extract_doy
-                          , subq_12.booking__ds_partitioned__day
-                          , subq_12.booking__ds_partitioned__week
-                          , subq_12.booking__ds_partitioned__month
-                          , subq_12.booking__ds_partitioned__quarter
-                          , subq_12.booking__ds_partitioned__year
-                          , subq_12.booking__ds_partitioned__extract_year
-                          , subq_12.booking__ds_partitioned__extract_quarter
-                          , subq_12.booking__ds_partitioned__extract_month
-                          , subq_12.booking__ds_partitioned__extract_day
-                          , subq_12.booking__ds_partitioned__extract_dow
-                          , subq_12.booking__ds_partitioned__extract_doy
-                          , subq_12.booking__paid_at__day
-                          , subq_12.booking__paid_at__week
-                          , subq_12.booking__paid_at__month
-                          , subq_12.booking__paid_at__quarter
-                          , subq_12.booking__paid_at__year
-                          , subq_12.booking__paid_at__extract_year
-                          , subq_12.booking__paid_at__extract_quarter
-                          , subq_12.booking__paid_at__extract_month
-                          , subq_12.booking__paid_at__extract_day
-                          , subq_12.booking__paid_at__extract_dow
-                          , subq_12.booking__paid_at__extract_doy
-                          , subq_12.ds__day AS metric_time__day
-                          , subq_12.ds__week AS metric_time__week
-                          , subq_12.ds__month AS metric_time__month
-                          , subq_12.ds__quarter AS metric_time__quarter
-                          , subq_12.ds__year AS metric_time__year
-                          , subq_12.ds__extract_year AS metric_time__extract_year
-                          , subq_12.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_12.ds__extract_month AS metric_time__extract_month
-                          , subq_12.ds__extract_day AS metric_time__extract_day
-                          , subq_12.ds__extract_dow AS metric_time__extract_dow
-                          , subq_12.ds__extract_doy AS metric_time__extract_doy
-                          , subq_12.listing
-                          , subq_12.guest
-                          , subq_12.host
-                          , subq_12.booking__listing
-                          , subq_12.booking__guest
-                          , subq_12.booking__host
-                          , subq_12.is_instant
-                          , subq_12.booking__is_instant
-                          , subq_12.bookings
-                          , subq_12.instant_bookings
-                          , subq_12.booking_value
-                          , subq_12.max_booking_value
-                          , subq_12.min_booking_value
-                          , subq_12.bookers
-                          , subq_12.average_booking_value
-                          , subq_12.referred_bookings
-                          , subq_12.median_booking_value
-                          , subq_12.booking_value_p99
-                          , subq_12.discrete_booking_value_p99
-                          , subq_12.approximate_continuous_booking_value_p99
-                          , subq_12.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -388,84 +388,84 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_12
-                      ) subq_13
-                    ) subq_14
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['listing', 'user']
                       SELECT
-                        subq_16.listing
-                        , subq_16.user
+                        subq_7.listing
+                        , subq_7.user
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_15.ds__day
-                          , subq_15.ds__week
-                          , subq_15.ds__month
-                          , subq_15.ds__quarter
-                          , subq_15.ds__year
-                          , subq_15.ds__extract_year
-                          , subq_15.ds__extract_quarter
-                          , subq_15.ds__extract_month
-                          , subq_15.ds__extract_day
-                          , subq_15.ds__extract_dow
-                          , subq_15.ds__extract_doy
-                          , subq_15.created_at__day
-                          , subq_15.created_at__week
-                          , subq_15.created_at__month
-                          , subq_15.created_at__quarter
-                          , subq_15.created_at__year
-                          , subq_15.created_at__extract_year
-                          , subq_15.created_at__extract_quarter
-                          , subq_15.created_at__extract_month
-                          , subq_15.created_at__extract_day
-                          , subq_15.created_at__extract_dow
-                          , subq_15.created_at__extract_doy
-                          , subq_15.listing__ds__day
-                          , subq_15.listing__ds__week
-                          , subq_15.listing__ds__month
-                          , subq_15.listing__ds__quarter
-                          , subq_15.listing__ds__year
-                          , subq_15.listing__ds__extract_year
-                          , subq_15.listing__ds__extract_quarter
-                          , subq_15.listing__ds__extract_month
-                          , subq_15.listing__ds__extract_day
-                          , subq_15.listing__ds__extract_dow
-                          , subq_15.listing__ds__extract_doy
-                          , subq_15.listing__created_at__day
-                          , subq_15.listing__created_at__week
-                          , subq_15.listing__created_at__month
-                          , subq_15.listing__created_at__quarter
-                          , subq_15.listing__created_at__year
-                          , subq_15.listing__created_at__extract_year
-                          , subq_15.listing__created_at__extract_quarter
-                          , subq_15.listing__created_at__extract_month
-                          , subq_15.listing__created_at__extract_day
-                          , subq_15.listing__created_at__extract_dow
-                          , subq_15.listing__created_at__extract_doy
-                          , subq_15.ds__day AS metric_time__day
-                          , subq_15.ds__week AS metric_time__week
-                          , subq_15.ds__month AS metric_time__month
-                          , subq_15.ds__quarter AS metric_time__quarter
-                          , subq_15.ds__year AS metric_time__year
-                          , subq_15.ds__extract_year AS metric_time__extract_year
-                          , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_15.ds__extract_month AS metric_time__extract_month
-                          , subq_15.ds__extract_day AS metric_time__extract_day
-                          , subq_15.ds__extract_dow AS metric_time__extract_dow
-                          , subq_15.ds__extract_doy AS metric_time__extract_doy
-                          , subq_15.listing
-                          , subq_15.user
-                          , subq_15.listing__user
-                          , subq_15.country_latest
-                          , subq_15.is_lux_latest
-                          , subq_15.capacity_latest
-                          , subq_15.listing__country_latest
-                          , subq_15.listing__is_lux_latest
-                          , subq_15.listing__capacity_latest
-                          , subq_15.listings
-                          , subq_15.largest_listing
-                          , subq_15.smallest_listing
+                          subq_6.ds__day
+                          , subq_6.ds__week
+                          , subq_6.ds__month
+                          , subq_6.ds__quarter
+                          , subq_6.ds__year
+                          , subq_6.ds__extract_year
+                          , subq_6.ds__extract_quarter
+                          , subq_6.ds__extract_month
+                          , subq_6.ds__extract_day
+                          , subq_6.ds__extract_dow
+                          , subq_6.ds__extract_doy
+                          , subq_6.created_at__day
+                          , subq_6.created_at__week
+                          , subq_6.created_at__month
+                          , subq_6.created_at__quarter
+                          , subq_6.created_at__year
+                          , subq_6.created_at__extract_year
+                          , subq_6.created_at__extract_quarter
+                          , subq_6.created_at__extract_month
+                          , subq_6.created_at__extract_day
+                          , subq_6.created_at__extract_dow
+                          , subq_6.created_at__extract_doy
+                          , subq_6.listing__ds__day
+                          , subq_6.listing__ds__week
+                          , subq_6.listing__ds__month
+                          , subq_6.listing__ds__quarter
+                          , subq_6.listing__ds__year
+                          , subq_6.listing__ds__extract_year
+                          , subq_6.listing__ds__extract_quarter
+                          , subq_6.listing__ds__extract_month
+                          , subq_6.listing__ds__extract_day
+                          , subq_6.listing__ds__extract_dow
+                          , subq_6.listing__ds__extract_doy
+                          , subq_6.listing__created_at__day
+                          , subq_6.listing__created_at__week
+                          , subq_6.listing__created_at__month
+                          , subq_6.listing__created_at__quarter
+                          , subq_6.listing__created_at__year
+                          , subq_6.listing__created_at__extract_year
+                          , subq_6.listing__created_at__extract_quarter
+                          , subq_6.listing__created_at__extract_month
+                          , subq_6.listing__created_at__extract_day
+                          , subq_6.listing__created_at__extract_dow
+                          , subq_6.listing__created_at__extract_doy
+                          , subq_6.ds__day AS metric_time__day
+                          , subq_6.ds__week AS metric_time__week
+                          , subq_6.ds__month AS metric_time__month
+                          , subq_6.ds__quarter AS metric_time__quarter
+                          , subq_6.ds__year AS metric_time__year
+                          , subq_6.ds__extract_year AS metric_time__extract_year
+                          , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_6.ds__extract_month AS metric_time__extract_month
+                          , subq_6.ds__extract_day AS metric_time__extract_day
+                          , subq_6.ds__extract_dow AS metric_time__extract_dow
+                          , subq_6.ds__extract_doy AS metric_time__extract_doy
+                          , subq_6.listing
+                          , subq_6.user
+                          , subq_6.listing__user
+                          , subq_6.country_latest
+                          , subq_6.is_lux_latest
+                          , subq_6.capacity_latest
+                          , subq_6.listing__country_latest
+                          , subq_6.listing__is_lux_latest
+                          , subq_6.listing__capacity_latest
+                          , subq_6.listings
+                          , subq_6.largest_listing
+                          , subq_6.smallest_listing
                         FROM (
                           -- Read Elements From Semantic Model 'listings_latest'
                           SELECT
@@ -526,23 +526,23 @@ FROM (
                             , listings_latest_src_28000.user_id AS user
                             , listings_latest_src_28000.user_id AS listing__user
                           FROM ***************************.dim_listings_latest listings_latest_src_28000
-                        ) subq_15
-                      ) subq_16
-                    ) subq_17
+                        ) subq_6
+                      ) subq_7
+                    ) subq_8
                     ON
-                      subq_14.listing = subq_17.listing
-                  ) subq_18
-                ) subq_19
+                      subq_5.listing = subq_8.listing
+                  ) subq_9
+                ) subq_10
                 GROUP BY
-                  subq_19.listing__user
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_10.listing__user
+              ) subq_11
+            ) subq_12
+          ) subq_13
           ON
-            subq_11.user = subq_22.listing__user
-        ) subq_23
-      ) subq_24
+            subq_2.user = subq_13.listing__user
+        ) subq_14
+      ) subq_15
       WHERE user__listing__user__average_booking_value > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_16
+  ) subq_17
+) subq_18

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_39.listings AS listings
+    subq_32.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_21.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_39
+  ) subq_21
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_50
+  ) subq_32
   ON
-    subq_39.user = subq_50.listing__user
-) subq_52
+    subq_21.user = subq_32.listing__user
+) subq_34
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_multi_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_40.third_hop_count
+  subq_22.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_39.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_21.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_38.third_hop_count
+      subq_20.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_37.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-        , subq_37.third_hop_count
+        subq_19.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+        , subq_19.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
         SELECT
-          subq_36.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-          , subq_36.third_hop_count
+          subq_18.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+          , subq_18.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_20.customer_third_hop_id AS customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-            , subq_20.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_19.customer_third_hop_id
-              , subq_19.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_18.third_hop_ds__day
-                , subq_18.third_hop_ds__week
-                , subq_18.third_hop_ds__month
-                , subq_18.third_hop_ds__quarter
-                , subq_18.third_hop_ds__year
-                , subq_18.third_hop_ds__extract_year
-                , subq_18.third_hop_ds__extract_quarter
-                , subq_18.third_hop_ds__extract_month
-                , subq_18.third_hop_ds__extract_day
-                , subq_18.third_hop_ds__extract_dow
-                , subq_18.third_hop_ds__extract_doy
-                , subq_18.customer_third_hop_id__third_hop_ds__day
-                , subq_18.customer_third_hop_id__third_hop_ds__week
-                , subq_18.customer_third_hop_id__third_hop_ds__month
-                , subq_18.customer_third_hop_id__third_hop_ds__quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_18.third_hop_ds__day AS metric_time__day
-                , subq_18.third_hop_ds__week AS metric_time__week
-                , subq_18.third_hop_ds__month AS metric_time__month
-                , subq_18.third_hop_ds__quarter AS metric_time__quarter
-                , subq_18.third_hop_ds__year AS metric_time__year
-                , subq_18.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_18.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_18.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_18.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_18.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_18.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_18.customer_third_hop_id
-                , subq_18.value
-                , subq_18.customer_third_hop_id__value
-                , subq_18.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,105 +101,105 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_18
-            ) subq_19
-          ) subq_20
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
             SELECT
-              subq_34.account_id__customer_id__customer_third_hop_id
-              , subq_34.account_id__customer_id__customer_third_hop_id__txn_count
+              subq_16.account_id__customer_id__customer_third_hop_id
+              , subq_16.account_id__customer_id__customer_third_hop_id__txn_count
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_33.account_id__customer_id__customer_third_hop_id
-                , subq_33.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
+                subq_15.account_id__customer_id__customer_third_hop_id
+                , subq_15.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_32.account_id__customer_id__customer_third_hop_id
-                  , SUM(subq_32.txn_count) AS txn_count
+                  subq_14.account_id__customer_id__customer_third_hop_id
+                  , SUM(subq_14.txn_count) AS txn_count
                 FROM (
                   -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_third_hop_id']
                   SELECT
-                    subq_31.account_id__customer_id__customer_third_hop_id
-                    , subq_31.txn_count
+                    subq_13.account_id__customer_id__customer_third_hop_id
+                    , subq_13.txn_count
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_23.ds_partitioned__day AS ds_partitioned__day
-                      , subq_30.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_23.account_id AS account_id
-                      , subq_30.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
-                      , subq_23.txn_count AS txn_count
+                      subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
+                      , subq_5.account_id AS account_id
+                      , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
                       SELECT
-                        subq_22.ds_partitioned__day
-                        , subq_22.account_id
-                        , subq_22.txn_count
+                        subq_4.ds_partitioned__day
+                        , subq_4.account_id
+                        , subq_4.txn_count
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_21.ds_partitioned__day
-                          , subq_21.ds_partitioned__week
-                          , subq_21.ds_partitioned__month
-                          , subq_21.ds_partitioned__quarter
-                          , subq_21.ds_partitioned__year
-                          , subq_21.ds_partitioned__extract_year
-                          , subq_21.ds_partitioned__extract_quarter
-                          , subq_21.ds_partitioned__extract_month
-                          , subq_21.ds_partitioned__extract_day
-                          , subq_21.ds_partitioned__extract_dow
-                          , subq_21.ds_partitioned__extract_doy
-                          , subq_21.ds__day
-                          , subq_21.ds__week
-                          , subq_21.ds__month
-                          , subq_21.ds__quarter
-                          , subq_21.ds__year
-                          , subq_21.ds__extract_year
-                          , subq_21.ds__extract_quarter
-                          , subq_21.ds__extract_month
-                          , subq_21.ds__extract_day
-                          , subq_21.ds__extract_dow
-                          , subq_21.ds__extract_doy
-                          , subq_21.account_id__ds_partitioned__day
-                          , subq_21.account_id__ds_partitioned__week
-                          , subq_21.account_id__ds_partitioned__month
-                          , subq_21.account_id__ds_partitioned__quarter
-                          , subq_21.account_id__ds_partitioned__year
-                          , subq_21.account_id__ds_partitioned__extract_year
-                          , subq_21.account_id__ds_partitioned__extract_quarter
-                          , subq_21.account_id__ds_partitioned__extract_month
-                          , subq_21.account_id__ds_partitioned__extract_day
-                          , subq_21.account_id__ds_partitioned__extract_dow
-                          , subq_21.account_id__ds_partitioned__extract_doy
-                          , subq_21.account_id__ds__day
-                          , subq_21.account_id__ds__week
-                          , subq_21.account_id__ds__month
-                          , subq_21.account_id__ds__quarter
-                          , subq_21.account_id__ds__year
-                          , subq_21.account_id__ds__extract_year
-                          , subq_21.account_id__ds__extract_quarter
-                          , subq_21.account_id__ds__extract_month
-                          , subq_21.account_id__ds__extract_day
-                          , subq_21.account_id__ds__extract_dow
-                          , subq_21.account_id__ds__extract_doy
-                          , subq_21.ds__day AS metric_time__day
-                          , subq_21.ds__week AS metric_time__week
-                          , subq_21.ds__month AS metric_time__month
-                          , subq_21.ds__quarter AS metric_time__quarter
-                          , subq_21.ds__year AS metric_time__year
-                          , subq_21.ds__extract_year AS metric_time__extract_year
-                          , subq_21.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_21.ds__extract_month AS metric_time__extract_month
-                          , subq_21.ds__extract_day AS metric_time__extract_day
-                          , subq_21.ds__extract_dow AS metric_time__extract_dow
-                          , subq_21.ds__extract_doy AS metric_time__extract_doy
-                          , subq_21.account_id
-                          , subq_21.account_month
-                          , subq_21.account_id__account_month
-                          , subq_21.txn_count
+                          subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.account_id__ds_partitioned__day
+                          , subq_3.account_id__ds_partitioned__week
+                          , subq_3.account_id__ds_partitioned__month
+                          , subq_3.account_id__ds_partitioned__quarter
+                          , subq_3.account_id__ds_partitioned__year
+                          , subq_3.account_id__ds_partitioned__extract_year
+                          , subq_3.account_id__ds_partitioned__extract_quarter
+                          , subq_3.account_id__ds_partitioned__extract_month
+                          , subq_3.account_id__ds_partitioned__extract_day
+                          , subq_3.account_id__ds_partitioned__extract_dow
+                          , subq_3.account_id__ds_partitioned__extract_doy
+                          , subq_3.account_id__ds__day
+                          , subq_3.account_id__ds__week
+                          , subq_3.account_id__ds__month
+                          , subq_3.account_id__ds__quarter
+                          , subq_3.account_id__ds__year
+                          , subq_3.account_id__ds__extract_year
+                          , subq_3.account_id__ds__extract_quarter
+                          , subq_3.account_id__ds__extract_month
+                          , subq_3.account_id__ds__extract_day
+                          , subq_3.account_id__ds__extract_dow
+                          , subq_3.account_id__ds__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.account_id
+                          , subq_3.account_month
+                          , subq_3.account_id__account_month
+                          , subq_3.txn_count
                         FROM (
                           -- Read Elements From Semantic Model 'account_month_txns'
                           SELECT
@@ -252,164 +252,164 @@ FROM (
                             , account_month_txns_src_22000.account_month AS account_id__account_month
                             , account_month_txns_src_22000.account_id
                           FROM ***************************.account_month_txns account_month_txns_src_22000
-                        ) subq_21
-                      ) subq_22
-                    ) subq_23
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['ds_partitioned__day', 'account_id', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_29.ds_partitioned__day
-                        , subq_29.account_id
-                        , subq_29.customer_id__customer_third_hop_id
+                        subq_11.ds_partitioned__day
+                        , subq_11.account_id
+                        , subq_11.customer_id__customer_third_hop_id
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_25.ds_partitioned__day AS ds_partitioned__day
-                          , subq_25.ds_partitioned__week AS ds_partitioned__week
-                          , subq_25.ds_partitioned__month AS ds_partitioned__month
-                          , subq_25.ds_partitioned__quarter AS ds_partitioned__quarter
-                          , subq_25.ds_partitioned__year AS ds_partitioned__year
-                          , subq_25.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                          , subq_25.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                          , subq_25.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                          , subq_25.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                          , subq_25.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                          , subq_25.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                          , subq_25.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-                          , subq_25.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-                          , subq_25.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-                          , subq_25.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-                          , subq_25.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-                          , subq_25.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-                          , subq_25.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-                          , subq_25.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-                          , subq_25.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-                          , subq_25.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-                          , subq_25.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-                          , subq_25.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-                          , subq_25.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-                          , subq_25.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-                          , subq_25.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-                          , subq_25.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-                          , subq_25.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-                          , subq_25.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-                          , subq_25.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-                          , subq_25.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-                          , subq_25.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-                          , subq_25.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-                          , subq_25.metric_time__day AS metric_time__day
-                          , subq_25.metric_time__week AS metric_time__week
-                          , subq_25.metric_time__month AS metric_time__month
-                          , subq_25.metric_time__quarter AS metric_time__quarter
-                          , subq_25.metric_time__year AS metric_time__year
-                          , subq_25.metric_time__extract_year AS metric_time__extract_year
-                          , subq_25.metric_time__extract_quarter AS metric_time__extract_quarter
-                          , subq_25.metric_time__extract_month AS metric_time__extract_month
-                          , subq_25.metric_time__extract_day AS metric_time__extract_day
-                          , subq_25.metric_time__extract_dow AS metric_time__extract_dow
-                          , subq_25.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_28.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_28.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_28.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_28.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_28.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_28.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_28.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_28.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_28.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_28.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_28.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_28.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_28.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_28.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_28.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_28.metric_time__day AS customer_id__metric_time__day
-                          , subq_28.metric_time__week AS customer_id__metric_time__week
-                          , subq_28.metric_time__month AS customer_id__metric_time__month
-                          , subq_28.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_28.metric_time__year AS customer_id__metric_time__year
-                          , subq_28.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_28.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_28.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_28.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_28.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_28.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-                          , subq_25.account_id AS account_id
-                          , subq_25.customer_id AS customer_id
-                          , subq_25.account_id__customer_id AS account_id__customer_id
-                          , subq_25.bridge_account__account_id AS bridge_account__account_id
-                          , subq_25.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_28.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_28.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
-                          , subq_25.extra_dim AS extra_dim
-                          , subq_25.account_id__extra_dim AS account_id__extra_dim
-                          , subq_25.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_28.country AS customer_id__country
-                          , subq_28.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
-                          , subq_25.account_customer_combos AS account_customer_combos
+                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          , subq_7.ds_partitioned__week AS ds_partitioned__week
+                          , subq_7.ds_partitioned__month AS ds_partitioned__month
+                          , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+                          , subq_7.ds_partitioned__year AS ds_partitioned__year
+                          , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                          , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                          , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                          , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                          , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                          , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                          , subq_7.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+                          , subq_7.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+                          , subq_7.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+                          , subq_7.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+                          , subq_7.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+                          , subq_7.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+                          , subq_7.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+                          , subq_7.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+                          , subq_7.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+                          , subq_7.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+                          , subq_7.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+                          , subq_7.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+                          , subq_7.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+                          , subq_7.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+                          , subq_7.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+                          , subq_7.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+                          , subq_7.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+                          , subq_7.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+                          , subq_7.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+                          , subq_7.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+                          , subq_7.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+                          , subq_7.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+                          , subq_7.metric_time__day AS metric_time__day
+                          , subq_7.metric_time__week AS metric_time__week
+                          , subq_7.metric_time__month AS metric_time__month
+                          , subq_7.metric_time__quarter AS metric_time__quarter
+                          , subq_7.metric_time__year AS metric_time__year
+                          , subq_7.metric_time__extract_year AS metric_time__extract_year
+                          , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+                          , subq_7.metric_time__extract_month AS metric_time__extract_month
+                          , subq_7.metric_time__extract_day AS metric_time__extract_day
+                          , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+                          , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_7.account_id AS account_id
+                          , subq_7.customer_id AS customer_id
+                          , subq_7.account_id__customer_id AS account_id__customer_id
+                          , subq_7.bridge_account__account_id AS bridge_account__account_id
+                          , subq_7.bridge_account__customer_id AS bridge_account__customer_id
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.extra_dim AS extra_dim
+                          , subq_7.account_id__extra_dim AS account_id__extra_dim
+                          , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
+                          , subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'
                           SELECT
-                            subq_24.ds_partitioned__day
-                            , subq_24.ds_partitioned__week
-                            , subq_24.ds_partitioned__month
-                            , subq_24.ds_partitioned__quarter
-                            , subq_24.ds_partitioned__year
-                            , subq_24.ds_partitioned__extract_year
-                            , subq_24.ds_partitioned__extract_quarter
-                            , subq_24.ds_partitioned__extract_month
-                            , subq_24.ds_partitioned__extract_day
-                            , subq_24.ds_partitioned__extract_dow
-                            , subq_24.ds_partitioned__extract_doy
-                            , subq_24.account_id__ds_partitioned__day
-                            , subq_24.account_id__ds_partitioned__week
-                            , subq_24.account_id__ds_partitioned__month
-                            , subq_24.account_id__ds_partitioned__quarter
-                            , subq_24.account_id__ds_partitioned__year
-                            , subq_24.account_id__ds_partitioned__extract_year
-                            , subq_24.account_id__ds_partitioned__extract_quarter
-                            , subq_24.account_id__ds_partitioned__extract_month
-                            , subq_24.account_id__ds_partitioned__extract_day
-                            , subq_24.account_id__ds_partitioned__extract_dow
-                            , subq_24.account_id__ds_partitioned__extract_doy
-                            , subq_24.bridge_account__ds_partitioned__day
-                            , subq_24.bridge_account__ds_partitioned__week
-                            , subq_24.bridge_account__ds_partitioned__month
-                            , subq_24.bridge_account__ds_partitioned__quarter
-                            , subq_24.bridge_account__ds_partitioned__year
-                            , subq_24.bridge_account__ds_partitioned__extract_year
-                            , subq_24.bridge_account__ds_partitioned__extract_quarter
-                            , subq_24.bridge_account__ds_partitioned__extract_month
-                            , subq_24.bridge_account__ds_partitioned__extract_day
-                            , subq_24.bridge_account__ds_partitioned__extract_dow
-                            , subq_24.bridge_account__ds_partitioned__extract_doy
-                            , subq_24.ds_partitioned__day AS metric_time__day
-                            , subq_24.ds_partitioned__week AS metric_time__week
-                            , subq_24.ds_partitioned__month AS metric_time__month
-                            , subq_24.ds_partitioned__quarter AS metric_time__quarter
-                            , subq_24.ds_partitioned__year AS metric_time__year
-                            , subq_24.ds_partitioned__extract_year AS metric_time__extract_year
-                            , subq_24.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                            , subq_24.ds_partitioned__extract_month AS metric_time__extract_month
-                            , subq_24.ds_partitioned__extract_day AS metric_time__extract_day
-                            , subq_24.ds_partitioned__extract_dow AS metric_time__extract_dow
-                            , subq_24.ds_partitioned__extract_doy AS metric_time__extract_doy
-                            , subq_24.account_id
-                            , subq_24.customer_id
-                            , subq_24.account_id__customer_id
-                            , subq_24.bridge_account__account_id
-                            , subq_24.bridge_account__customer_id
-                            , subq_24.extra_dim
-                            , subq_24.account_id__extra_dim
-                            , subq_24.bridge_account__extra_dim
-                            , subq_24.account_customer_combos
+                            subq_6.ds_partitioned__day
+                            , subq_6.ds_partitioned__week
+                            , subq_6.ds_partitioned__month
+                            , subq_6.ds_partitioned__quarter
+                            , subq_6.ds_partitioned__year
+                            , subq_6.ds_partitioned__extract_year
+                            , subq_6.ds_partitioned__extract_quarter
+                            , subq_6.ds_partitioned__extract_month
+                            , subq_6.ds_partitioned__extract_day
+                            , subq_6.ds_partitioned__extract_dow
+                            , subq_6.ds_partitioned__extract_doy
+                            , subq_6.account_id__ds_partitioned__day
+                            , subq_6.account_id__ds_partitioned__week
+                            , subq_6.account_id__ds_partitioned__month
+                            , subq_6.account_id__ds_partitioned__quarter
+                            , subq_6.account_id__ds_partitioned__year
+                            , subq_6.account_id__ds_partitioned__extract_year
+                            , subq_6.account_id__ds_partitioned__extract_quarter
+                            , subq_6.account_id__ds_partitioned__extract_month
+                            , subq_6.account_id__ds_partitioned__extract_day
+                            , subq_6.account_id__ds_partitioned__extract_dow
+                            , subq_6.account_id__ds_partitioned__extract_doy
+                            , subq_6.bridge_account__ds_partitioned__day
+                            , subq_6.bridge_account__ds_partitioned__week
+                            , subq_6.bridge_account__ds_partitioned__month
+                            , subq_6.bridge_account__ds_partitioned__quarter
+                            , subq_6.bridge_account__ds_partitioned__year
+                            , subq_6.bridge_account__ds_partitioned__extract_year
+                            , subq_6.bridge_account__ds_partitioned__extract_quarter
+                            , subq_6.bridge_account__ds_partitioned__extract_month
+                            , subq_6.bridge_account__ds_partitioned__extract_day
+                            , subq_6.bridge_account__ds_partitioned__extract_dow
+                            , subq_6.bridge_account__ds_partitioned__extract_doy
+                            , subq_6.ds_partitioned__day AS metric_time__day
+                            , subq_6.ds_partitioned__week AS metric_time__week
+                            , subq_6.ds_partitioned__month AS metric_time__month
+                            , subq_6.ds_partitioned__quarter AS metric_time__quarter
+                            , subq_6.ds_partitioned__year AS metric_time__year
+                            , subq_6.ds_partitioned__extract_year AS metric_time__extract_year
+                            , subq_6.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                            , subq_6.ds_partitioned__extract_month AS metric_time__extract_month
+                            , subq_6.ds_partitioned__extract_day AS metric_time__extract_day
+                            , subq_6.ds_partitioned__extract_dow AS metric_time__extract_dow
+                            , subq_6.ds_partitioned__extract_doy AS metric_time__extract_doy
+                            , subq_6.account_id
+                            , subq_6.customer_id
+                            , subq_6.account_id__customer_id
+                            , subq_6.bridge_account__account_id
+                            , subq_6.bridge_account__customer_id
+                            , subq_6.extra_dim
+                            , subq_6.account_id__extra_dim
+                            , subq_6.bridge_account__extra_dim
+                            , subq_6.account_customer_combos
                           FROM (
                             -- Read Elements From Semantic Model 'bridge_table'
                             SELECT
@@ -456,8 +456,8 @@ FROM (
                               , bridge_table_src_22000.account_id AS bridge_account__account_id
                               , bridge_table_src_22000.customer_id AS bridge_account__customer_id
                             FROM ***************************.bridge_table bridge_table_src_22000
-                          ) subq_24
-                        ) subq_25
+                          ) subq_6
+                        ) subq_7
                         LEFT OUTER JOIN (
                           -- Pass Only Elements: [
                           --   'country',
@@ -513,112 +513,112 @@ FROM (
                           --   'customer_third_hop_id__customer_id',
                           -- ]
                           SELECT
-                            subq_27.acquired_ds__day
-                            , subq_27.acquired_ds__week
-                            , subq_27.acquired_ds__month
-                            , subq_27.acquired_ds__quarter
-                            , subq_27.acquired_ds__year
-                            , subq_27.acquired_ds__extract_year
-                            , subq_27.acquired_ds__extract_quarter
-                            , subq_27.acquired_ds__extract_month
-                            , subq_27.acquired_ds__extract_day
-                            , subq_27.acquired_ds__extract_dow
-                            , subq_27.acquired_ds__extract_doy
-                            , subq_27.customer_id__acquired_ds__day
-                            , subq_27.customer_id__acquired_ds__week
-                            , subq_27.customer_id__acquired_ds__month
-                            , subq_27.customer_id__acquired_ds__quarter
-                            , subq_27.customer_id__acquired_ds__year
-                            , subq_27.customer_id__acquired_ds__extract_year
-                            , subq_27.customer_id__acquired_ds__extract_quarter
-                            , subq_27.customer_id__acquired_ds__extract_month
-                            , subq_27.customer_id__acquired_ds__extract_day
-                            , subq_27.customer_id__acquired_ds__extract_dow
-                            , subq_27.customer_id__acquired_ds__extract_doy
-                            , subq_27.customer_third_hop_id__acquired_ds__day
-                            , subq_27.customer_third_hop_id__acquired_ds__week
-                            , subq_27.customer_third_hop_id__acquired_ds__month
-                            , subq_27.customer_third_hop_id__acquired_ds__quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_27.metric_time__day
-                            , subq_27.metric_time__week
-                            , subq_27.metric_time__month
-                            , subq_27.metric_time__quarter
-                            , subq_27.metric_time__year
-                            , subq_27.metric_time__extract_year
-                            , subq_27.metric_time__extract_quarter
-                            , subq_27.metric_time__extract_month
-                            , subq_27.metric_time__extract_day
-                            , subq_27.metric_time__extract_dow
-                            , subq_27.metric_time__extract_doy
-                            , subq_27.customer_id
-                            , subq_27.customer_third_hop_id
-                            , subq_27.customer_id__customer_third_hop_id
-                            , subq_27.customer_third_hop_id__customer_id
-                            , subq_27.country
-                            , subq_27.customer_id__country
-                            , subq_27.customer_third_hop_id__country
+                            subq_9.acquired_ds__day
+                            , subq_9.acquired_ds__week
+                            , subq_9.acquired_ds__month
+                            , subq_9.acquired_ds__quarter
+                            , subq_9.acquired_ds__year
+                            , subq_9.acquired_ds__extract_year
+                            , subq_9.acquired_ds__extract_quarter
+                            , subq_9.acquired_ds__extract_month
+                            , subq_9.acquired_ds__extract_day
+                            , subq_9.acquired_ds__extract_dow
+                            , subq_9.acquired_ds__extract_doy
+                            , subq_9.customer_id__acquired_ds__day
+                            , subq_9.customer_id__acquired_ds__week
+                            , subq_9.customer_id__acquired_ds__month
+                            , subq_9.customer_id__acquired_ds__quarter
+                            , subq_9.customer_id__acquired_ds__year
+                            , subq_9.customer_id__acquired_ds__extract_year
+                            , subq_9.customer_id__acquired_ds__extract_quarter
+                            , subq_9.customer_id__acquired_ds__extract_month
+                            , subq_9.customer_id__acquired_ds__extract_day
+                            , subq_9.customer_id__acquired_ds__extract_dow
+                            , subq_9.customer_id__acquired_ds__extract_doy
+                            , subq_9.customer_third_hop_id__acquired_ds__day
+                            , subq_9.customer_third_hop_id__acquired_ds__week
+                            , subq_9.customer_third_hop_id__acquired_ds__month
+                            , subq_9.customer_third_hop_id__acquired_ds__quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_9.metric_time__day
+                            , subq_9.metric_time__week
+                            , subq_9.metric_time__month
+                            , subq_9.metric_time__quarter
+                            , subq_9.metric_time__year
+                            , subq_9.metric_time__extract_year
+                            , subq_9.metric_time__extract_quarter
+                            , subq_9.metric_time__extract_month
+                            , subq_9.metric_time__extract_day
+                            , subq_9.metric_time__extract_dow
+                            , subq_9.metric_time__extract_doy
+                            , subq_9.customer_id
+                            , subq_9.customer_third_hop_id
+                            , subq_9.customer_id__customer_third_hop_id
+                            , subq_9.customer_third_hop_id__customer_id
+                            , subq_9.country
+                            , subq_9.customer_id__country
+                            , subq_9.customer_third_hop_id__country
                           FROM (
                             -- Metric Time Dimension 'acquired_ds'
                             SELECT
-                              subq_26.acquired_ds__day
-                              , subq_26.acquired_ds__week
-                              , subq_26.acquired_ds__month
-                              , subq_26.acquired_ds__quarter
-                              , subq_26.acquired_ds__year
-                              , subq_26.acquired_ds__extract_year
-                              , subq_26.acquired_ds__extract_quarter
-                              , subq_26.acquired_ds__extract_month
-                              , subq_26.acquired_ds__extract_day
-                              , subq_26.acquired_ds__extract_dow
-                              , subq_26.acquired_ds__extract_doy
-                              , subq_26.customer_id__acquired_ds__day
-                              , subq_26.customer_id__acquired_ds__week
-                              , subq_26.customer_id__acquired_ds__month
-                              , subq_26.customer_id__acquired_ds__quarter
-                              , subq_26.customer_id__acquired_ds__year
-                              , subq_26.customer_id__acquired_ds__extract_year
-                              , subq_26.customer_id__acquired_ds__extract_quarter
-                              , subq_26.customer_id__acquired_ds__extract_month
-                              , subq_26.customer_id__acquired_ds__extract_day
-                              , subq_26.customer_id__acquired_ds__extract_dow
-                              , subq_26.customer_id__acquired_ds__extract_doy
-                              , subq_26.customer_third_hop_id__acquired_ds__day
-                              , subq_26.customer_third_hop_id__acquired_ds__week
-                              , subq_26.customer_third_hop_id__acquired_ds__month
-                              , subq_26.customer_third_hop_id__acquired_ds__quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_month
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_day
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_dow
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_doy
-                              , subq_26.acquired_ds__day AS metric_time__day
-                              , subq_26.acquired_ds__week AS metric_time__week
-                              , subq_26.acquired_ds__month AS metric_time__month
-                              , subq_26.acquired_ds__quarter AS metric_time__quarter
-                              , subq_26.acquired_ds__year AS metric_time__year
-                              , subq_26.acquired_ds__extract_year AS metric_time__extract_year
-                              , subq_26.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_26.acquired_ds__extract_month AS metric_time__extract_month
-                              , subq_26.acquired_ds__extract_day AS metric_time__extract_day
-                              , subq_26.acquired_ds__extract_dow AS metric_time__extract_dow
-                              , subq_26.acquired_ds__extract_doy AS metric_time__extract_doy
-                              , subq_26.customer_id
-                              , subq_26.customer_third_hop_id
-                              , subq_26.customer_id__customer_third_hop_id
-                              , subq_26.customer_third_hop_id__customer_id
-                              , subq_26.country
-                              , subq_26.customer_id__country
-                              , subq_26.customer_third_hop_id__country
-                              , subq_26.customers_with_other_data
+                              subq_8.acquired_ds__day
+                              , subq_8.acquired_ds__week
+                              , subq_8.acquired_ds__month
+                              , subq_8.acquired_ds__quarter
+                              , subq_8.acquired_ds__year
+                              , subq_8.acquired_ds__extract_year
+                              , subq_8.acquired_ds__extract_quarter
+                              , subq_8.acquired_ds__extract_month
+                              , subq_8.acquired_ds__extract_day
+                              , subq_8.acquired_ds__extract_dow
+                              , subq_8.acquired_ds__extract_doy
+                              , subq_8.customer_id__acquired_ds__day
+                              , subq_8.customer_id__acquired_ds__week
+                              , subq_8.customer_id__acquired_ds__month
+                              , subq_8.customer_id__acquired_ds__quarter
+                              , subq_8.customer_id__acquired_ds__year
+                              , subq_8.customer_id__acquired_ds__extract_year
+                              , subq_8.customer_id__acquired_ds__extract_quarter
+                              , subq_8.customer_id__acquired_ds__extract_month
+                              , subq_8.customer_id__acquired_ds__extract_day
+                              , subq_8.customer_id__acquired_ds__extract_dow
+                              , subq_8.customer_id__acquired_ds__extract_doy
+                              , subq_8.customer_third_hop_id__acquired_ds__day
+                              , subq_8.customer_third_hop_id__acquired_ds__week
+                              , subq_8.customer_third_hop_id__acquired_ds__month
+                              , subq_8.customer_third_hop_id__acquired_ds__quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_month
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_day
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_dow
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_doy
+                              , subq_8.acquired_ds__day AS metric_time__day
+                              , subq_8.acquired_ds__week AS metric_time__week
+                              , subq_8.acquired_ds__month AS metric_time__month
+                              , subq_8.acquired_ds__quarter AS metric_time__quarter
+                              , subq_8.acquired_ds__year AS metric_time__year
+                              , subq_8.acquired_ds__extract_year AS metric_time__extract_year
+                              , subq_8.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_8.acquired_ds__extract_month AS metric_time__extract_month
+                              , subq_8.acquired_ds__extract_day AS metric_time__extract_day
+                              , subq_8.acquired_ds__extract_dow AS metric_time__extract_dow
+                              , subq_8.acquired_ds__extract_doy AS metric_time__extract_doy
+                              , subq_8.customer_id
+                              , subq_8.customer_third_hop_id
+                              , subq_8.customer_id__customer_third_hop_id
+                              , subq_8.customer_third_hop_id__customer_id
+                              , subq_8.country
+                              , subq_8.customer_id__country
+                              , subq_8.customer_third_hop_id__country
+                              , subq_8.customers_with_other_data
                             FROM (
                               -- Read Elements From Semantic Model 'customer_other_data'
                               SELECT
@@ -664,31 +664,31 @@ FROM (
                                 , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                                 , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                               FROM ***************************.customer_other_data customer_other_data_src_22000
-                            ) subq_26
-                          ) subq_27
-                        ) subq_28
+                            ) subq_8
+                          ) subq_9
+                        ) subq_10
                         ON
-                          subq_25.customer_id = subq_28.customer_id
-                      ) subq_29
-                    ) subq_30
+                          subq_7.customer_id = subq_10.customer_id
+                      ) subq_11
+                    ) subq_12
                     ON
                       (
-                        subq_23.account_id = subq_30.account_id
+                        subq_5.account_id = subq_12.account_id
                       ) AND (
-                        subq_23.ds_partitioned__day = subq_30.ds_partitioned__day
+                        subq_5.ds_partitioned__day = subq_12.ds_partitioned__day
                       )
-                  ) subq_31
-                ) subq_32
+                  ) subq_13
+                ) subq_14
                 GROUP BY
-                  subq_32.account_id__customer_id__customer_third_hop_id
-              ) subq_33
-            ) subq_34
-          ) subq_35
+                  subq_14.account_id__customer_id__customer_third_hop_id
+              ) subq_15
+            ) subq_16
+          ) subq_17
           ON
-            subq_20.customer_third_hop_id = subq_35.account_id__customer_id__customer_third_hop_id
-        ) subq_36
-      ) subq_37
+            subq_2.customer_third_hop_id = subq_17.account_id__customer_id__customer_third_hop_id
+        ) subq_18
+      ) subq_19
       WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2
-    ) subq_38
-  ) subq_39
-) subq_40
+    ) subq_20
+  ) subq_21
+) subq_22

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_40.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_35.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_71
+    ) subq_35
     ON
       (
-        account_month_txns_src_22000.account_id = subq_71.account_id
+        account_month_txns_src_22000.account_id = subq_35.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_35.ds_partitioned__day
       )
     GROUP BY
-      subq_71.customer_id__customer_third_hop_id
-  ) subq_76
+      subq_35.customer_id__customer_third_hop_id
+  ) subq_40
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
-) subq_78
+    third_hop_table_src_22000.customer_third_hop_id = subq_40.account_id__customer_id__customer_third_hop_id
+) subq_42
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_25.third_hop_count
+  subq_16.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_24.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_23.third_hop_count
+      subq_14.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_22.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_22.third_hop_count
+        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_13.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_21.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_21.third_hop_count
+          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_12.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.customer_third_hop_id AS customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-            , subq_11.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_10.customer_third_hop_id
-              , subq_10.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_9.third_hop_ds__day
-                , subq_9.third_hop_ds__week
-                , subq_9.third_hop_ds__month
-                , subq_9.third_hop_ds__quarter
-                , subq_9.third_hop_ds__year
-                , subq_9.third_hop_ds__extract_year
-                , subq_9.third_hop_ds__extract_quarter
-                , subq_9.third_hop_ds__extract_month
-                , subq_9.third_hop_ds__extract_day
-                , subq_9.third_hop_ds__extract_dow
-                , subq_9.third_hop_ds__extract_doy
-                , subq_9.customer_third_hop_id__third_hop_ds__day
-                , subq_9.customer_third_hop_id__third_hop_ds__week
-                , subq_9.customer_third_hop_id__third_hop_ds__month
-                , subq_9.customer_third_hop_id__third_hop_ds__quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_9.third_hop_ds__day AS metric_time__day
-                , subq_9.third_hop_ds__week AS metric_time__week
-                , subq_9.third_hop_ds__month AS metric_time__month
-                , subq_9.third_hop_ds__quarter AS metric_time__quarter
-                , subq_9.third_hop_ds__year AS metric_time__year
-                , subq_9.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_9.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_9.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_9.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_9.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_9.customer_third_hop_id
-                , subq_9.value
-                , subq_9.customer_third_hop_id__value
-                , subq_9.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,151 +101,151 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_19.customer_id__customer_third_hop_id
-              , subq_19.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_10.customer_id__customer_third_hop_id
+              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_18.customer_id__customer_third_hop_id
-                , subq_18.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_9.customer_id__customer_third_hop_id
+                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_17.customer_id__customer_third_hop_id
-                  , SUM(subq_17.customers_with_other_data) AS customers_with_other_data
+                  subq_8.customer_id__customer_third_hop_id
+                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_16.customer_id__customer_third_hop_id
-                    , subq_16.customers_with_other_data
+                    subq_7.customer_id__customer_third_hop_id
+                    , subq_7.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_15.customer_id__customer_third_hop_id
-                      , subq_15.customer_id__country
-                      , subq_15.customers_with_other_data
+                      subq_6.customer_id__customer_third_hop_id
+                      , subq_6.customer_id__country
+                      , subq_6.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_14.customer_id__customer_third_hop_id
-                        , subq_14.customer_id__country
-                        , subq_14.customers_with_other_data
+                        subq_5.customer_id__customer_third_hop_id
+                        , subq_5.customer_id__country
+                        , subq_5.customers_with_other_data
                       FROM (
                         -- Constrain Output with WHERE
                         SELECT
-                          subq_13.acquired_ds__day
-                          , subq_13.acquired_ds__week
-                          , subq_13.acquired_ds__month
-                          , subq_13.acquired_ds__quarter
-                          , subq_13.acquired_ds__year
-                          , subq_13.acquired_ds__extract_year
-                          , subq_13.acquired_ds__extract_quarter
-                          , subq_13.acquired_ds__extract_month
-                          , subq_13.acquired_ds__extract_day
-                          , subq_13.acquired_ds__extract_dow
-                          , subq_13.acquired_ds__extract_doy
-                          , subq_13.customer_id__acquired_ds__day
-                          , subq_13.customer_id__acquired_ds__week
-                          , subq_13.customer_id__acquired_ds__month
-                          , subq_13.customer_id__acquired_ds__quarter
-                          , subq_13.customer_id__acquired_ds__year
-                          , subq_13.customer_id__acquired_ds__extract_year
-                          , subq_13.customer_id__acquired_ds__extract_quarter
-                          , subq_13.customer_id__acquired_ds__extract_month
-                          , subq_13.customer_id__acquired_ds__extract_day
-                          , subq_13.customer_id__acquired_ds__extract_dow
-                          , subq_13.customer_id__acquired_ds__extract_doy
-                          , subq_13.customer_third_hop_id__acquired_ds__day
-                          , subq_13.customer_third_hop_id__acquired_ds__week
-                          , subq_13.customer_third_hop_id__acquired_ds__month
-                          , subq_13.customer_third_hop_id__acquired_ds__quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_13.metric_time__day
-                          , subq_13.metric_time__week
-                          , subq_13.metric_time__month
-                          , subq_13.metric_time__quarter
-                          , subq_13.metric_time__year
-                          , subq_13.metric_time__extract_year
-                          , subq_13.metric_time__extract_quarter
-                          , subq_13.metric_time__extract_month
-                          , subq_13.metric_time__extract_day
-                          , subq_13.metric_time__extract_dow
-                          , subq_13.metric_time__extract_doy
-                          , subq_13.customer_id
-                          , subq_13.customer_third_hop_id
-                          , subq_13.customer_id__customer_third_hop_id
-                          , subq_13.customer_third_hop_id__customer_id
-                          , subq_13.country
-                          , subq_13.customer_id__country
-                          , subq_13.customer_third_hop_id__country
-                          , subq_13.customers_with_other_data
+                          subq_4.acquired_ds__day
+                          , subq_4.acquired_ds__week
+                          , subq_4.acquired_ds__month
+                          , subq_4.acquired_ds__quarter
+                          , subq_4.acquired_ds__year
+                          , subq_4.acquired_ds__extract_year
+                          , subq_4.acquired_ds__extract_quarter
+                          , subq_4.acquired_ds__extract_month
+                          , subq_4.acquired_ds__extract_day
+                          , subq_4.acquired_ds__extract_dow
+                          , subq_4.acquired_ds__extract_doy
+                          , subq_4.customer_id__acquired_ds__day
+                          , subq_4.customer_id__acquired_ds__week
+                          , subq_4.customer_id__acquired_ds__month
+                          , subq_4.customer_id__acquired_ds__quarter
+                          , subq_4.customer_id__acquired_ds__year
+                          , subq_4.customer_id__acquired_ds__extract_year
+                          , subq_4.customer_id__acquired_ds__extract_quarter
+                          , subq_4.customer_id__acquired_ds__extract_month
+                          , subq_4.customer_id__acquired_ds__extract_day
+                          , subq_4.customer_id__acquired_ds__extract_dow
+                          , subq_4.customer_id__acquired_ds__extract_doy
+                          , subq_4.customer_third_hop_id__acquired_ds__day
+                          , subq_4.customer_third_hop_id__acquired_ds__week
+                          , subq_4.customer_third_hop_id__acquired_ds__month
+                          , subq_4.customer_third_hop_id__acquired_ds__quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_4.metric_time__day
+                          , subq_4.metric_time__week
+                          , subq_4.metric_time__month
+                          , subq_4.metric_time__quarter
+                          , subq_4.metric_time__year
+                          , subq_4.metric_time__extract_year
+                          , subq_4.metric_time__extract_quarter
+                          , subq_4.metric_time__extract_month
+                          , subq_4.metric_time__extract_day
+                          , subq_4.metric_time__extract_dow
+                          , subq_4.metric_time__extract_doy
+                          , subq_4.customer_id
+                          , subq_4.customer_third_hop_id
+                          , subq_4.customer_id__customer_third_hop_id
+                          , subq_4.customer_third_hop_id__customer_id
+                          , subq_4.country
+                          , subq_4.customer_id__country
+                          , subq_4.customer_third_hop_id__country
+                          , subq_4.customers_with_other_data
                         FROM (
                           -- Metric Time Dimension 'acquired_ds'
                           SELECT
-                            subq_12.acquired_ds__day
-                            , subq_12.acquired_ds__week
-                            , subq_12.acquired_ds__month
-                            , subq_12.acquired_ds__quarter
-                            , subq_12.acquired_ds__year
-                            , subq_12.acquired_ds__extract_year
-                            , subq_12.acquired_ds__extract_quarter
-                            , subq_12.acquired_ds__extract_month
-                            , subq_12.acquired_ds__extract_day
-                            , subq_12.acquired_ds__extract_dow
-                            , subq_12.acquired_ds__extract_doy
-                            , subq_12.customer_id__acquired_ds__day
-                            , subq_12.customer_id__acquired_ds__week
-                            , subq_12.customer_id__acquired_ds__month
-                            , subq_12.customer_id__acquired_ds__quarter
-                            , subq_12.customer_id__acquired_ds__year
-                            , subq_12.customer_id__acquired_ds__extract_year
-                            , subq_12.customer_id__acquired_ds__extract_quarter
-                            , subq_12.customer_id__acquired_ds__extract_month
-                            , subq_12.customer_id__acquired_ds__extract_day
-                            , subq_12.customer_id__acquired_ds__extract_dow
-                            , subq_12.customer_id__acquired_ds__extract_doy
-                            , subq_12.customer_third_hop_id__acquired_ds__day
-                            , subq_12.customer_third_hop_id__acquired_ds__week
-                            , subq_12.customer_third_hop_id__acquired_ds__month
-                            , subq_12.customer_third_hop_id__acquired_ds__quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_12.acquired_ds__day AS metric_time__day
-                            , subq_12.acquired_ds__week AS metric_time__week
-                            , subq_12.acquired_ds__month AS metric_time__month
-                            , subq_12.acquired_ds__quarter AS metric_time__quarter
-                            , subq_12.acquired_ds__year AS metric_time__year
-                            , subq_12.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_12.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_12.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_12.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_12.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_12.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_12.customer_id
-                            , subq_12.customer_third_hop_id
-                            , subq_12.customer_id__customer_third_hop_id
-                            , subq_12.customer_third_hop_id__customer_id
-                            , subq_12.country
-                            , subq_12.customer_id__country
-                            , subq_12.customer_third_hop_id__country
-                            , subq_12.customers_with_other_data
+                            subq_3.acquired_ds__day
+                            , subq_3.acquired_ds__week
+                            , subq_3.acquired_ds__month
+                            , subq_3.acquired_ds__quarter
+                            , subq_3.acquired_ds__year
+                            , subq_3.acquired_ds__extract_year
+                            , subq_3.acquired_ds__extract_quarter
+                            , subq_3.acquired_ds__extract_month
+                            , subq_3.acquired_ds__extract_day
+                            , subq_3.acquired_ds__extract_dow
+                            , subq_3.acquired_ds__extract_doy
+                            , subq_3.customer_id__acquired_ds__day
+                            , subq_3.customer_id__acquired_ds__week
+                            , subq_3.customer_id__acquired_ds__month
+                            , subq_3.customer_id__acquired_ds__quarter
+                            , subq_3.customer_id__acquired_ds__year
+                            , subq_3.customer_id__acquired_ds__extract_year
+                            , subq_3.customer_id__acquired_ds__extract_quarter
+                            , subq_3.customer_id__acquired_ds__extract_month
+                            , subq_3.customer_id__acquired_ds__extract_day
+                            , subq_3.customer_id__acquired_ds__extract_dow
+                            , subq_3.customer_id__acquired_ds__extract_doy
+                            , subq_3.customer_third_hop_id__acquired_ds__day
+                            , subq_3.customer_third_hop_id__acquired_ds__week
+                            , subq_3.customer_third_hop_id__acquired_ds__month
+                            , subq_3.customer_third_hop_id__acquired_ds__quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_3.acquired_ds__day AS metric_time__day
+                            , subq_3.acquired_ds__week AS metric_time__week
+                            , subq_3.acquired_ds__month AS metric_time__month
+                            , subq_3.acquired_ds__quarter AS metric_time__quarter
+                            , subq_3.acquired_ds__year AS metric_time__year
+                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                            , subq_3.customer_id
+                            , subq_3.customer_third_hop_id
+                            , subq_3.customer_id__customer_third_hop_id
+                            , subq_3.customer_third_hop_id__customer_id
+                            , subq_3.country
+                            , subq_3.customer_id__country
+                            , subq_3.customer_third_hop_id__country
+                            , subq_3.customers_with_other_data
                           FROM (
                             -- Read Elements From Semantic Model 'customer_other_data'
                             SELECT
@@ -291,24 +291,24 @@ FROM (
                               , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                               , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                             FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_12
-                        ) subq_13
+                          ) subq_3
+                        ) subq_4
                         WHERE customer_id__country = 'paraguay'
-                      ) subq_14
-                    ) subq_15
+                      ) subq_5
+                    ) subq_6
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_16
-                ) subq_17
+                  ) subq_7
+                ) subq_8
                 GROUP BY
-                  subq_17.customer_id__customer_third_hop_id
-              ) subq_18
-            ) subq_19
-          ) subq_20
+                  subq_8.customer_id__customer_third_hop_id
+              ) subq_9
+            ) subq_10
+          ) subq_11
           ON
-            subq_11.customer_third_hop_id = subq_20.customer_id__customer_third_hop_id
-        ) subq_21
-      ) subq_22
+            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
+        ) subq_12
+      ) subq_13
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_23
-  ) subq_24
-) subq_25
+    ) subq_14
+  ) subq_15
+) subq_16

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_39
+      ) subq_21
       WHERE customer_id__country = 'paraguay'
-    ) subq_41
+    ) subq_23
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_46
+  ) subq_28
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
-) subq_48
+    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
+) subq_30
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookers
-        , subq_14.bookers
+        subq_10.listing__bookers
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'listing__bookers']
         SELECT
-          subq_13.listing__bookers
-          , subq_13.bookers
+          subq_9.listing__bookers
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookers AS listing__bookers
-            , subq_6.bookers AS bookers
+            subq_2.listing AS listing
+            , subq_8.listing__bookers AS listing__bookers
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.bookers
+              subq_1.listing
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookers
+              subq_7.listing
+              , subq_7.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookers AS listing__bookers
+                subq_6.listing
+                , subq_6.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , COUNT(DISTINCT subq_9.bookers) AS bookers
+                  subq_5.listing
+                  , COUNT(DISTINCT subq_5.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookers
+                    subq_4.listing
+                    , subq_4.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookers > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_30.listing__bookers AS listing__bookers
-    , subq_24.bookers AS bookers
+    subq_22.listing__bookers AS listing__bookers
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_with_metric_in_where_filter__plan0.sql
@@ -1,112 +1,112 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time__day
-  , subq_17.listings AS active_listings
+  subq_13.metric_time__day
+  , subq_13.listings AS active_listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.metric_time__day
-    , SUM(subq_16.listings) AS listings
+    subq_12.metric_time__day
+    , SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'metric_time__day']
     SELECT
-      subq_15.metric_time__day
-      , subq_15.listings
+      subq_11.metric_time__day
+      , subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.metric_time__day
-        , subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.metric_time__day
+        , subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
         SELECT
-          subq_13.metric_time__day
-          , subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.metric_time__day
+          , subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.metric_time__day AS metric_time__day
-            , subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']
             SELECT
-              subq_5.metric_time__day
-              , subq_5.listing
-              , subq_5.listings
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -167,130 +167,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -383,21 +383,21 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
+    ) subq_11
+  ) subq_12
   GROUP BY
-    subq_16.metric_time__day
-) subq_17
+    subq_12.metric_time__day
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_24.metric_time__day AS metric_time__day
-    , subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_16.metric_time__day AS metric_time__day
+    , subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.user__revenue_all_time
-        , subq_14.listings
+        subq_10.user__revenue_all_time
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__revenue_all_time']
         SELECT
-          subq_13.user__revenue_all_time
-          , subq_13.listings
+          subq_9.user__revenue_all_time
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.user AS user
-            , subq_12.user__revenue_all_time AS user__revenue_all_time
-            , subq_6.listings AS listings
+            subq_2.user AS user
+            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_5.user
-              , subq_5.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,68 +160,68 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__revenue_all_time']
             SELECT
-              subq_11.user
-              , subq_11.user__revenue_all_time
+              subq_7.user
+              , subq_7.user__revenue_all_time
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.user
-                , subq_10.txn_revenue AS user__revenue_all_time
+                subq_6.user
+                , subq_6.txn_revenue AS user__revenue_all_time
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.user
-                  , SUM(subq_9.txn_revenue) AS txn_revenue
+                  subq_5.user
+                  , SUM(subq_5.txn_revenue) AS txn_revenue
                 FROM (
                   -- Pass Only Elements: ['txn_revenue', 'user']
                   SELECT
-                    subq_8.user
-                    , subq_8.txn_revenue
+                    subq_4.user
+                    , subq_4.txn_revenue
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.revenue_instance__ds__day
-                      , subq_7.revenue_instance__ds__week
-                      , subq_7.revenue_instance__ds__month
-                      , subq_7.revenue_instance__ds__quarter
-                      , subq_7.revenue_instance__ds__year
-                      , subq_7.revenue_instance__ds__extract_year
-                      , subq_7.revenue_instance__ds__extract_quarter
-                      , subq_7.revenue_instance__ds__extract_month
-                      , subq_7.revenue_instance__ds__extract_day
-                      , subq_7.revenue_instance__ds__extract_dow
-                      , subq_7.revenue_instance__ds__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.user
-                      , subq_7.revenue_instance__user
-                      , subq_7.txn_revenue
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.revenue_instance__ds__day
+                      , subq_3.revenue_instance__ds__week
+                      , subq_3.revenue_instance__ds__month
+                      , subq_3.revenue_instance__ds__quarter
+                      , subq_3.revenue_instance__ds__year
+                      , subq_3.revenue_instance__ds__extract_year
+                      , subq_3.revenue_instance__ds__extract_quarter
+                      , subq_3.revenue_instance__ds__extract_month
+                      , subq_3.revenue_instance__ds__extract_day
+                      , subq_3.revenue_instance__ds__extract_dow
+                      , subq_3.revenue_instance__ds__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.user
+                      , subq_3.revenue_instance__user
+                      , subq_3.txn_revenue
                     FROM (
                       -- Read Elements From Semantic Model 'revenue'
                       SELECT
@@ -251,19 +251,19 @@ FROM (
                         , revenue_src_28000.user_id AS user
                         , revenue_src_28000.user_id AS revenue_instance__user
                       FROM ***************************.fct_revenue revenue_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.user
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.user
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.user = subq_12.user
-        ) subq_13
-      ) subq_14
+            subq_2.user = subq_8.user
+        ) subq_9
+      ) subq_10
       WHERE user__revenue_all_time > 1
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_30.user__revenue_all_time AS user__revenue_all_time
-    , subq_24.listings AS listings
+    subq_22.user__revenue_all_time AS user__revenue_all_time
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.user = subq_30.user
-) subq_32
+    subq_16.user = subq_22.user
+) subq_24
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__views_times_booking_value
-        , subq_28.listings
+        subq_17.listing__views_times_booking_value
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
         SELECT
-          subq_27.listing__views_times_booking_value
-          , subq_27.listings
+          subq_16.listing__views_times_booking_value
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__views_times_booking_value AS listing__views_times_booking_value
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
             SELECT
-              subq_25.listing
-              , subq_25.listing__views_times_booking_value
+              subq_14.listing
+              , subq_14.listing__views_times_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
+                subq_13.listing
                 , booking_value * views AS listing__views_times_booking_value
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.booking_value) AS booking_value
-                  , MAX(subq_23.views) AS views
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.booking_value) AS booking_value
+                  , MAX(subq_12.views) AS views
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.booking_value
+                    subq_6.listing
+                    , subq_6.booking_value
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.booking_value) AS booking_value
+                      subq_5.listing
+                      , SUM(subq_5.booking_value) AS booking_value
                     FROM (
                       -- Pass Only Elements: ['booking_value', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.booking_value
+                        subq_4.listing
+                        , subq_4.booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,91 +387,91 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.views
+                    subq_11.listing
+                    , subq_11.views
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , SUM(subq_21.views) AS views
+                      subq_10.listing
+                      , SUM(subq_10.views) AS views
                     FROM (
                       -- Pass Only Elements: ['views', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.views
+                        subq_9.listing
+                        , subq_9.views
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.view__ds__day
-                          , subq_19.view__ds__week
-                          , subq_19.view__ds__month
-                          , subq_19.view__ds__quarter
-                          , subq_19.view__ds__year
-                          , subq_19.view__ds__extract_year
-                          , subq_19.view__ds__extract_quarter
-                          , subq_19.view__ds__extract_month
-                          , subq_19.view__ds__extract_day
-                          , subq_19.view__ds__extract_dow
-                          , subq_19.view__ds__extract_doy
-                          , subq_19.view__ds_partitioned__day
-                          , subq_19.view__ds_partitioned__week
-                          , subq_19.view__ds_partitioned__month
-                          , subq_19.view__ds_partitioned__quarter
-                          , subq_19.view__ds_partitioned__year
-                          , subq_19.view__ds_partitioned__extract_year
-                          , subq_19.view__ds_partitioned__extract_quarter
-                          , subq_19.view__ds_partitioned__extract_month
-                          , subq_19.view__ds_partitioned__extract_day
-                          , subq_19.view__ds_partitioned__extract_dow
-                          , subq_19.view__ds_partitioned__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.user
-                          , subq_19.view__listing
-                          , subq_19.view__user
-                          , subq_19.views
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.view__ds__day
+                          , subq_8.view__ds__week
+                          , subq_8.view__ds__month
+                          , subq_8.view__ds__quarter
+                          , subq_8.view__ds__year
+                          , subq_8.view__ds__extract_year
+                          , subq_8.view__ds__extract_quarter
+                          , subq_8.view__ds__extract_month
+                          , subq_8.view__ds__extract_day
+                          , subq_8.view__ds__extract_dow
+                          , subq_8.view__ds__extract_doy
+                          , subq_8.view__ds_partitioned__day
+                          , subq_8.view__ds_partitioned__week
+                          , subq_8.view__ds_partitioned__month
+                          , subq_8.view__ds_partitioned__quarter
+                          , subq_8.view__ds_partitioned__year
+                          , subq_8.view__ds_partitioned__extract_year
+                          , subq_8.view__ds_partitioned__extract_quarter
+                          , subq_8.view__ds_partitioned__extract_month
+                          , subq_8.view__ds_partitioned__extract_day
+                          , subq_8.view__ds_partitioned__extract_dow
+                          , subq_8.view__ds_partitioned__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.user
+                          , subq_8.view__listing
+                          , subq_8.view__user
+                          , subq_8.views
                         FROM (
                           -- Read Elements From Semantic Model 'views_source'
                           SELECT
@@ -525,25 +525,25 @@ FROM (
                             , views_source_src_28000.listing_id AS view__listing
                             , views_source_src_28000.user_id AS view__user
                           FROM ***************************.fct_views views_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__views_times_booking_value > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_45.listings AS listings
+    subq_36.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_50.listing, subq_55.listing) AS listing
-        , MAX(subq_50.booking_value) AS booking_value
-        , MAX(subq_55.views) AS views
+        COALESCE(subq_28.listing, subq_33.listing) AS listing
+        , MAX(subq_28.booking_value) AS booking_value
+        , MAX(subq_33.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_50
+      ) subq_28
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_53
+        ) subq_31
         GROUP BY
           listing
-      ) subq_55
+      ) subq_33
       ON
-        subq_50.listing = subq_55.listing
+        subq_28.listing = subq_33.listing
       GROUP BY
-        COALESCE(subq_50.listing, subq_55.listing)
-    ) subq_56
-  ) subq_58
+        COALESCE(subq_28.listing, subq_33.listing)
+    ) subq_34
+  ) subq_36
   ON
-    subq_45.listing = subq_58.listing
-) subq_60
+    subq_23.listing = subq_36.listing
+) subq_38
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -1,108 +1,108 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_19.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_18.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_17.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.listing__bookings
-        , subq_24.listing__bookers
-        , subq_24.listings
+        subq_16.listing__bookings
+        , subq_16.listing__bookers
+        , subq_16.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
         SELECT
-          subq_23.listing__bookings
-          , subq_23.listing__bookers
-          , subq_23.listings
+          subq_15.listing__bookings
+          , subq_15.listing__bookers
+          , subq_15.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_10.listing AS listing
-            , subq_16.listing__bookings AS listing__bookings
-            , subq_22.listing__bookers AS listing__bookers
-            , subq_10.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']
             SELECT
-              subq_9.listing
-              , subq_9.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_8.ds__day
-                , subq_8.ds__week
-                , subq_8.ds__month
-                , subq_8.ds__quarter
-                , subq_8.ds__year
-                , subq_8.ds__extract_year
-                , subq_8.ds__extract_quarter
-                , subq_8.ds__extract_month
-                , subq_8.ds__extract_day
-                , subq_8.ds__extract_dow
-                , subq_8.ds__extract_doy
-                , subq_8.created_at__day
-                , subq_8.created_at__week
-                , subq_8.created_at__month
-                , subq_8.created_at__quarter
-                , subq_8.created_at__year
-                , subq_8.created_at__extract_year
-                , subq_8.created_at__extract_quarter
-                , subq_8.created_at__extract_month
-                , subq_8.created_at__extract_day
-                , subq_8.created_at__extract_dow
-                , subq_8.created_at__extract_doy
-                , subq_8.listing__ds__day
-                , subq_8.listing__ds__week
-                , subq_8.listing__ds__month
-                , subq_8.listing__ds__quarter
-                , subq_8.listing__ds__year
-                , subq_8.listing__ds__extract_year
-                , subq_8.listing__ds__extract_quarter
-                , subq_8.listing__ds__extract_month
-                , subq_8.listing__ds__extract_day
-                , subq_8.listing__ds__extract_dow
-                , subq_8.listing__ds__extract_doy
-                , subq_8.listing__created_at__day
-                , subq_8.listing__created_at__week
-                , subq_8.listing__created_at__month
-                , subq_8.listing__created_at__quarter
-                , subq_8.listing__created_at__year
-                , subq_8.listing__created_at__extract_year
-                , subq_8.listing__created_at__extract_quarter
-                , subq_8.listing__created_at__extract_month
-                , subq_8.listing__created_at__extract_day
-                , subq_8.listing__created_at__extract_dow
-                , subq_8.listing__created_at__extract_doy
-                , subq_8.ds__day AS metric_time__day
-                , subq_8.ds__week AS metric_time__week
-                , subq_8.ds__month AS metric_time__month
-                , subq_8.ds__quarter AS metric_time__quarter
-                , subq_8.ds__year AS metric_time__year
-                , subq_8.ds__extract_year AS metric_time__extract_year
-                , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_8.ds__extract_month AS metric_time__extract_month
-                , subq_8.ds__extract_day AS metric_time__extract_day
-                , subq_8.ds__extract_dow AS metric_time__extract_dow
-                , subq_8.ds__extract_doy AS metric_time__extract_doy
-                , subq_8.listing
-                , subq_8.user
-                , subq_8.listing__user
-                , subq_8.country_latest
-                , subq_8.is_lux_latest
-                , subq_8.capacity_latest
-                , subq_8.listing__country_latest
-                , subq_8.listing__is_lux_latest
-                , subq_8.listing__capacity_latest
-                , subq_8.listings
-                , subq_8.largest_listing
-                , subq_8.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -163,130 +163,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_8
-            ) subq_9
-          ) subq_10
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_15.listing
-              , subq_15.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_14.listing
-                , subq_14.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_13.listing
-                  , SUM(subq_13.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_12.listing
-                    , subq_12.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_11.ds__day
-                      , subq_11.ds__week
-                      , subq_11.ds__month
-                      , subq_11.ds__quarter
-                      , subq_11.ds__year
-                      , subq_11.ds__extract_year
-                      , subq_11.ds__extract_quarter
-                      , subq_11.ds__extract_month
-                      , subq_11.ds__extract_day
-                      , subq_11.ds__extract_dow
-                      , subq_11.ds__extract_doy
-                      , subq_11.ds_partitioned__day
-                      , subq_11.ds_partitioned__week
-                      , subq_11.ds_partitioned__month
-                      , subq_11.ds_partitioned__quarter
-                      , subq_11.ds_partitioned__year
-                      , subq_11.ds_partitioned__extract_year
-                      , subq_11.ds_partitioned__extract_quarter
-                      , subq_11.ds_partitioned__extract_month
-                      , subq_11.ds_partitioned__extract_day
-                      , subq_11.ds_partitioned__extract_dow
-                      , subq_11.ds_partitioned__extract_doy
-                      , subq_11.paid_at__day
-                      , subq_11.paid_at__week
-                      , subq_11.paid_at__month
-                      , subq_11.paid_at__quarter
-                      , subq_11.paid_at__year
-                      , subq_11.paid_at__extract_year
-                      , subq_11.paid_at__extract_quarter
-                      , subq_11.paid_at__extract_month
-                      , subq_11.paid_at__extract_day
-                      , subq_11.paid_at__extract_dow
-                      , subq_11.paid_at__extract_doy
-                      , subq_11.booking__ds__day
-                      , subq_11.booking__ds__week
-                      , subq_11.booking__ds__month
-                      , subq_11.booking__ds__quarter
-                      , subq_11.booking__ds__year
-                      , subq_11.booking__ds__extract_year
-                      , subq_11.booking__ds__extract_quarter
-                      , subq_11.booking__ds__extract_month
-                      , subq_11.booking__ds__extract_day
-                      , subq_11.booking__ds__extract_dow
-                      , subq_11.booking__ds__extract_doy
-                      , subq_11.booking__ds_partitioned__day
-                      , subq_11.booking__ds_partitioned__week
-                      , subq_11.booking__ds_partitioned__month
-                      , subq_11.booking__ds_partitioned__quarter
-                      , subq_11.booking__ds_partitioned__year
-                      , subq_11.booking__ds_partitioned__extract_year
-                      , subq_11.booking__ds_partitioned__extract_quarter
-                      , subq_11.booking__ds_partitioned__extract_month
-                      , subq_11.booking__ds_partitioned__extract_day
-                      , subq_11.booking__ds_partitioned__extract_dow
-                      , subq_11.booking__ds_partitioned__extract_doy
-                      , subq_11.booking__paid_at__day
-                      , subq_11.booking__paid_at__week
-                      , subq_11.booking__paid_at__month
-                      , subq_11.booking__paid_at__quarter
-                      , subq_11.booking__paid_at__year
-                      , subq_11.booking__paid_at__extract_year
-                      , subq_11.booking__paid_at__extract_quarter
-                      , subq_11.booking__paid_at__extract_month
-                      , subq_11.booking__paid_at__extract_day
-                      , subq_11.booking__paid_at__extract_dow
-                      , subq_11.booking__paid_at__extract_doy
-                      , subq_11.ds__day AS metric_time__day
-                      , subq_11.ds__week AS metric_time__week
-                      , subq_11.ds__month AS metric_time__month
-                      , subq_11.ds__quarter AS metric_time__quarter
-                      , subq_11.ds__year AS metric_time__year
-                      , subq_11.ds__extract_year AS metric_time__extract_year
-                      , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_11.ds__extract_month AS metric_time__extract_month
-                      , subq_11.ds__extract_day AS metric_time__extract_day
-                      , subq_11.ds__extract_dow AS metric_time__extract_dow
-                      , subq_11.ds__extract_doy AS metric_time__extract_doy
-                      , subq_11.listing
-                      , subq_11.guest
-                      , subq_11.host
-                      , subq_11.booking__listing
-                      , subq_11.booking__guest
-                      , subq_11.booking__host
-                      , subq_11.is_instant
-                      , subq_11.booking__is_instant
-                      , subq_11.bookings
-                      , subq_11.instant_bookings
-                      , subq_11.booking_value
-                      , subq_11.max_booking_value
-                      , subq_11.min_booking_value
-                      , subq_11.bookers
-                      , subq_11.average_booking_value
-                      , subq_11.referred_bookings
-                      , subq_11.median_booking_value
-                      , subq_11.booking_value_p99
-                      , subq_11.discrete_booking_value_p99
-                      , subq_11.approximate_continuous_booking_value_p99
-                      , subq_11.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -379,137 +379,137 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_11
-                  ) subq_12
-                ) subq_13
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_13.listing
-              ) subq_14
-            ) subq_15
-          ) subq_16
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_10.listing = subq_16.listing
+            subq_2.listing = subq_8.listing
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_21.listing
-              , subq_21.listing__bookers
+              subq_13.listing
+              , subq_13.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing
-                , subq_20.bookers AS listing__bookers
+                subq_12.listing
+                , subq_12.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing
-                  , COUNT(DISTINCT subq_19.bookers) AS bookers
+                  subq_11.listing
+                  , COUNT(DISTINCT subq_11.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_18.listing
-                    , subq_18.bookers
+                    subq_10.listing
+                    , subq_10.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.ds_partitioned__day
-                      , subq_17.ds_partitioned__week
-                      , subq_17.ds_partitioned__month
-                      , subq_17.ds_partitioned__quarter
-                      , subq_17.ds_partitioned__year
-                      , subq_17.ds_partitioned__extract_year
-                      , subq_17.ds_partitioned__extract_quarter
-                      , subq_17.ds_partitioned__extract_month
-                      , subq_17.ds_partitioned__extract_day
-                      , subq_17.ds_partitioned__extract_dow
-                      , subq_17.ds_partitioned__extract_doy
-                      , subq_17.paid_at__day
-                      , subq_17.paid_at__week
-                      , subq_17.paid_at__month
-                      , subq_17.paid_at__quarter
-                      , subq_17.paid_at__year
-                      , subq_17.paid_at__extract_year
-                      , subq_17.paid_at__extract_quarter
-                      , subq_17.paid_at__extract_month
-                      , subq_17.paid_at__extract_day
-                      , subq_17.paid_at__extract_dow
-                      , subq_17.paid_at__extract_doy
-                      , subq_17.booking__ds__day
-                      , subq_17.booking__ds__week
-                      , subq_17.booking__ds__month
-                      , subq_17.booking__ds__quarter
-                      , subq_17.booking__ds__year
-                      , subq_17.booking__ds__extract_year
-                      , subq_17.booking__ds__extract_quarter
-                      , subq_17.booking__ds__extract_month
-                      , subq_17.booking__ds__extract_day
-                      , subq_17.booking__ds__extract_dow
-                      , subq_17.booking__ds__extract_doy
-                      , subq_17.booking__ds_partitioned__day
-                      , subq_17.booking__ds_partitioned__week
-                      , subq_17.booking__ds_partitioned__month
-                      , subq_17.booking__ds_partitioned__quarter
-                      , subq_17.booking__ds_partitioned__year
-                      , subq_17.booking__ds_partitioned__extract_year
-                      , subq_17.booking__ds_partitioned__extract_quarter
-                      , subq_17.booking__ds_partitioned__extract_month
-                      , subq_17.booking__ds_partitioned__extract_day
-                      , subq_17.booking__ds_partitioned__extract_dow
-                      , subq_17.booking__ds_partitioned__extract_doy
-                      , subq_17.booking__paid_at__day
-                      , subq_17.booking__paid_at__week
-                      , subq_17.booking__paid_at__month
-                      , subq_17.booking__paid_at__quarter
-                      , subq_17.booking__paid_at__year
-                      , subq_17.booking__paid_at__extract_year
-                      , subq_17.booking__paid_at__extract_quarter
-                      , subq_17.booking__paid_at__extract_month
-                      , subq_17.booking__paid_at__extract_day
-                      , subq_17.booking__paid_at__extract_dow
-                      , subq_17.booking__paid_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.guest
-                      , subq_17.host
-                      , subq_17.booking__listing
-                      , subq_17.booking__guest
-                      , subq_17.booking__host
-                      , subq_17.is_instant
-                      , subq_17.booking__is_instant
-                      , subq_17.bookings
-                      , subq_17.instant_bookings
-                      , subq_17.booking_value
-                      , subq_17.max_booking_value
-                      , subq_17.min_booking_value
-                      , subq_17.bookers
-                      , subq_17.average_booking_value
-                      , subq_17.referred_bookings
-                      , subq_17.median_booking_value
-                      , subq_17.booking_value_p99
-                      , subq_17.discrete_booking_value_p99
-                      , subq_17.approximate_continuous_booking_value_p99
-                      , subq_17.approximate_discrete_booking_value_p99
+                      subq_9.ds__day
+                      , subq_9.ds__week
+                      , subq_9.ds__month
+                      , subq_9.ds__quarter
+                      , subq_9.ds__year
+                      , subq_9.ds__extract_year
+                      , subq_9.ds__extract_quarter
+                      , subq_9.ds__extract_month
+                      , subq_9.ds__extract_day
+                      , subq_9.ds__extract_dow
+                      , subq_9.ds__extract_doy
+                      , subq_9.ds_partitioned__day
+                      , subq_9.ds_partitioned__week
+                      , subq_9.ds_partitioned__month
+                      , subq_9.ds_partitioned__quarter
+                      , subq_9.ds_partitioned__year
+                      , subq_9.ds_partitioned__extract_year
+                      , subq_9.ds_partitioned__extract_quarter
+                      , subq_9.ds_partitioned__extract_month
+                      , subq_9.ds_partitioned__extract_day
+                      , subq_9.ds_partitioned__extract_dow
+                      , subq_9.ds_partitioned__extract_doy
+                      , subq_9.paid_at__day
+                      , subq_9.paid_at__week
+                      , subq_9.paid_at__month
+                      , subq_9.paid_at__quarter
+                      , subq_9.paid_at__year
+                      , subq_9.paid_at__extract_year
+                      , subq_9.paid_at__extract_quarter
+                      , subq_9.paid_at__extract_month
+                      , subq_9.paid_at__extract_day
+                      , subq_9.paid_at__extract_dow
+                      , subq_9.paid_at__extract_doy
+                      , subq_9.booking__ds__day
+                      , subq_9.booking__ds__week
+                      , subq_9.booking__ds__month
+                      , subq_9.booking__ds__quarter
+                      , subq_9.booking__ds__year
+                      , subq_9.booking__ds__extract_year
+                      , subq_9.booking__ds__extract_quarter
+                      , subq_9.booking__ds__extract_month
+                      , subq_9.booking__ds__extract_day
+                      , subq_9.booking__ds__extract_dow
+                      , subq_9.booking__ds__extract_doy
+                      , subq_9.booking__ds_partitioned__day
+                      , subq_9.booking__ds_partitioned__week
+                      , subq_9.booking__ds_partitioned__month
+                      , subq_9.booking__ds_partitioned__quarter
+                      , subq_9.booking__ds_partitioned__year
+                      , subq_9.booking__ds_partitioned__extract_year
+                      , subq_9.booking__ds_partitioned__extract_quarter
+                      , subq_9.booking__ds_partitioned__extract_month
+                      , subq_9.booking__ds_partitioned__extract_day
+                      , subq_9.booking__ds_partitioned__extract_dow
+                      , subq_9.booking__ds_partitioned__extract_doy
+                      , subq_9.booking__paid_at__day
+                      , subq_9.booking__paid_at__week
+                      , subq_9.booking__paid_at__month
+                      , subq_9.booking__paid_at__quarter
+                      , subq_9.booking__paid_at__year
+                      , subq_9.booking__paid_at__extract_year
+                      , subq_9.booking__paid_at__extract_quarter
+                      , subq_9.booking__paid_at__extract_month
+                      , subq_9.booking__paid_at__extract_day
+                      , subq_9.booking__paid_at__extract_dow
+                      , subq_9.booking__paid_at__extract_doy
+                      , subq_9.ds__day AS metric_time__day
+                      , subq_9.ds__week AS metric_time__week
+                      , subq_9.ds__month AS metric_time__month
+                      , subq_9.ds__quarter AS metric_time__quarter
+                      , subq_9.ds__year AS metric_time__year
+                      , subq_9.ds__extract_year AS metric_time__extract_year
+                      , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_9.ds__extract_month AS metric_time__extract_month
+                      , subq_9.ds__extract_day AS metric_time__extract_day
+                      , subq_9.ds__extract_dow AS metric_time__extract_dow
+                      , subq_9.ds__extract_doy AS metric_time__extract_doy
+                      , subq_9.listing
+                      , subq_9.guest
+                      , subq_9.host
+                      , subq_9.booking__listing
+                      , subq_9.booking__guest
+                      , subq_9.booking__host
+                      , subq_9.is_instant
+                      , subq_9.booking__is_instant
+                      , subq_9.bookings
+                      , subq_9.instant_bookings
+                      , subq_9.booking_value
+                      , subq_9.max_booking_value
+                      , subq_9.min_booking_value
+                      , subq_9.bookers
+                      , subq_9.average_booking_value
+                      , subq_9.referred_bookings
+                      , subq_9.median_booking_value
+                      , subq_9.booking_value_p99
+                      , subq_9.discrete_booking_value_p99
+                      , subq_9.approximate_continuous_booking_value_p99
+                      , subq_9.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -602,19 +602,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_9
+                  ) subq_10
+                ) subq_11
                 GROUP BY
-                  subq_19.listing
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_11.listing
+              ) subq_12
+            ) subq_13
+          ) subq_14
           ON
-            subq_10.listing = subq_22.listing
-        ) subq_23
-      ) subq_24
+            subq_2.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       WHERE listing__bookings > 2 AND listing__bookers > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_17
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_44.listing__bookings AS listing__bookings
-    , subq_50.listing__bookers AS listing__bookers
-    , subq_38.listings AS listings
+    subq_28.listing__bookings AS listing__bookings
+    , subq_34.listing__bookers AS listing__bookers
+    , subq_22.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_38
+  ) subq_22
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_41
+    ) subq_25
     GROUP BY
       listing
-  ) subq_44
+  ) subq_28
   ON
-    subq_38.listing = subq_44.listing
+    subq_22.listing = subq_28.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_50
+  ) subq_34
   ON
-    subq_38.listing = subq_50.listing
-) subq_52
+    subq_22.listing = subq_34.listing
+) subq_36
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__bookings_per_booker
-        , subq_28.listings
+        subq_17.listing__bookings_per_booker
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
         SELECT
-          subq_27.listing__bookings_per_booker
-          , subq_27.listings
+          subq_16.listing__bookings_per_booker
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__bookings_per_booker AS listing__bookings_per_booker
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings_per_booker']
             SELECT
-              subq_25.listing
-              , subq_25.listing__bookings_per_booker
+              subq_14.listing
+              , subq_14.listing__bookings_per_booker
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
-                , CAST(subq_24.bookings AS DOUBLE) / CAST(NULLIF(subq_24.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+                subq_13.listing
+                , CAST(subq_13.bookings AS DOUBLE) / CAST(NULLIF(subq_13.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.bookings) AS bookings
-                  , MAX(subq_23.bookers) AS bookers
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.bookings) AS bookings
+                  , MAX(subq_12.bookers) AS bookers
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.bookings
+                    subq_6.listing
+                    , subq_6.bookings
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.bookings) AS bookings
+                      subq_5.listing
+                      , SUM(subq_5.bookings) AS bookings
                     FROM (
                       -- Pass Only Elements: ['bookings', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.bookings
+                        subq_4.listing
+                        , subq_4.bookings
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,129 +387,129 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.bookers
+                    subq_11.listing
+                    , subq_11.bookers
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , COUNT(DISTINCT subq_21.bookers) AS bookers
+                      subq_10.listing
+                      , COUNT(DISTINCT subq_10.bookers) AS bookers
                     FROM (
                       -- Pass Only Elements: ['bookers', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.bookers
+                        subq_9.listing
+                        , subq_9.bookers
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.paid_at__day
-                          , subq_19.paid_at__week
-                          , subq_19.paid_at__month
-                          , subq_19.paid_at__quarter
-                          , subq_19.paid_at__year
-                          , subq_19.paid_at__extract_year
-                          , subq_19.paid_at__extract_quarter
-                          , subq_19.paid_at__extract_month
-                          , subq_19.paid_at__extract_day
-                          , subq_19.paid_at__extract_dow
-                          , subq_19.paid_at__extract_doy
-                          , subq_19.booking__ds__day
-                          , subq_19.booking__ds__week
-                          , subq_19.booking__ds__month
-                          , subq_19.booking__ds__quarter
-                          , subq_19.booking__ds__year
-                          , subq_19.booking__ds__extract_year
-                          , subq_19.booking__ds__extract_quarter
-                          , subq_19.booking__ds__extract_month
-                          , subq_19.booking__ds__extract_day
-                          , subq_19.booking__ds__extract_dow
-                          , subq_19.booking__ds__extract_doy
-                          , subq_19.booking__ds_partitioned__day
-                          , subq_19.booking__ds_partitioned__week
-                          , subq_19.booking__ds_partitioned__month
-                          , subq_19.booking__ds_partitioned__quarter
-                          , subq_19.booking__ds_partitioned__year
-                          , subq_19.booking__ds_partitioned__extract_year
-                          , subq_19.booking__ds_partitioned__extract_quarter
-                          , subq_19.booking__ds_partitioned__extract_month
-                          , subq_19.booking__ds_partitioned__extract_day
-                          , subq_19.booking__ds_partitioned__extract_dow
-                          , subq_19.booking__ds_partitioned__extract_doy
-                          , subq_19.booking__paid_at__day
-                          , subq_19.booking__paid_at__week
-                          , subq_19.booking__paid_at__month
-                          , subq_19.booking__paid_at__quarter
-                          , subq_19.booking__paid_at__year
-                          , subq_19.booking__paid_at__extract_year
-                          , subq_19.booking__paid_at__extract_quarter
-                          , subq_19.booking__paid_at__extract_month
-                          , subq_19.booking__paid_at__extract_day
-                          , subq_19.booking__paid_at__extract_dow
-                          , subq_19.booking__paid_at__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.guest
-                          , subq_19.host
-                          , subq_19.booking__listing
-                          , subq_19.booking__guest
-                          , subq_19.booking__host
-                          , subq_19.is_instant
-                          , subq_19.booking__is_instant
-                          , subq_19.bookings
-                          , subq_19.instant_bookings
-                          , subq_19.booking_value
-                          , subq_19.max_booking_value
-                          , subq_19.min_booking_value
-                          , subq_19.bookers
-                          , subq_19.average_booking_value
-                          , subq_19.referred_bookings
-                          , subq_19.median_booking_value
-                          , subq_19.booking_value_p99
-                          , subq_19.discrete_booking_value_p99
-                          , subq_19.approximate_continuous_booking_value_p99
-                          , subq_19.approximate_discrete_booking_value_p99
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.paid_at__day
+                          , subq_8.paid_at__week
+                          , subq_8.paid_at__month
+                          , subq_8.paid_at__quarter
+                          , subq_8.paid_at__year
+                          , subq_8.paid_at__extract_year
+                          , subq_8.paid_at__extract_quarter
+                          , subq_8.paid_at__extract_month
+                          , subq_8.paid_at__extract_day
+                          , subq_8.paid_at__extract_dow
+                          , subq_8.paid_at__extract_doy
+                          , subq_8.booking__ds__day
+                          , subq_8.booking__ds__week
+                          , subq_8.booking__ds__month
+                          , subq_8.booking__ds__quarter
+                          , subq_8.booking__ds__year
+                          , subq_8.booking__ds__extract_year
+                          , subq_8.booking__ds__extract_quarter
+                          , subq_8.booking__ds__extract_month
+                          , subq_8.booking__ds__extract_day
+                          , subq_8.booking__ds__extract_dow
+                          , subq_8.booking__ds__extract_doy
+                          , subq_8.booking__ds_partitioned__day
+                          , subq_8.booking__ds_partitioned__week
+                          , subq_8.booking__ds_partitioned__month
+                          , subq_8.booking__ds_partitioned__quarter
+                          , subq_8.booking__ds_partitioned__year
+                          , subq_8.booking__ds_partitioned__extract_year
+                          , subq_8.booking__ds_partitioned__extract_quarter
+                          , subq_8.booking__ds_partitioned__extract_month
+                          , subq_8.booking__ds_partitioned__extract_day
+                          , subq_8.booking__ds_partitioned__extract_dow
+                          , subq_8.booking__ds_partitioned__extract_doy
+                          , subq_8.booking__paid_at__day
+                          , subq_8.booking__paid_at__week
+                          , subq_8.booking__paid_at__month
+                          , subq_8.booking__paid_at__quarter
+                          , subq_8.booking__paid_at__year
+                          , subq_8.booking__paid_at__extract_year
+                          , subq_8.booking__paid_at__extract_quarter
+                          , subq_8.booking__paid_at__extract_month
+                          , subq_8.booking__paid_at__extract_day
+                          , subq_8.booking__paid_at__extract_dow
+                          , subq_8.booking__paid_at__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.guest
+                          , subq_8.host
+                          , subq_8.booking__listing
+                          , subq_8.booking__guest
+                          , subq_8.booking__host
+                          , subq_8.is_instant
+                          , subq_8.booking__is_instant
+                          , subq_8.bookings
+                          , subq_8.instant_bookings
+                          , subq_8.booking_value
+                          , subq_8.max_booking_value
+                          , subq_8.min_booking_value
+                          , subq_8.bookers
+                          , subq_8.average_booking_value
+                          , subq_8.referred_bookings
+                          , subq_8.median_booking_value
+                          , subq_8.booking_value_p99
+                          , subq_8.discrete_booking_value_p99
+                          , subq_8.approximate_continuous_booking_value_p99
+                          , subq_8.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -602,25 +602,25 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__bookings_per_booker > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_56.bookings AS DOUBLE) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
-    , subq_45.listings AS listings
+    CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_50.listing, subq_55.listing) AS listing
-      , MAX(subq_50.bookings) AS bookings
-      , MAX(subq_55.bookers) AS bookers
+      COALESCE(subq_28.listing, subq_33.listing) AS listing
+      , MAX(subq_28.bookings) AS bookings
+      , MAX(subq_33.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_48
+      ) subq_26
       GROUP BY
         listing
-    ) subq_50
+    ) subq_28
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_55
+    ) subq_33
     ON
-      subq_50.listing = subq_55.listing
+      subq_28.listing = subq_33.listing
     GROUP BY
-      COALESCE(subq_50.listing, subq_55.listing)
-  ) subq_56
+      COALESCE(subq_28.listing, subq_33.listing)
+  ) subq_34
   ON
-    subq_45.listing = subq_56.listing
-) subq_60
+    subq_23.listing = subq_34.listing
+) subq_38
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings']
         SELECT
-          subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,130 +160,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -376,19 +376,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -1,20 +1,20 @@
 -- Pass Only Elements: ['listing',]
 SELECT
-  subq_12.listing
+  subq_8.listing
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_11.listing
-    , subq_11.lux_listing
-    , subq_11.listing__lux_listing
-    , subq_11.listing__bookings
+    subq_7.listing
+    , subq_7.lux_listing
+    , subq_7.listing__lux_listing
+    , subq_7.listing__bookings
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_4.listing AS listing
-      , subq_4.lux_listing AS lux_listing
-      , subq_4.listing__lux_listing AS listing__lux_listing
-      , subq_10.listing__bookings AS listing__bookings
+      subq_0.listing AS listing
+      , subq_0.lux_listing AS lux_listing
+      , subq_0.listing__lux_listing AS listing__lux_listing
+      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT
@@ -22,128 +22,128 @@ FROM (
         , lux_listing_mapping_src_28000.lux_listing_id AS lux_listing
         , lux_listing_mapping_src_28000.lux_listing_id AS listing__lux_listing
       FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
-    ) subq_4
+    ) subq_0
     FULL OUTER JOIN (
       -- Pass Only Elements: ['listing', 'listing__bookings']
       SELECT
-        subq_9.listing
-        , subq_9.listing__bookings
+        subq_5.listing
+        , subq_5.listing__bookings
       FROM (
         -- Compute Metrics via Expressions
         SELECT
-          subq_8.listing
-          , subq_8.bookings AS listing__bookings
+          subq_4.listing
+          , subq_4.bookings AS listing__bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_7.listing
-            , SUM(subq_7.bookings) AS bookings
+            subq_3.listing
+            , SUM(subq_3.bookings) AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'listing']
             SELECT
-              subq_6.listing
-              , subq_6.bookings
+              subq_2.listing
+              , subq_2.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds__day
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.ds__extract_year
-                , subq_5.ds__extract_quarter
-                , subq_5.ds__extract_month
-                , subq_5.ds__extract_day
-                , subq_5.ds__extract_dow
-                , subq_5.ds__extract_doy
-                , subq_5.ds_partitioned__day
-                , subq_5.ds_partitioned__week
-                , subq_5.ds_partitioned__month
-                , subq_5.ds_partitioned__quarter
-                , subq_5.ds_partitioned__year
-                , subq_5.ds_partitioned__extract_year
-                , subq_5.ds_partitioned__extract_quarter
-                , subq_5.ds_partitioned__extract_month
-                , subq_5.ds_partitioned__extract_day
-                , subq_5.ds_partitioned__extract_dow
-                , subq_5.ds_partitioned__extract_doy
-                , subq_5.paid_at__day
-                , subq_5.paid_at__week
-                , subq_5.paid_at__month
-                , subq_5.paid_at__quarter
-                , subq_5.paid_at__year
-                , subq_5.paid_at__extract_year
-                , subq_5.paid_at__extract_quarter
-                , subq_5.paid_at__extract_month
-                , subq_5.paid_at__extract_day
-                , subq_5.paid_at__extract_dow
-                , subq_5.paid_at__extract_doy
-                , subq_5.booking__ds__day
-                , subq_5.booking__ds__week
-                , subq_5.booking__ds__month
-                , subq_5.booking__ds__quarter
-                , subq_5.booking__ds__year
-                , subq_5.booking__ds__extract_year
-                , subq_5.booking__ds__extract_quarter
-                , subq_5.booking__ds__extract_month
-                , subq_5.booking__ds__extract_day
-                , subq_5.booking__ds__extract_dow
-                , subq_5.booking__ds__extract_doy
-                , subq_5.booking__ds_partitioned__day
-                , subq_5.booking__ds_partitioned__week
-                , subq_5.booking__ds_partitioned__month
-                , subq_5.booking__ds_partitioned__quarter
-                , subq_5.booking__ds_partitioned__year
-                , subq_5.booking__ds_partitioned__extract_year
-                , subq_5.booking__ds_partitioned__extract_quarter
-                , subq_5.booking__ds_partitioned__extract_month
-                , subq_5.booking__ds_partitioned__extract_day
-                , subq_5.booking__ds_partitioned__extract_dow
-                , subq_5.booking__ds_partitioned__extract_doy
-                , subq_5.booking__paid_at__day
-                , subq_5.booking__paid_at__week
-                , subq_5.booking__paid_at__month
-                , subq_5.booking__paid_at__quarter
-                , subq_5.booking__paid_at__year
-                , subq_5.booking__paid_at__extract_year
-                , subq_5.booking__paid_at__extract_quarter
-                , subq_5.booking__paid_at__extract_month
-                , subq_5.booking__paid_at__extract_day
-                , subq_5.booking__paid_at__extract_dow
-                , subq_5.booking__paid_at__extract_doy
-                , subq_5.ds__day AS metric_time__day
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.ds__extract_year AS metric_time__extract_year
-                , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_5.ds__extract_month AS metric_time__extract_month
-                , subq_5.ds__extract_day AS metric_time__extract_day
-                , subq_5.ds__extract_dow AS metric_time__extract_dow
-                , subq_5.ds__extract_doy AS metric_time__extract_doy
-                , subq_5.listing
-                , subq_5.guest
-                , subq_5.host
-                , subq_5.booking__listing
-                , subq_5.booking__guest
-                , subq_5.booking__host
-                , subq_5.is_instant
-                , subq_5.booking__is_instant
-                , subq_5.bookings
-                , subq_5.instant_bookings
-                , subq_5.booking_value
-                , subq_5.max_booking_value
-                , subq_5.min_booking_value
-                , subq_5.bookers
-                , subq_5.average_booking_value
-                , subq_5.referred_bookings
-                , subq_5.median_booking_value
-                , subq_5.booking_value_p99
-                , subq_5.discrete_booking_value_p99
-                , subq_5.approximate_continuous_booking_value_p99
-                , subq_5.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.ds__day AS metric_time__day
+                , subq_1.ds__week AS metric_time__week
+                , subq_1.ds__month AS metric_time__month
+                , subq_1.ds__quarter AS metric_time__quarter
+                , subq_1.ds__year AS metric_time__year
+                , subq_1.ds__extract_year AS metric_time__extract_year
+                , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_1.ds__extract_month AS metric_time__extract_month
+                , subq_1.ds__extract_day AS metric_time__extract_day
+                , subq_1.ds__extract_dow AS metric_time__extract_dow
+                , subq_1.ds__extract_doy AS metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -236,18 +236,18 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_5
-            ) subq_6
-          ) subq_7
+              ) subq_1
+            ) subq_2
+          ) subq_3
           GROUP BY
-            subq_7.listing
-        ) subq_8
-      ) subq_9
-    ) subq_10
+            subq_3.listing
+        ) subq_4
+      ) subq_5
+    ) subq_6
     ON
-      subq_4.listing = subq_10.listing
-  ) subq_11
+      subq_0.listing = subq_6.listing
+  ) subq_7
   WHERE listing__bookings > 2
-) subq_12
+) subq_8
 GROUP BY
-  subq_12.listing
+  subq_8.listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_23.listing__bookings AS listing__bookings
+    , subq_15.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+    ) subq_12
     GROUP BY
       listing
-  ) subq_23
+  ) subq_15
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_23.listing
-) subq_24
+    lux_listing_mapping_src_28000.listing_id = subq_15.listing
+) subq_16
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.guest__booking_value
-        , subq_14.bookers
+        subq_10.guest__booking_value
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'guest__booking_value']
         SELECT
-          subq_13.guest__booking_value
-          , subq_13.bookers
+          subq_9.guest__booking_value
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.guest AS guest
-            , subq_12.guest__booking_value AS guest__booking_value
-            , subq_6.bookers AS bookers
+            subq_2.guest AS guest
+            , subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']
             SELECT
-              subq_5.guest
-              , subq_5.bookers
+              subq_1.guest
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['guest', 'guest__booking_value']
             SELECT
-              subq_11.guest
-              , subq_11.guest__booking_value
+              subq_7.guest
+              , subq_7.guest__booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.guest
-                , subq_10.booking_value AS guest__booking_value
+                subq_6.guest
+                , subq_6.booking_value AS guest__booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.guest
-                  , SUM(subq_9.booking_value) AS booking_value
+                  subq_5.guest
+                  , SUM(subq_5.booking_value) AS booking_value
                 FROM (
                   -- Pass Only Elements: ['booking_value', 'guest']
                   SELECT
-                    subq_8.guest
-                    , subq_8.booking_value
+                    subq_4.guest
+                    , subq_4.booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.guest
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.guest
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.guest = subq_12.guest
-        ) subq_13
-      ) subq_14
+            subq_2.guest = subq_8.guest
+        ) subq_9
+      ) subq_10
       WHERE guest__booking_value > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_30.guest__booking_value AS guest__booking_value
-    , subq_24.bookers AS bookers
+    subq_22.guest__booking_value AS guest__booking_value
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.guest = subq_30.guest
-) subq_32
+    subq_16.guest = subq_22.guest
+) subq_24
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_39.listings
+  subq_24.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_38.listings) AS listings
+    SUM(subq_23.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_37.listings
+      subq_22.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_36.user__visit_buy_conversion_rate
-        , subq_36.listings
+        subq_21.user__visit_buy_conversion_rate
+        , subq_21.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
         SELECT
-          subq_35.user__visit_buy_conversion_rate
-          , subq_35.listings
+          subq_20.user__visit_buy_conversion_rate
+          , subq_20.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_17.user AS user
-            , subq_34.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
-            , subq_17.listings AS listings
+            subq_2.user AS user
+            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_16.user
-              , subq_16.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_15.ds__day
-                , subq_15.ds__week
-                , subq_15.ds__month
-                , subq_15.ds__quarter
-                , subq_15.ds__year
-                , subq_15.ds__extract_year
-                , subq_15.ds__extract_quarter
-                , subq_15.ds__extract_month
-                , subq_15.ds__extract_day
-                , subq_15.ds__extract_dow
-                , subq_15.ds__extract_doy
-                , subq_15.created_at__day
-                , subq_15.created_at__week
-                , subq_15.created_at__month
-                , subq_15.created_at__quarter
-                , subq_15.created_at__year
-                , subq_15.created_at__extract_year
-                , subq_15.created_at__extract_quarter
-                , subq_15.created_at__extract_month
-                , subq_15.created_at__extract_day
-                , subq_15.created_at__extract_dow
-                , subq_15.created_at__extract_doy
-                , subq_15.listing__ds__day
-                , subq_15.listing__ds__week
-                , subq_15.listing__ds__month
-                , subq_15.listing__ds__quarter
-                , subq_15.listing__ds__year
-                , subq_15.listing__ds__extract_year
-                , subq_15.listing__ds__extract_quarter
-                , subq_15.listing__ds__extract_month
-                , subq_15.listing__ds__extract_day
-                , subq_15.listing__ds__extract_dow
-                , subq_15.listing__ds__extract_doy
-                , subq_15.listing__created_at__day
-                , subq_15.listing__created_at__week
-                , subq_15.listing__created_at__month
-                , subq_15.listing__created_at__quarter
-                , subq_15.listing__created_at__year
-                , subq_15.listing__created_at__extract_year
-                , subq_15.listing__created_at__extract_quarter
-                , subq_15.listing__created_at__extract_month
-                , subq_15.listing__created_at__extract_day
-                , subq_15.listing__created_at__extract_dow
-                , subq_15.listing__created_at__extract_doy
-                , subq_15.ds__day AS metric_time__day
-                , subq_15.ds__week AS metric_time__week
-                , subq_15.ds__month AS metric_time__month
-                , subq_15.ds__quarter AS metric_time__quarter
-                , subq_15.ds__year AS metric_time__year
-                , subq_15.ds__extract_year AS metric_time__extract_year
-                , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_15.ds__extract_month AS metric_time__extract_month
-                , subq_15.ds__extract_day AS metric_time__extract_day
-                , subq_15.ds__extract_dow AS metric_time__extract_dow
-                , subq_15.ds__extract_doy AS metric_time__extract_doy
-                , subq_15.listing
-                , subq_15.user
-                , subq_15.listing__user
-                , subq_15.country_latest
-                , subq_15.is_lux_latest
-                , subq_15.capacity_latest
-                , subq_15.listing__country_latest
-                , subq_15.listing__is_lux_latest
-                , subq_15.listing__capacity_latest
-                , subq_15.listings
-                , subq_15.largest_listing
-                , subq_15.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,79 +160,79 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_15
-            ) subq_16
-          ) subq_17
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__visit_buy_conversion_rate']
             SELECT
-              subq_33.user
-              , subq_33.user__visit_buy_conversion_rate
+              subq_18.user
+              , subq_18.user__visit_buy_conversion_rate
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_32.user
-                , CAST(subq_32.buys AS DOUBLE) / CAST(NULLIF(subq_32.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+                subq_17.user
+                , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_21.user, subq_31.user) AS user
-                  , MAX(subq_21.visits) AS visits
-                  , MAX(subq_31.buys) AS buys
+                  COALESCE(subq_6.user, subq_16.user) AS user
+                  , MAX(subq_6.visits) AS visits
+                  , MAX(subq_16.buys) AS buys
                 FROM (
                   -- Aggregate Measures
                   SELECT
-                    subq_20.user
-                    , SUM(subq_20.visits) AS visits
+                    subq_5.user
+                    , SUM(subq_5.visits) AS visits
                   FROM (
                     -- Pass Only Elements: ['visits', 'user']
                     SELECT
-                      subq_19.user
-                      , subq_19.visits
+                      subq_4.user
+                      , subq_4.visits
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_18.ds__day
-                        , subq_18.ds__week
-                        , subq_18.ds__month
-                        , subq_18.ds__quarter
-                        , subq_18.ds__year
-                        , subq_18.ds__extract_year
-                        , subq_18.ds__extract_quarter
-                        , subq_18.ds__extract_month
-                        , subq_18.ds__extract_day
-                        , subq_18.ds__extract_dow
-                        , subq_18.ds__extract_doy
-                        , subq_18.visit__ds__day
-                        , subq_18.visit__ds__week
-                        , subq_18.visit__ds__month
-                        , subq_18.visit__ds__quarter
-                        , subq_18.visit__ds__year
-                        , subq_18.visit__ds__extract_year
-                        , subq_18.visit__ds__extract_quarter
-                        , subq_18.visit__ds__extract_month
-                        , subq_18.visit__ds__extract_day
-                        , subq_18.visit__ds__extract_dow
-                        , subq_18.visit__ds__extract_doy
-                        , subq_18.ds__day AS metric_time__day
-                        , subq_18.ds__week AS metric_time__week
-                        , subq_18.ds__month AS metric_time__month
-                        , subq_18.ds__quarter AS metric_time__quarter
-                        , subq_18.ds__year AS metric_time__year
-                        , subq_18.ds__extract_year AS metric_time__extract_year
-                        , subq_18.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_18.ds__extract_month AS metric_time__extract_month
-                        , subq_18.ds__extract_day AS metric_time__extract_day
-                        , subq_18.ds__extract_dow AS metric_time__extract_dow
-                        , subq_18.ds__extract_doy AS metric_time__extract_doy
-                        , subq_18.user
-                        , subq_18.session
-                        , subq_18.visit__user
-                        , subq_18.visit__session
-                        , subq_18.referrer_id
-                        , subq_18.visit__referrer_id
-                        , subq_18.visits
-                        , subq_18.visitors
+                        subq_3.ds__day
+                        , subq_3.ds__week
+                        , subq_3.ds__month
+                        , subq_3.ds__quarter
+                        , subq_3.ds__year
+                        , subq_3.ds__extract_year
+                        , subq_3.ds__extract_quarter
+                        , subq_3.ds__extract_month
+                        , subq_3.ds__extract_day
+                        , subq_3.ds__extract_dow
+                        , subq_3.ds__extract_doy
+                        , subq_3.visit__ds__day
+                        , subq_3.visit__ds__week
+                        , subq_3.visit__ds__month
+                        , subq_3.visit__ds__quarter
+                        , subq_3.visit__ds__year
+                        , subq_3.visit__ds__extract_year
+                        , subq_3.visit__ds__extract_quarter
+                        , subq_3.visit__ds__extract_month
+                        , subq_3.visit__ds__extract_day
+                        , subq_3.visit__ds__extract_dow
+                        , subq_3.visit__ds__extract_doy
+                        , subq_3.ds__day AS metric_time__day
+                        , subq_3.ds__week AS metric_time__week
+                        , subq_3.ds__month AS metric_time__month
+                        , subq_3.ds__quarter AS metric_time__quarter
+                        , subq_3.ds__year AS metric_time__year
+                        , subq_3.ds__extract_year AS metric_time__extract_year
+                        , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_3.ds__extract_month AS metric_time__extract_month
+                        , subq_3.ds__extract_day AS metric_time__extract_day
+                        , subq_3.ds__extract_dow AS metric_time__extract_dow
+                        , subq_3.ds__extract_doy AS metric_time__extract_doy
+                        , subq_3.user
+                        , subq_3.session
+                        , subq_3.visit__user
+                        , subq_3.visit__session
+                        , subq_3.referrer_id
+                        , subq_3.visit__referrer_id
+                        , subq_3.visits
+                        , subq_3.visitors
                       FROM (
                         -- Read Elements From Semantic Model 'visits_source'
                         SELECT
@@ -267,108 +267,108 @@ FROM (
                           , visits_source_src_28000.user_id AS visit__user
                           , visits_source_src_28000.session_id AS visit__session
                         FROM ***************************.fct_visits visits_source_src_28000
-                      ) subq_18
-                    ) subq_19
-                  ) subq_20
+                      ) subq_3
+                    ) subq_4
+                  ) subq_5
                   GROUP BY
-                    subq_20.user
-                ) subq_21
+                    subq_5.user
+                ) subq_6
                 FULL OUTER JOIN (
                   -- Aggregate Measures
                   SELECT
-                    subq_30.user
-                    , SUM(subq_30.buys) AS buys
+                    subq_15.user
+                    , SUM(subq_15.buys) AS buys
                   FROM (
                     -- Pass Only Elements: ['buys', 'user']
                     SELECT
-                      subq_29.user
-                      , subq_29.buys
+                      subq_14.user
+                      , subq_14.buys
                     FROM (
                       -- Find conversions for user within the range of INF
                       SELECT
-                        subq_28.ds__day
-                        , subq_28.user
-                        , subq_28.buys
-                        , subq_28.visits
+                        subq_13.ds__day
+                        , subq_13.user
+                        , subq_13.buys
+                        , subq_13.visits
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          FIRST_VALUE(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_9.visits) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , FIRST_VALUE(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_9.ds__day) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , FIRST_VALUE(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_9.user) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS user
-                          , subq_27.mf_internal_uuid AS mf_internal_uuid
-                          , subq_27.buys AS buys
+                          , subq_12.mf_internal_uuid AS mf_internal_uuid
+                          , subq_12.buys AS buys
                         FROM (
                           -- Pass Only Elements: ['visits', 'ds__day', 'user']
                           SELECT
-                            subq_23.ds__day
-                            , subq_23.user
-                            , subq_23.visits
+                            subq_8.ds__day
+                            , subq_8.user
+                            , subq_8.visits
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_22.ds__day
-                              , subq_22.ds__week
-                              , subq_22.ds__month
-                              , subq_22.ds__quarter
-                              , subq_22.ds__year
-                              , subq_22.ds__extract_year
-                              , subq_22.ds__extract_quarter
-                              , subq_22.ds__extract_month
-                              , subq_22.ds__extract_day
-                              , subq_22.ds__extract_dow
-                              , subq_22.ds__extract_doy
-                              , subq_22.visit__ds__day
-                              , subq_22.visit__ds__week
-                              , subq_22.visit__ds__month
-                              , subq_22.visit__ds__quarter
-                              , subq_22.visit__ds__year
-                              , subq_22.visit__ds__extract_year
-                              , subq_22.visit__ds__extract_quarter
-                              , subq_22.visit__ds__extract_month
-                              , subq_22.visit__ds__extract_day
-                              , subq_22.visit__ds__extract_dow
-                              , subq_22.visit__ds__extract_doy
-                              , subq_22.ds__day AS metric_time__day
-                              , subq_22.ds__week AS metric_time__week
-                              , subq_22.ds__month AS metric_time__month
-                              , subq_22.ds__quarter AS metric_time__quarter
-                              , subq_22.ds__year AS metric_time__year
-                              , subq_22.ds__extract_year AS metric_time__extract_year
-                              , subq_22.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_22.ds__extract_month AS metric_time__extract_month
-                              , subq_22.ds__extract_day AS metric_time__extract_day
-                              , subq_22.ds__extract_dow AS metric_time__extract_dow
-                              , subq_22.ds__extract_doy AS metric_time__extract_doy
-                              , subq_22.user
-                              , subq_22.session
-                              , subq_22.visit__user
-                              , subq_22.visit__session
-                              , subq_22.referrer_id
-                              , subq_22.visit__referrer_id
-                              , subq_22.visits
-                              , subq_22.visitors
+                              subq_7.ds__day
+                              , subq_7.ds__week
+                              , subq_7.ds__month
+                              , subq_7.ds__quarter
+                              , subq_7.ds__year
+                              , subq_7.ds__extract_year
+                              , subq_7.ds__extract_quarter
+                              , subq_7.ds__extract_month
+                              , subq_7.ds__extract_day
+                              , subq_7.ds__extract_dow
+                              , subq_7.ds__extract_doy
+                              , subq_7.visit__ds__day
+                              , subq_7.visit__ds__week
+                              , subq_7.visit__ds__month
+                              , subq_7.visit__ds__quarter
+                              , subq_7.visit__ds__year
+                              , subq_7.visit__ds__extract_year
+                              , subq_7.visit__ds__extract_quarter
+                              , subq_7.visit__ds__extract_month
+                              , subq_7.visit__ds__extract_day
+                              , subq_7.visit__ds__extract_dow
+                              , subq_7.visit__ds__extract_doy
+                              , subq_7.ds__day AS metric_time__day
+                              , subq_7.ds__week AS metric_time__week
+                              , subq_7.ds__month AS metric_time__month
+                              , subq_7.ds__quarter AS metric_time__quarter
+                              , subq_7.ds__year AS metric_time__year
+                              , subq_7.ds__extract_year AS metric_time__extract_year
+                              , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_7.ds__extract_month AS metric_time__extract_month
+                              , subq_7.ds__extract_day AS metric_time__extract_day
+                              , subq_7.ds__extract_dow AS metric_time__extract_dow
+                              , subq_7.ds__extract_doy AS metric_time__extract_doy
+                              , subq_7.user
+                              , subq_7.session
+                              , subq_7.visit__user
+                              , subq_7.visit__session
+                              , subq_7.referrer_id
+                              , subq_7.visit__referrer_id
+                              , subq_7.visits
+                              , subq_7.visitors
                             FROM (
                               -- Read Elements From Semantic Model 'visits_source'
                               SELECT
@@ -403,94 +403,94 @@ FROM (
                                 , visits_source_src_28000.user_id AS visit__user
                                 , visits_source_src_28000.session_id AS visit__session
                               FROM ***************************.fct_visits visits_source_src_28000
-                            ) subq_22
-                          ) subq_23
-                        ) subq_24
+                            ) subq_7
+                          ) subq_8
+                        ) subq_9
                         INNER JOIN (
                           -- Add column with generated UUID
                           SELECT
-                            subq_26.ds__day
-                            , subq_26.ds__week
-                            , subq_26.ds__month
-                            , subq_26.ds__quarter
-                            , subq_26.ds__year
-                            , subq_26.ds__extract_year
-                            , subq_26.ds__extract_quarter
-                            , subq_26.ds__extract_month
-                            , subq_26.ds__extract_day
-                            , subq_26.ds__extract_dow
-                            , subq_26.ds__extract_doy
-                            , subq_26.buy__ds__day
-                            , subq_26.buy__ds__week
-                            , subq_26.buy__ds__month
-                            , subq_26.buy__ds__quarter
-                            , subq_26.buy__ds__year
-                            , subq_26.buy__ds__extract_year
-                            , subq_26.buy__ds__extract_quarter
-                            , subq_26.buy__ds__extract_month
-                            , subq_26.buy__ds__extract_day
-                            , subq_26.buy__ds__extract_dow
-                            , subq_26.buy__ds__extract_doy
-                            , subq_26.metric_time__day
-                            , subq_26.metric_time__week
-                            , subq_26.metric_time__month
-                            , subq_26.metric_time__quarter
-                            , subq_26.metric_time__year
-                            , subq_26.metric_time__extract_year
-                            , subq_26.metric_time__extract_quarter
-                            , subq_26.metric_time__extract_month
-                            , subq_26.metric_time__extract_day
-                            , subq_26.metric_time__extract_dow
-                            , subq_26.metric_time__extract_doy
-                            , subq_26.user
-                            , subq_26.session_id
-                            , subq_26.buy__user
-                            , subq_26.buy__session_id
-                            , subq_26.buys
-                            , subq_26.buyers
+                            subq_11.ds__day
+                            , subq_11.ds__week
+                            , subq_11.ds__month
+                            , subq_11.ds__quarter
+                            , subq_11.ds__year
+                            , subq_11.ds__extract_year
+                            , subq_11.ds__extract_quarter
+                            , subq_11.ds__extract_month
+                            , subq_11.ds__extract_day
+                            , subq_11.ds__extract_dow
+                            , subq_11.ds__extract_doy
+                            , subq_11.buy__ds__day
+                            , subq_11.buy__ds__week
+                            , subq_11.buy__ds__month
+                            , subq_11.buy__ds__quarter
+                            , subq_11.buy__ds__year
+                            , subq_11.buy__ds__extract_year
+                            , subq_11.buy__ds__extract_quarter
+                            , subq_11.buy__ds__extract_month
+                            , subq_11.buy__ds__extract_day
+                            , subq_11.buy__ds__extract_dow
+                            , subq_11.buy__ds__extract_doy
+                            , subq_11.metric_time__day
+                            , subq_11.metric_time__week
+                            , subq_11.metric_time__month
+                            , subq_11.metric_time__quarter
+                            , subq_11.metric_time__year
+                            , subq_11.metric_time__extract_year
+                            , subq_11.metric_time__extract_quarter
+                            , subq_11.metric_time__extract_month
+                            , subq_11.metric_time__extract_day
+                            , subq_11.metric_time__extract_dow
+                            , subq_11.metric_time__extract_doy
+                            , subq_11.user
+                            , subq_11.session_id
+                            , subq_11.buy__user
+                            , subq_11.buy__session_id
+                            , subq_11.buys
+                            , subq_11.buyers
                             , GEN_RANDOM_UUID() AS mf_internal_uuid
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_25.ds__day
-                              , subq_25.ds__week
-                              , subq_25.ds__month
-                              , subq_25.ds__quarter
-                              , subq_25.ds__year
-                              , subq_25.ds__extract_year
-                              , subq_25.ds__extract_quarter
-                              , subq_25.ds__extract_month
-                              , subq_25.ds__extract_day
-                              , subq_25.ds__extract_dow
-                              , subq_25.ds__extract_doy
-                              , subq_25.buy__ds__day
-                              , subq_25.buy__ds__week
-                              , subq_25.buy__ds__month
-                              , subq_25.buy__ds__quarter
-                              , subq_25.buy__ds__year
-                              , subq_25.buy__ds__extract_year
-                              , subq_25.buy__ds__extract_quarter
-                              , subq_25.buy__ds__extract_month
-                              , subq_25.buy__ds__extract_day
-                              , subq_25.buy__ds__extract_dow
-                              , subq_25.buy__ds__extract_doy
-                              , subq_25.ds__day AS metric_time__day
-                              , subq_25.ds__week AS metric_time__week
-                              , subq_25.ds__month AS metric_time__month
-                              , subq_25.ds__quarter AS metric_time__quarter
-                              , subq_25.ds__year AS metric_time__year
-                              , subq_25.ds__extract_year AS metric_time__extract_year
-                              , subq_25.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_25.ds__extract_month AS metric_time__extract_month
-                              , subq_25.ds__extract_day AS metric_time__extract_day
-                              , subq_25.ds__extract_dow AS metric_time__extract_dow
-                              , subq_25.ds__extract_doy AS metric_time__extract_doy
-                              , subq_25.user
-                              , subq_25.session_id
-                              , subq_25.buy__user
-                              , subq_25.buy__session_id
-                              , subq_25.buys
-                              , subq_25.buyers
+                              subq_10.ds__day
+                              , subq_10.ds__week
+                              , subq_10.ds__month
+                              , subq_10.ds__quarter
+                              , subq_10.ds__year
+                              , subq_10.ds__extract_year
+                              , subq_10.ds__extract_quarter
+                              , subq_10.ds__extract_month
+                              , subq_10.ds__extract_day
+                              , subq_10.ds__extract_dow
+                              , subq_10.ds__extract_doy
+                              , subq_10.buy__ds__day
+                              , subq_10.buy__ds__week
+                              , subq_10.buy__ds__month
+                              , subq_10.buy__ds__quarter
+                              , subq_10.buy__ds__year
+                              , subq_10.buy__ds__extract_year
+                              , subq_10.buy__ds__extract_quarter
+                              , subq_10.buy__ds__extract_month
+                              , subq_10.buy__ds__extract_day
+                              , subq_10.buy__ds__extract_dow
+                              , subq_10.buy__ds__extract_doy
+                              , subq_10.ds__day AS metric_time__day
+                              , subq_10.ds__week AS metric_time__week
+                              , subq_10.ds__month AS metric_time__month
+                              , subq_10.ds__quarter AS metric_time__quarter
+                              , subq_10.ds__year AS metric_time__year
+                              , subq_10.ds__extract_year AS metric_time__extract_year
+                              , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_10.ds__extract_month AS metric_time__extract_month
+                              , subq_10.ds__extract_day AS metric_time__extract_day
+                              , subq_10.ds__extract_dow AS metric_time__extract_dow
+                              , subq_10.ds__extract_doy AS metric_time__extract_doy
+                              , subq_10.user
+                              , subq_10.session_id
+                              , subq_10.buy__user
+                              , subq_10.buy__session_id
+                              , subq_10.buys
+                              , subq_10.buyers
                             FROM (
                               -- Read Elements From Semantic Model 'buys_source'
                               SELECT
@@ -523,33 +523,33 @@ FROM (
                                 , buys_source_src_28000.user_id AS buy__user
                                 , buys_source_src_28000.session_id AS buy__session_id
                               FROM ***************************.fct_buys buys_source_src_28000
-                            ) subq_25
-                          ) subq_26
-                        ) subq_27
+                            ) subq_10
+                          ) subq_11
+                        ) subq_12
                         ON
                           (
-                            subq_24.user = subq_27.user
+                            subq_9.user = subq_12.user
                           ) AND (
-                            (subq_24.ds__day <= subq_27.ds__day)
+                            (subq_9.ds__day <= subq_12.ds__day)
                           )
-                      ) subq_28
-                    ) subq_29
-                  ) subq_30
+                      ) subq_13
+                    ) subq_14
+                  ) subq_15
                   GROUP BY
-                    subq_30.user
-                ) subq_31
+                    subq_15.user
+                ) subq_16
                 ON
-                  subq_21.user = subq_31.user
+                  subq_6.user = subq_16.user
                 GROUP BY
-                  COALESCE(subq_21.user, subq_31.user)
-              ) subq_32
-            ) subq_33
-          ) subq_34
+                  COALESCE(subq_6.user, subq_16.user)
+              ) subq_17
+            ) subq_18
+          ) subq_19
           ON
-            subq_17.user = subq_34.user
-        ) subq_35
-      ) subq_36
+            subq_2.user = subq_19.user
+        ) subq_20
+      ) subq_21
       WHERE user__visit_buy_conversion_rate > 2
-    ) subq_37
-  ) subq_38
-) subq_39
+    ) subq_22
+  ) subq_23
+) subq_24

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_72.buys AS DOUBLE) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
-    , subq_57.listings AS listings
+    CAST(subq_42.buys AS DOUBLE) / CAST(NULLIF(subq_42.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    , subq_27.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_57
+  ) subq_27
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_61.user, subq_71.user) AS user
-      , MAX(subq_61.visits) AS visits
-      , MAX(subq_71.buys) AS buys
+      COALESCE(subq_31.user, subq_41.user) AS user
+      , MAX(subq_31.visits) AS visits
+      , MAX(subq_41.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_60.user
+        subq_30.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_60
+      ) subq_30
       GROUP BY
-        subq_60.user
-    ) subq_61
+        subq_30.user
+    ) subq_31
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_68.user
+        subq_38.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_64.visits) OVER (
+          FIRST_VALUE(subq_34.visits) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_64.ds__day) OVER (
+          , FIRST_VALUE(subq_34.ds__day) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_64.user) OVER (
+          , FIRST_VALUE(subq_34.user) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_67.mf_internal_uuid AS mf_internal_uuid
-          , subq_67.buys AS buys
+          , subq_37.mf_internal_uuid AS mf_internal_uuid
+          , subq_37.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_64
+        ) subq_34
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , GEN_RANDOM_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_67
+        ) subq_37
         ON
           (
-            subq_64.user = subq_67.user
+            subq_34.user = subq_37.user
           ) AND (
-            (subq_64.ds__day <= subq_67.ds__day)
+            (subq_34.ds__day <= subq_37.ds__day)
           )
-      ) subq_68
+      ) subq_38
       GROUP BY
-        subq_68.user
-    ) subq_71
+        subq_38.user
+    ) subq_41
     ON
-      subq_61.user = subq_71.user
+      subq_31.user = subq_41.user
     GROUP BY
-      COALESCE(subq_61.user, subq_71.user)
-  ) subq_72
+      COALESCE(subq_31.user, subq_41.user)
+  ) subq_42
   ON
-    subq_57.user = subq_72.user
-) subq_76
+    subq_27.user = subq_42.user
+) subq_46
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0.sql
@@ -1,106 +1,106 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_18.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_17.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_16.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.user__listing__user__average_booking_value
-        , subq_24.listings
+        subq_15.user__listing__user__average_booking_value
+        , subq_15.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
         SELECT
-          subq_23.user__listing__user__average_booking_value
-          , subq_23.listings
+          subq_14.user__listing__user__average_booking_value
+          , subq_14.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.user AS user
-            , subq_22.listing__user AS user__listing__user
-            , subq_22.listing__user__average_booking_value AS user__listing__user__average_booking_value
-            , subq_11.listings AS listings
+            subq_2.user AS user
+            , subq_13.listing__user AS user__listing__user
+            , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_10.user
-              , subq_10.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds__day
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds__extract_year
-                , subq_9.ds__extract_quarter
-                , subq_9.ds__extract_month
-                , subq_9.ds__extract_day
-                , subq_9.ds__extract_dow
-                , subq_9.ds__extract_doy
-                , subq_9.created_at__day
-                , subq_9.created_at__week
-                , subq_9.created_at__month
-                , subq_9.created_at__quarter
-                , subq_9.created_at__year
-                , subq_9.created_at__extract_year
-                , subq_9.created_at__extract_quarter
-                , subq_9.created_at__extract_month
-                , subq_9.created_at__extract_day
-                , subq_9.created_at__extract_dow
-                , subq_9.created_at__extract_doy
-                , subq_9.listing__ds__day
-                , subq_9.listing__ds__week
-                , subq_9.listing__ds__month
-                , subq_9.listing__ds__quarter
-                , subq_9.listing__ds__year
-                , subq_9.listing__ds__extract_year
-                , subq_9.listing__ds__extract_quarter
-                , subq_9.listing__ds__extract_month
-                , subq_9.listing__ds__extract_day
-                , subq_9.listing__ds__extract_dow
-                , subq_9.listing__ds__extract_doy
-                , subq_9.listing__created_at__day
-                , subq_9.listing__created_at__week
-                , subq_9.listing__created_at__month
-                , subq_9.listing__created_at__quarter
-                , subq_9.listing__created_at__year
-                , subq_9.listing__created_at__extract_year
-                , subq_9.listing__created_at__extract_quarter
-                , subq_9.listing__created_at__extract_month
-                , subq_9.listing__created_at__extract_day
-                , subq_9.listing__created_at__extract_dow
-                , subq_9.listing__created_at__extract_doy
-                , subq_9.ds__day AS metric_time__day
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.ds__extract_year AS metric_time__extract_year
-                , subq_9.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.ds__extract_month AS metric_time__extract_month
-                , subq_9.ds__extract_day AS metric_time__extract_day
-                , subq_9.ds__extract_dow AS metric_time__extract_dow
-                , subq_9.ds__extract_doy AS metric_time__extract_doy
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.listing__user
-                , subq_9.country_latest
-                , subq_9.is_lux_latest
-                , subq_9.capacity_latest
-                , subq_9.listing__country_latest
-                , subq_9.listing__is_lux_latest
-                , subq_9.listing__capacity_latest
-                , subq_9.listings
-                , subq_9.largest_listing
-                , subq_9.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -161,141 +161,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
             SELECT
-              subq_21.listing__user
-              , subq_21.listing__user__average_booking_value
+              subq_12.listing__user
+              , subq_12.listing__user__average_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing__user
-                , subq_20.average_booking_value AS listing__user__average_booking_value
+                subq_11.listing__user
+                , subq_11.average_booking_value AS listing__user__average_booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing__user
-                  , AVG(subq_19.average_booking_value) AS average_booking_value
+                  subq_10.listing__user
+                  , AVG(subq_10.average_booking_value) AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'listing__user']
                   SELECT
-                    subq_18.listing__user
-                    , subq_18.average_booking_value
+                    subq_9.listing__user
+                    , subq_9.average_booking_value
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_14.listing AS listing
-                      , subq_17.user AS listing__user
-                      , subq_14.average_booking_value AS average_booking_value
+                      subq_5.listing AS listing
+                      , subq_8.user AS listing__user
+                      , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']
                       SELECT
-                        subq_13.listing
-                        , subq_13.average_booking_value
+                        subq_4.listing
+                        , subq_4.average_booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_12.ds__day
-                          , subq_12.ds__week
-                          , subq_12.ds__month
-                          , subq_12.ds__quarter
-                          , subq_12.ds__year
-                          , subq_12.ds__extract_year
-                          , subq_12.ds__extract_quarter
-                          , subq_12.ds__extract_month
-                          , subq_12.ds__extract_day
-                          , subq_12.ds__extract_dow
-                          , subq_12.ds__extract_doy
-                          , subq_12.ds_partitioned__day
-                          , subq_12.ds_partitioned__week
-                          , subq_12.ds_partitioned__month
-                          , subq_12.ds_partitioned__quarter
-                          , subq_12.ds_partitioned__year
-                          , subq_12.ds_partitioned__extract_year
-                          , subq_12.ds_partitioned__extract_quarter
-                          , subq_12.ds_partitioned__extract_month
-                          , subq_12.ds_partitioned__extract_day
-                          , subq_12.ds_partitioned__extract_dow
-                          , subq_12.ds_partitioned__extract_doy
-                          , subq_12.paid_at__day
-                          , subq_12.paid_at__week
-                          , subq_12.paid_at__month
-                          , subq_12.paid_at__quarter
-                          , subq_12.paid_at__year
-                          , subq_12.paid_at__extract_year
-                          , subq_12.paid_at__extract_quarter
-                          , subq_12.paid_at__extract_month
-                          , subq_12.paid_at__extract_day
-                          , subq_12.paid_at__extract_dow
-                          , subq_12.paid_at__extract_doy
-                          , subq_12.booking__ds__day
-                          , subq_12.booking__ds__week
-                          , subq_12.booking__ds__month
-                          , subq_12.booking__ds__quarter
-                          , subq_12.booking__ds__year
-                          , subq_12.booking__ds__extract_year
-                          , subq_12.booking__ds__extract_quarter
-                          , subq_12.booking__ds__extract_month
-                          , subq_12.booking__ds__extract_day
-                          , subq_12.booking__ds__extract_dow
-                          , subq_12.booking__ds__extract_doy
-                          , subq_12.booking__ds_partitioned__day
-                          , subq_12.booking__ds_partitioned__week
-                          , subq_12.booking__ds_partitioned__month
-                          , subq_12.booking__ds_partitioned__quarter
-                          , subq_12.booking__ds_partitioned__year
-                          , subq_12.booking__ds_partitioned__extract_year
-                          , subq_12.booking__ds_partitioned__extract_quarter
-                          , subq_12.booking__ds_partitioned__extract_month
-                          , subq_12.booking__ds_partitioned__extract_day
-                          , subq_12.booking__ds_partitioned__extract_dow
-                          , subq_12.booking__ds_partitioned__extract_doy
-                          , subq_12.booking__paid_at__day
-                          , subq_12.booking__paid_at__week
-                          , subq_12.booking__paid_at__month
-                          , subq_12.booking__paid_at__quarter
-                          , subq_12.booking__paid_at__year
-                          , subq_12.booking__paid_at__extract_year
-                          , subq_12.booking__paid_at__extract_quarter
-                          , subq_12.booking__paid_at__extract_month
-                          , subq_12.booking__paid_at__extract_day
-                          , subq_12.booking__paid_at__extract_dow
-                          , subq_12.booking__paid_at__extract_doy
-                          , subq_12.ds__day AS metric_time__day
-                          , subq_12.ds__week AS metric_time__week
-                          , subq_12.ds__month AS metric_time__month
-                          , subq_12.ds__quarter AS metric_time__quarter
-                          , subq_12.ds__year AS metric_time__year
-                          , subq_12.ds__extract_year AS metric_time__extract_year
-                          , subq_12.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_12.ds__extract_month AS metric_time__extract_month
-                          , subq_12.ds__extract_day AS metric_time__extract_day
-                          , subq_12.ds__extract_dow AS metric_time__extract_dow
-                          , subq_12.ds__extract_doy AS metric_time__extract_doy
-                          , subq_12.listing
-                          , subq_12.guest
-                          , subq_12.host
-                          , subq_12.booking__listing
-                          , subq_12.booking__guest
-                          , subq_12.booking__host
-                          , subq_12.is_instant
-                          , subq_12.booking__is_instant
-                          , subq_12.bookings
-                          , subq_12.instant_bookings
-                          , subq_12.booking_value
-                          , subq_12.max_booking_value
-                          , subq_12.min_booking_value
-                          , subq_12.bookers
-                          , subq_12.average_booking_value
-                          , subq_12.referred_bookings
-                          , subq_12.median_booking_value
-                          , subq_12.booking_value_p99
-                          , subq_12.discrete_booking_value_p99
-                          , subq_12.approximate_continuous_booking_value_p99
-                          , subq_12.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -388,84 +388,84 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_12
-                      ) subq_13
-                    ) subq_14
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['listing', 'user']
                       SELECT
-                        subq_16.listing
-                        , subq_16.user
+                        subq_7.listing
+                        , subq_7.user
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_15.ds__day
-                          , subq_15.ds__week
-                          , subq_15.ds__month
-                          , subq_15.ds__quarter
-                          , subq_15.ds__year
-                          , subq_15.ds__extract_year
-                          , subq_15.ds__extract_quarter
-                          , subq_15.ds__extract_month
-                          , subq_15.ds__extract_day
-                          , subq_15.ds__extract_dow
-                          , subq_15.ds__extract_doy
-                          , subq_15.created_at__day
-                          , subq_15.created_at__week
-                          , subq_15.created_at__month
-                          , subq_15.created_at__quarter
-                          , subq_15.created_at__year
-                          , subq_15.created_at__extract_year
-                          , subq_15.created_at__extract_quarter
-                          , subq_15.created_at__extract_month
-                          , subq_15.created_at__extract_day
-                          , subq_15.created_at__extract_dow
-                          , subq_15.created_at__extract_doy
-                          , subq_15.listing__ds__day
-                          , subq_15.listing__ds__week
-                          , subq_15.listing__ds__month
-                          , subq_15.listing__ds__quarter
-                          , subq_15.listing__ds__year
-                          , subq_15.listing__ds__extract_year
-                          , subq_15.listing__ds__extract_quarter
-                          , subq_15.listing__ds__extract_month
-                          , subq_15.listing__ds__extract_day
-                          , subq_15.listing__ds__extract_dow
-                          , subq_15.listing__ds__extract_doy
-                          , subq_15.listing__created_at__day
-                          , subq_15.listing__created_at__week
-                          , subq_15.listing__created_at__month
-                          , subq_15.listing__created_at__quarter
-                          , subq_15.listing__created_at__year
-                          , subq_15.listing__created_at__extract_year
-                          , subq_15.listing__created_at__extract_quarter
-                          , subq_15.listing__created_at__extract_month
-                          , subq_15.listing__created_at__extract_day
-                          , subq_15.listing__created_at__extract_dow
-                          , subq_15.listing__created_at__extract_doy
-                          , subq_15.ds__day AS metric_time__day
-                          , subq_15.ds__week AS metric_time__week
-                          , subq_15.ds__month AS metric_time__month
-                          , subq_15.ds__quarter AS metric_time__quarter
-                          , subq_15.ds__year AS metric_time__year
-                          , subq_15.ds__extract_year AS metric_time__extract_year
-                          , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_15.ds__extract_month AS metric_time__extract_month
-                          , subq_15.ds__extract_day AS metric_time__extract_day
-                          , subq_15.ds__extract_dow AS metric_time__extract_dow
-                          , subq_15.ds__extract_doy AS metric_time__extract_doy
-                          , subq_15.listing
-                          , subq_15.user
-                          , subq_15.listing__user
-                          , subq_15.country_latest
-                          , subq_15.is_lux_latest
-                          , subq_15.capacity_latest
-                          , subq_15.listing__country_latest
-                          , subq_15.listing__is_lux_latest
-                          , subq_15.listing__capacity_latest
-                          , subq_15.listings
-                          , subq_15.largest_listing
-                          , subq_15.smallest_listing
+                          subq_6.ds__day
+                          , subq_6.ds__week
+                          , subq_6.ds__month
+                          , subq_6.ds__quarter
+                          , subq_6.ds__year
+                          , subq_6.ds__extract_year
+                          , subq_6.ds__extract_quarter
+                          , subq_6.ds__extract_month
+                          , subq_6.ds__extract_day
+                          , subq_6.ds__extract_dow
+                          , subq_6.ds__extract_doy
+                          , subq_6.created_at__day
+                          , subq_6.created_at__week
+                          , subq_6.created_at__month
+                          , subq_6.created_at__quarter
+                          , subq_6.created_at__year
+                          , subq_6.created_at__extract_year
+                          , subq_6.created_at__extract_quarter
+                          , subq_6.created_at__extract_month
+                          , subq_6.created_at__extract_day
+                          , subq_6.created_at__extract_dow
+                          , subq_6.created_at__extract_doy
+                          , subq_6.listing__ds__day
+                          , subq_6.listing__ds__week
+                          , subq_6.listing__ds__month
+                          , subq_6.listing__ds__quarter
+                          , subq_6.listing__ds__year
+                          , subq_6.listing__ds__extract_year
+                          , subq_6.listing__ds__extract_quarter
+                          , subq_6.listing__ds__extract_month
+                          , subq_6.listing__ds__extract_day
+                          , subq_6.listing__ds__extract_dow
+                          , subq_6.listing__ds__extract_doy
+                          , subq_6.listing__created_at__day
+                          , subq_6.listing__created_at__week
+                          , subq_6.listing__created_at__month
+                          , subq_6.listing__created_at__quarter
+                          , subq_6.listing__created_at__year
+                          , subq_6.listing__created_at__extract_year
+                          , subq_6.listing__created_at__extract_quarter
+                          , subq_6.listing__created_at__extract_month
+                          , subq_6.listing__created_at__extract_day
+                          , subq_6.listing__created_at__extract_dow
+                          , subq_6.listing__created_at__extract_doy
+                          , subq_6.ds__day AS metric_time__day
+                          , subq_6.ds__week AS metric_time__week
+                          , subq_6.ds__month AS metric_time__month
+                          , subq_6.ds__quarter AS metric_time__quarter
+                          , subq_6.ds__year AS metric_time__year
+                          , subq_6.ds__extract_year AS metric_time__extract_year
+                          , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_6.ds__extract_month AS metric_time__extract_month
+                          , subq_6.ds__extract_day AS metric_time__extract_day
+                          , subq_6.ds__extract_dow AS metric_time__extract_dow
+                          , subq_6.ds__extract_doy AS metric_time__extract_doy
+                          , subq_6.listing
+                          , subq_6.user
+                          , subq_6.listing__user
+                          , subq_6.country_latest
+                          , subq_6.is_lux_latest
+                          , subq_6.capacity_latest
+                          , subq_6.listing__country_latest
+                          , subq_6.listing__is_lux_latest
+                          , subq_6.listing__capacity_latest
+                          , subq_6.listings
+                          , subq_6.largest_listing
+                          , subq_6.smallest_listing
                         FROM (
                           -- Read Elements From Semantic Model 'listings_latest'
                           SELECT
@@ -526,23 +526,23 @@ FROM (
                             , listings_latest_src_28000.user_id AS user
                             , listings_latest_src_28000.user_id AS listing__user
                           FROM ***************************.dim_listings_latest listings_latest_src_28000
-                        ) subq_15
-                      ) subq_16
-                    ) subq_17
+                        ) subq_6
+                      ) subq_7
+                    ) subq_8
                     ON
-                      subq_14.listing = subq_17.listing
-                  ) subq_18
-                ) subq_19
+                      subq_5.listing = subq_8.listing
+                  ) subq_9
+                ) subq_10
                 GROUP BY
-                  subq_19.listing__user
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_10.listing__user
+              ) subq_11
+            ) subq_12
+          ) subq_13
           ON
-            subq_11.user = subq_22.listing__user
-        ) subq_23
-      ) subq_24
+            subq_2.user = subq_13.listing__user
+        ) subq_14
+      ) subq_15
       WHERE user__listing__user__average_booking_value > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_16
+  ) subq_17
+) subq_18

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_39.listings AS listings
+    subq_32.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_21.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_39
+  ) subq_21
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_50
+  ) subq_32
   ON
-    subq_39.user = subq_50.listing__user
-) subq_52
+    subq_21.user = subq_32.listing__user
+) subq_34
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_multi_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_40.third_hop_count
+  subq_22.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_39.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_21.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_38.third_hop_count
+      subq_20.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_37.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-        , subq_37.third_hop_count
+        subq_19.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+        , subq_19.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
         SELECT
-          subq_36.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-          , subq_36.third_hop_count
+          subq_18.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+          , subq_18.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_20.customer_third_hop_id AS customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-            , subq_20.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_19.customer_third_hop_id
-              , subq_19.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_18.third_hop_ds__day
-                , subq_18.third_hop_ds__week
-                , subq_18.third_hop_ds__month
-                , subq_18.third_hop_ds__quarter
-                , subq_18.third_hop_ds__year
-                , subq_18.third_hop_ds__extract_year
-                , subq_18.third_hop_ds__extract_quarter
-                , subq_18.third_hop_ds__extract_month
-                , subq_18.third_hop_ds__extract_day
-                , subq_18.third_hop_ds__extract_dow
-                , subq_18.third_hop_ds__extract_doy
-                , subq_18.customer_third_hop_id__third_hop_ds__day
-                , subq_18.customer_third_hop_id__third_hop_ds__week
-                , subq_18.customer_third_hop_id__third_hop_ds__month
-                , subq_18.customer_third_hop_id__third_hop_ds__quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_18.third_hop_ds__day AS metric_time__day
-                , subq_18.third_hop_ds__week AS metric_time__week
-                , subq_18.third_hop_ds__month AS metric_time__month
-                , subq_18.third_hop_ds__quarter AS metric_time__quarter
-                , subq_18.third_hop_ds__year AS metric_time__year
-                , subq_18.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_18.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_18.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_18.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_18.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_18.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_18.customer_third_hop_id
-                , subq_18.value
-                , subq_18.customer_third_hop_id__value
-                , subq_18.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,105 +101,105 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_18
-            ) subq_19
-          ) subq_20
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
             SELECT
-              subq_34.account_id__customer_id__customer_third_hop_id
-              , subq_34.account_id__customer_id__customer_third_hop_id__txn_count
+              subq_16.account_id__customer_id__customer_third_hop_id
+              , subq_16.account_id__customer_id__customer_third_hop_id__txn_count
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_33.account_id__customer_id__customer_third_hop_id
-                , subq_33.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
+                subq_15.account_id__customer_id__customer_third_hop_id
+                , subq_15.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_32.account_id__customer_id__customer_third_hop_id
-                  , SUM(subq_32.txn_count) AS txn_count
+                  subq_14.account_id__customer_id__customer_third_hop_id
+                  , SUM(subq_14.txn_count) AS txn_count
                 FROM (
                   -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_third_hop_id']
                   SELECT
-                    subq_31.account_id__customer_id__customer_third_hop_id
-                    , subq_31.txn_count
+                    subq_13.account_id__customer_id__customer_third_hop_id
+                    , subq_13.txn_count
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_23.ds_partitioned__day AS ds_partitioned__day
-                      , subq_30.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_23.account_id AS account_id
-                      , subq_30.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
-                      , subq_23.txn_count AS txn_count
+                      subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
+                      , subq_5.account_id AS account_id
+                      , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
                       SELECT
-                        subq_22.ds_partitioned__day
-                        , subq_22.account_id
-                        , subq_22.txn_count
+                        subq_4.ds_partitioned__day
+                        , subq_4.account_id
+                        , subq_4.txn_count
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_21.ds_partitioned__day
-                          , subq_21.ds_partitioned__week
-                          , subq_21.ds_partitioned__month
-                          , subq_21.ds_partitioned__quarter
-                          , subq_21.ds_partitioned__year
-                          , subq_21.ds_partitioned__extract_year
-                          , subq_21.ds_partitioned__extract_quarter
-                          , subq_21.ds_partitioned__extract_month
-                          , subq_21.ds_partitioned__extract_day
-                          , subq_21.ds_partitioned__extract_dow
-                          , subq_21.ds_partitioned__extract_doy
-                          , subq_21.ds__day
-                          , subq_21.ds__week
-                          , subq_21.ds__month
-                          , subq_21.ds__quarter
-                          , subq_21.ds__year
-                          , subq_21.ds__extract_year
-                          , subq_21.ds__extract_quarter
-                          , subq_21.ds__extract_month
-                          , subq_21.ds__extract_day
-                          , subq_21.ds__extract_dow
-                          , subq_21.ds__extract_doy
-                          , subq_21.account_id__ds_partitioned__day
-                          , subq_21.account_id__ds_partitioned__week
-                          , subq_21.account_id__ds_partitioned__month
-                          , subq_21.account_id__ds_partitioned__quarter
-                          , subq_21.account_id__ds_partitioned__year
-                          , subq_21.account_id__ds_partitioned__extract_year
-                          , subq_21.account_id__ds_partitioned__extract_quarter
-                          , subq_21.account_id__ds_partitioned__extract_month
-                          , subq_21.account_id__ds_partitioned__extract_day
-                          , subq_21.account_id__ds_partitioned__extract_dow
-                          , subq_21.account_id__ds_partitioned__extract_doy
-                          , subq_21.account_id__ds__day
-                          , subq_21.account_id__ds__week
-                          , subq_21.account_id__ds__month
-                          , subq_21.account_id__ds__quarter
-                          , subq_21.account_id__ds__year
-                          , subq_21.account_id__ds__extract_year
-                          , subq_21.account_id__ds__extract_quarter
-                          , subq_21.account_id__ds__extract_month
-                          , subq_21.account_id__ds__extract_day
-                          , subq_21.account_id__ds__extract_dow
-                          , subq_21.account_id__ds__extract_doy
-                          , subq_21.ds__day AS metric_time__day
-                          , subq_21.ds__week AS metric_time__week
-                          , subq_21.ds__month AS metric_time__month
-                          , subq_21.ds__quarter AS metric_time__quarter
-                          , subq_21.ds__year AS metric_time__year
-                          , subq_21.ds__extract_year AS metric_time__extract_year
-                          , subq_21.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_21.ds__extract_month AS metric_time__extract_month
-                          , subq_21.ds__extract_day AS metric_time__extract_day
-                          , subq_21.ds__extract_dow AS metric_time__extract_dow
-                          , subq_21.ds__extract_doy AS metric_time__extract_doy
-                          , subq_21.account_id
-                          , subq_21.account_month
-                          , subq_21.account_id__account_month
-                          , subq_21.txn_count
+                          subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.account_id__ds_partitioned__day
+                          , subq_3.account_id__ds_partitioned__week
+                          , subq_3.account_id__ds_partitioned__month
+                          , subq_3.account_id__ds_partitioned__quarter
+                          , subq_3.account_id__ds_partitioned__year
+                          , subq_3.account_id__ds_partitioned__extract_year
+                          , subq_3.account_id__ds_partitioned__extract_quarter
+                          , subq_3.account_id__ds_partitioned__extract_month
+                          , subq_3.account_id__ds_partitioned__extract_day
+                          , subq_3.account_id__ds_partitioned__extract_dow
+                          , subq_3.account_id__ds_partitioned__extract_doy
+                          , subq_3.account_id__ds__day
+                          , subq_3.account_id__ds__week
+                          , subq_3.account_id__ds__month
+                          , subq_3.account_id__ds__quarter
+                          , subq_3.account_id__ds__year
+                          , subq_3.account_id__ds__extract_year
+                          , subq_3.account_id__ds__extract_quarter
+                          , subq_3.account_id__ds__extract_month
+                          , subq_3.account_id__ds__extract_day
+                          , subq_3.account_id__ds__extract_dow
+                          , subq_3.account_id__ds__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.account_id
+                          , subq_3.account_month
+                          , subq_3.account_id__account_month
+                          , subq_3.txn_count
                         FROM (
                           -- Read Elements From Semantic Model 'account_month_txns'
                           SELECT
@@ -252,164 +252,164 @@ FROM (
                             , account_month_txns_src_22000.account_month AS account_id__account_month
                             , account_month_txns_src_22000.account_id
                           FROM ***************************.account_month_txns account_month_txns_src_22000
-                        ) subq_21
-                      ) subq_22
-                    ) subq_23
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['ds_partitioned__day', 'account_id', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_29.ds_partitioned__day
-                        , subq_29.account_id
-                        , subq_29.customer_id__customer_third_hop_id
+                        subq_11.ds_partitioned__day
+                        , subq_11.account_id
+                        , subq_11.customer_id__customer_third_hop_id
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_25.ds_partitioned__day AS ds_partitioned__day
-                          , subq_25.ds_partitioned__week AS ds_partitioned__week
-                          , subq_25.ds_partitioned__month AS ds_partitioned__month
-                          , subq_25.ds_partitioned__quarter AS ds_partitioned__quarter
-                          , subq_25.ds_partitioned__year AS ds_partitioned__year
-                          , subq_25.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                          , subq_25.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                          , subq_25.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                          , subq_25.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                          , subq_25.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                          , subq_25.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                          , subq_25.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-                          , subq_25.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-                          , subq_25.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-                          , subq_25.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-                          , subq_25.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-                          , subq_25.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-                          , subq_25.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-                          , subq_25.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-                          , subq_25.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-                          , subq_25.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-                          , subq_25.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-                          , subq_25.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-                          , subq_25.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-                          , subq_25.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-                          , subq_25.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-                          , subq_25.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-                          , subq_25.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-                          , subq_25.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-                          , subq_25.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-                          , subq_25.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-                          , subq_25.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-                          , subq_25.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-                          , subq_25.metric_time__day AS metric_time__day
-                          , subq_25.metric_time__week AS metric_time__week
-                          , subq_25.metric_time__month AS metric_time__month
-                          , subq_25.metric_time__quarter AS metric_time__quarter
-                          , subq_25.metric_time__year AS metric_time__year
-                          , subq_25.metric_time__extract_year AS metric_time__extract_year
-                          , subq_25.metric_time__extract_quarter AS metric_time__extract_quarter
-                          , subq_25.metric_time__extract_month AS metric_time__extract_month
-                          , subq_25.metric_time__extract_day AS metric_time__extract_day
-                          , subq_25.metric_time__extract_dow AS metric_time__extract_dow
-                          , subq_25.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_28.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_28.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_28.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_28.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_28.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_28.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_28.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_28.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_28.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_28.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_28.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_28.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_28.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_28.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_28.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_28.metric_time__day AS customer_id__metric_time__day
-                          , subq_28.metric_time__week AS customer_id__metric_time__week
-                          , subq_28.metric_time__month AS customer_id__metric_time__month
-                          , subq_28.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_28.metric_time__year AS customer_id__metric_time__year
-                          , subq_28.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_28.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_28.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_28.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_28.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_28.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-                          , subq_25.account_id AS account_id
-                          , subq_25.customer_id AS customer_id
-                          , subq_25.account_id__customer_id AS account_id__customer_id
-                          , subq_25.bridge_account__account_id AS bridge_account__account_id
-                          , subq_25.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_28.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_28.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
-                          , subq_25.extra_dim AS extra_dim
-                          , subq_25.account_id__extra_dim AS account_id__extra_dim
-                          , subq_25.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_28.country AS customer_id__country
-                          , subq_28.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
-                          , subq_25.account_customer_combos AS account_customer_combos
+                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          , subq_7.ds_partitioned__week AS ds_partitioned__week
+                          , subq_7.ds_partitioned__month AS ds_partitioned__month
+                          , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+                          , subq_7.ds_partitioned__year AS ds_partitioned__year
+                          , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                          , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                          , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                          , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                          , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                          , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                          , subq_7.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+                          , subq_7.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+                          , subq_7.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+                          , subq_7.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+                          , subq_7.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+                          , subq_7.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+                          , subq_7.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+                          , subq_7.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+                          , subq_7.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+                          , subq_7.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+                          , subq_7.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+                          , subq_7.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+                          , subq_7.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+                          , subq_7.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+                          , subq_7.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+                          , subq_7.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+                          , subq_7.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+                          , subq_7.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+                          , subq_7.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+                          , subq_7.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+                          , subq_7.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+                          , subq_7.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+                          , subq_7.metric_time__day AS metric_time__day
+                          , subq_7.metric_time__week AS metric_time__week
+                          , subq_7.metric_time__month AS metric_time__month
+                          , subq_7.metric_time__quarter AS metric_time__quarter
+                          , subq_7.metric_time__year AS metric_time__year
+                          , subq_7.metric_time__extract_year AS metric_time__extract_year
+                          , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+                          , subq_7.metric_time__extract_month AS metric_time__extract_month
+                          , subq_7.metric_time__extract_day AS metric_time__extract_day
+                          , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+                          , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_7.account_id AS account_id
+                          , subq_7.customer_id AS customer_id
+                          , subq_7.account_id__customer_id AS account_id__customer_id
+                          , subq_7.bridge_account__account_id AS bridge_account__account_id
+                          , subq_7.bridge_account__customer_id AS bridge_account__customer_id
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.extra_dim AS extra_dim
+                          , subq_7.account_id__extra_dim AS account_id__extra_dim
+                          , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
+                          , subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'
                           SELECT
-                            subq_24.ds_partitioned__day
-                            , subq_24.ds_partitioned__week
-                            , subq_24.ds_partitioned__month
-                            , subq_24.ds_partitioned__quarter
-                            , subq_24.ds_partitioned__year
-                            , subq_24.ds_partitioned__extract_year
-                            , subq_24.ds_partitioned__extract_quarter
-                            , subq_24.ds_partitioned__extract_month
-                            , subq_24.ds_partitioned__extract_day
-                            , subq_24.ds_partitioned__extract_dow
-                            , subq_24.ds_partitioned__extract_doy
-                            , subq_24.account_id__ds_partitioned__day
-                            , subq_24.account_id__ds_partitioned__week
-                            , subq_24.account_id__ds_partitioned__month
-                            , subq_24.account_id__ds_partitioned__quarter
-                            , subq_24.account_id__ds_partitioned__year
-                            , subq_24.account_id__ds_partitioned__extract_year
-                            , subq_24.account_id__ds_partitioned__extract_quarter
-                            , subq_24.account_id__ds_partitioned__extract_month
-                            , subq_24.account_id__ds_partitioned__extract_day
-                            , subq_24.account_id__ds_partitioned__extract_dow
-                            , subq_24.account_id__ds_partitioned__extract_doy
-                            , subq_24.bridge_account__ds_partitioned__day
-                            , subq_24.bridge_account__ds_partitioned__week
-                            , subq_24.bridge_account__ds_partitioned__month
-                            , subq_24.bridge_account__ds_partitioned__quarter
-                            , subq_24.bridge_account__ds_partitioned__year
-                            , subq_24.bridge_account__ds_partitioned__extract_year
-                            , subq_24.bridge_account__ds_partitioned__extract_quarter
-                            , subq_24.bridge_account__ds_partitioned__extract_month
-                            , subq_24.bridge_account__ds_partitioned__extract_day
-                            , subq_24.bridge_account__ds_partitioned__extract_dow
-                            , subq_24.bridge_account__ds_partitioned__extract_doy
-                            , subq_24.ds_partitioned__day AS metric_time__day
-                            , subq_24.ds_partitioned__week AS metric_time__week
-                            , subq_24.ds_partitioned__month AS metric_time__month
-                            , subq_24.ds_partitioned__quarter AS metric_time__quarter
-                            , subq_24.ds_partitioned__year AS metric_time__year
-                            , subq_24.ds_partitioned__extract_year AS metric_time__extract_year
-                            , subq_24.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                            , subq_24.ds_partitioned__extract_month AS metric_time__extract_month
-                            , subq_24.ds_partitioned__extract_day AS metric_time__extract_day
-                            , subq_24.ds_partitioned__extract_dow AS metric_time__extract_dow
-                            , subq_24.ds_partitioned__extract_doy AS metric_time__extract_doy
-                            , subq_24.account_id
-                            , subq_24.customer_id
-                            , subq_24.account_id__customer_id
-                            , subq_24.bridge_account__account_id
-                            , subq_24.bridge_account__customer_id
-                            , subq_24.extra_dim
-                            , subq_24.account_id__extra_dim
-                            , subq_24.bridge_account__extra_dim
-                            , subq_24.account_customer_combos
+                            subq_6.ds_partitioned__day
+                            , subq_6.ds_partitioned__week
+                            , subq_6.ds_partitioned__month
+                            , subq_6.ds_partitioned__quarter
+                            , subq_6.ds_partitioned__year
+                            , subq_6.ds_partitioned__extract_year
+                            , subq_6.ds_partitioned__extract_quarter
+                            , subq_6.ds_partitioned__extract_month
+                            , subq_6.ds_partitioned__extract_day
+                            , subq_6.ds_partitioned__extract_dow
+                            , subq_6.ds_partitioned__extract_doy
+                            , subq_6.account_id__ds_partitioned__day
+                            , subq_6.account_id__ds_partitioned__week
+                            , subq_6.account_id__ds_partitioned__month
+                            , subq_6.account_id__ds_partitioned__quarter
+                            , subq_6.account_id__ds_partitioned__year
+                            , subq_6.account_id__ds_partitioned__extract_year
+                            , subq_6.account_id__ds_partitioned__extract_quarter
+                            , subq_6.account_id__ds_partitioned__extract_month
+                            , subq_6.account_id__ds_partitioned__extract_day
+                            , subq_6.account_id__ds_partitioned__extract_dow
+                            , subq_6.account_id__ds_partitioned__extract_doy
+                            , subq_6.bridge_account__ds_partitioned__day
+                            , subq_6.bridge_account__ds_partitioned__week
+                            , subq_6.bridge_account__ds_partitioned__month
+                            , subq_6.bridge_account__ds_partitioned__quarter
+                            , subq_6.bridge_account__ds_partitioned__year
+                            , subq_6.bridge_account__ds_partitioned__extract_year
+                            , subq_6.bridge_account__ds_partitioned__extract_quarter
+                            , subq_6.bridge_account__ds_partitioned__extract_month
+                            , subq_6.bridge_account__ds_partitioned__extract_day
+                            , subq_6.bridge_account__ds_partitioned__extract_dow
+                            , subq_6.bridge_account__ds_partitioned__extract_doy
+                            , subq_6.ds_partitioned__day AS metric_time__day
+                            , subq_6.ds_partitioned__week AS metric_time__week
+                            , subq_6.ds_partitioned__month AS metric_time__month
+                            , subq_6.ds_partitioned__quarter AS metric_time__quarter
+                            , subq_6.ds_partitioned__year AS metric_time__year
+                            , subq_6.ds_partitioned__extract_year AS metric_time__extract_year
+                            , subq_6.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                            , subq_6.ds_partitioned__extract_month AS metric_time__extract_month
+                            , subq_6.ds_partitioned__extract_day AS metric_time__extract_day
+                            , subq_6.ds_partitioned__extract_dow AS metric_time__extract_dow
+                            , subq_6.ds_partitioned__extract_doy AS metric_time__extract_doy
+                            , subq_6.account_id
+                            , subq_6.customer_id
+                            , subq_6.account_id__customer_id
+                            , subq_6.bridge_account__account_id
+                            , subq_6.bridge_account__customer_id
+                            , subq_6.extra_dim
+                            , subq_6.account_id__extra_dim
+                            , subq_6.bridge_account__extra_dim
+                            , subq_6.account_customer_combos
                           FROM (
                             -- Read Elements From Semantic Model 'bridge_table'
                             SELECT
@@ -456,8 +456,8 @@ FROM (
                               , bridge_table_src_22000.account_id AS bridge_account__account_id
                               , bridge_table_src_22000.customer_id AS bridge_account__customer_id
                             FROM ***************************.bridge_table bridge_table_src_22000
-                          ) subq_24
-                        ) subq_25
+                          ) subq_6
+                        ) subq_7
                         LEFT OUTER JOIN (
                           -- Pass Only Elements: [
                           --   'country',
@@ -513,112 +513,112 @@ FROM (
                           --   'customer_third_hop_id__customer_id',
                           -- ]
                           SELECT
-                            subq_27.acquired_ds__day
-                            , subq_27.acquired_ds__week
-                            , subq_27.acquired_ds__month
-                            , subq_27.acquired_ds__quarter
-                            , subq_27.acquired_ds__year
-                            , subq_27.acquired_ds__extract_year
-                            , subq_27.acquired_ds__extract_quarter
-                            , subq_27.acquired_ds__extract_month
-                            , subq_27.acquired_ds__extract_day
-                            , subq_27.acquired_ds__extract_dow
-                            , subq_27.acquired_ds__extract_doy
-                            , subq_27.customer_id__acquired_ds__day
-                            , subq_27.customer_id__acquired_ds__week
-                            , subq_27.customer_id__acquired_ds__month
-                            , subq_27.customer_id__acquired_ds__quarter
-                            , subq_27.customer_id__acquired_ds__year
-                            , subq_27.customer_id__acquired_ds__extract_year
-                            , subq_27.customer_id__acquired_ds__extract_quarter
-                            , subq_27.customer_id__acquired_ds__extract_month
-                            , subq_27.customer_id__acquired_ds__extract_day
-                            , subq_27.customer_id__acquired_ds__extract_dow
-                            , subq_27.customer_id__acquired_ds__extract_doy
-                            , subq_27.customer_third_hop_id__acquired_ds__day
-                            , subq_27.customer_third_hop_id__acquired_ds__week
-                            , subq_27.customer_third_hop_id__acquired_ds__month
-                            , subq_27.customer_third_hop_id__acquired_ds__quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_27.metric_time__day
-                            , subq_27.metric_time__week
-                            , subq_27.metric_time__month
-                            , subq_27.metric_time__quarter
-                            , subq_27.metric_time__year
-                            , subq_27.metric_time__extract_year
-                            , subq_27.metric_time__extract_quarter
-                            , subq_27.metric_time__extract_month
-                            , subq_27.metric_time__extract_day
-                            , subq_27.metric_time__extract_dow
-                            , subq_27.metric_time__extract_doy
-                            , subq_27.customer_id
-                            , subq_27.customer_third_hop_id
-                            , subq_27.customer_id__customer_third_hop_id
-                            , subq_27.customer_third_hop_id__customer_id
-                            , subq_27.country
-                            , subq_27.customer_id__country
-                            , subq_27.customer_third_hop_id__country
+                            subq_9.acquired_ds__day
+                            , subq_9.acquired_ds__week
+                            , subq_9.acquired_ds__month
+                            , subq_9.acquired_ds__quarter
+                            , subq_9.acquired_ds__year
+                            , subq_9.acquired_ds__extract_year
+                            , subq_9.acquired_ds__extract_quarter
+                            , subq_9.acquired_ds__extract_month
+                            , subq_9.acquired_ds__extract_day
+                            , subq_9.acquired_ds__extract_dow
+                            , subq_9.acquired_ds__extract_doy
+                            , subq_9.customer_id__acquired_ds__day
+                            , subq_9.customer_id__acquired_ds__week
+                            , subq_9.customer_id__acquired_ds__month
+                            , subq_9.customer_id__acquired_ds__quarter
+                            , subq_9.customer_id__acquired_ds__year
+                            , subq_9.customer_id__acquired_ds__extract_year
+                            , subq_9.customer_id__acquired_ds__extract_quarter
+                            , subq_9.customer_id__acquired_ds__extract_month
+                            , subq_9.customer_id__acquired_ds__extract_day
+                            , subq_9.customer_id__acquired_ds__extract_dow
+                            , subq_9.customer_id__acquired_ds__extract_doy
+                            , subq_9.customer_third_hop_id__acquired_ds__day
+                            , subq_9.customer_third_hop_id__acquired_ds__week
+                            , subq_9.customer_third_hop_id__acquired_ds__month
+                            , subq_9.customer_third_hop_id__acquired_ds__quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_9.metric_time__day
+                            , subq_9.metric_time__week
+                            , subq_9.metric_time__month
+                            , subq_9.metric_time__quarter
+                            , subq_9.metric_time__year
+                            , subq_9.metric_time__extract_year
+                            , subq_9.metric_time__extract_quarter
+                            , subq_9.metric_time__extract_month
+                            , subq_9.metric_time__extract_day
+                            , subq_9.metric_time__extract_dow
+                            , subq_9.metric_time__extract_doy
+                            , subq_9.customer_id
+                            , subq_9.customer_third_hop_id
+                            , subq_9.customer_id__customer_third_hop_id
+                            , subq_9.customer_third_hop_id__customer_id
+                            , subq_9.country
+                            , subq_9.customer_id__country
+                            , subq_9.customer_third_hop_id__country
                           FROM (
                             -- Metric Time Dimension 'acquired_ds'
                             SELECT
-                              subq_26.acquired_ds__day
-                              , subq_26.acquired_ds__week
-                              , subq_26.acquired_ds__month
-                              , subq_26.acquired_ds__quarter
-                              , subq_26.acquired_ds__year
-                              , subq_26.acquired_ds__extract_year
-                              , subq_26.acquired_ds__extract_quarter
-                              , subq_26.acquired_ds__extract_month
-                              , subq_26.acquired_ds__extract_day
-                              , subq_26.acquired_ds__extract_dow
-                              , subq_26.acquired_ds__extract_doy
-                              , subq_26.customer_id__acquired_ds__day
-                              , subq_26.customer_id__acquired_ds__week
-                              , subq_26.customer_id__acquired_ds__month
-                              , subq_26.customer_id__acquired_ds__quarter
-                              , subq_26.customer_id__acquired_ds__year
-                              , subq_26.customer_id__acquired_ds__extract_year
-                              , subq_26.customer_id__acquired_ds__extract_quarter
-                              , subq_26.customer_id__acquired_ds__extract_month
-                              , subq_26.customer_id__acquired_ds__extract_day
-                              , subq_26.customer_id__acquired_ds__extract_dow
-                              , subq_26.customer_id__acquired_ds__extract_doy
-                              , subq_26.customer_third_hop_id__acquired_ds__day
-                              , subq_26.customer_third_hop_id__acquired_ds__week
-                              , subq_26.customer_third_hop_id__acquired_ds__month
-                              , subq_26.customer_third_hop_id__acquired_ds__quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_month
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_day
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_dow
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_doy
-                              , subq_26.acquired_ds__day AS metric_time__day
-                              , subq_26.acquired_ds__week AS metric_time__week
-                              , subq_26.acquired_ds__month AS metric_time__month
-                              , subq_26.acquired_ds__quarter AS metric_time__quarter
-                              , subq_26.acquired_ds__year AS metric_time__year
-                              , subq_26.acquired_ds__extract_year AS metric_time__extract_year
-                              , subq_26.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_26.acquired_ds__extract_month AS metric_time__extract_month
-                              , subq_26.acquired_ds__extract_day AS metric_time__extract_day
-                              , subq_26.acquired_ds__extract_dow AS metric_time__extract_dow
-                              , subq_26.acquired_ds__extract_doy AS metric_time__extract_doy
-                              , subq_26.customer_id
-                              , subq_26.customer_third_hop_id
-                              , subq_26.customer_id__customer_third_hop_id
-                              , subq_26.customer_third_hop_id__customer_id
-                              , subq_26.country
-                              , subq_26.customer_id__country
-                              , subq_26.customer_third_hop_id__country
-                              , subq_26.customers_with_other_data
+                              subq_8.acquired_ds__day
+                              , subq_8.acquired_ds__week
+                              , subq_8.acquired_ds__month
+                              , subq_8.acquired_ds__quarter
+                              , subq_8.acquired_ds__year
+                              , subq_8.acquired_ds__extract_year
+                              , subq_8.acquired_ds__extract_quarter
+                              , subq_8.acquired_ds__extract_month
+                              , subq_8.acquired_ds__extract_day
+                              , subq_8.acquired_ds__extract_dow
+                              , subq_8.acquired_ds__extract_doy
+                              , subq_8.customer_id__acquired_ds__day
+                              , subq_8.customer_id__acquired_ds__week
+                              , subq_8.customer_id__acquired_ds__month
+                              , subq_8.customer_id__acquired_ds__quarter
+                              , subq_8.customer_id__acquired_ds__year
+                              , subq_8.customer_id__acquired_ds__extract_year
+                              , subq_8.customer_id__acquired_ds__extract_quarter
+                              , subq_8.customer_id__acquired_ds__extract_month
+                              , subq_8.customer_id__acquired_ds__extract_day
+                              , subq_8.customer_id__acquired_ds__extract_dow
+                              , subq_8.customer_id__acquired_ds__extract_doy
+                              , subq_8.customer_third_hop_id__acquired_ds__day
+                              , subq_8.customer_third_hop_id__acquired_ds__week
+                              , subq_8.customer_third_hop_id__acquired_ds__month
+                              , subq_8.customer_third_hop_id__acquired_ds__quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_month
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_day
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_dow
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_doy
+                              , subq_8.acquired_ds__day AS metric_time__day
+                              , subq_8.acquired_ds__week AS metric_time__week
+                              , subq_8.acquired_ds__month AS metric_time__month
+                              , subq_8.acquired_ds__quarter AS metric_time__quarter
+                              , subq_8.acquired_ds__year AS metric_time__year
+                              , subq_8.acquired_ds__extract_year AS metric_time__extract_year
+                              , subq_8.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_8.acquired_ds__extract_month AS metric_time__extract_month
+                              , subq_8.acquired_ds__extract_day AS metric_time__extract_day
+                              , subq_8.acquired_ds__extract_dow AS metric_time__extract_dow
+                              , subq_8.acquired_ds__extract_doy AS metric_time__extract_doy
+                              , subq_8.customer_id
+                              , subq_8.customer_third_hop_id
+                              , subq_8.customer_id__customer_third_hop_id
+                              , subq_8.customer_third_hop_id__customer_id
+                              , subq_8.country
+                              , subq_8.customer_id__country
+                              , subq_8.customer_third_hop_id__country
+                              , subq_8.customers_with_other_data
                             FROM (
                               -- Read Elements From Semantic Model 'customer_other_data'
                               SELECT
@@ -664,31 +664,31 @@ FROM (
                                 , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                                 , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                               FROM ***************************.customer_other_data customer_other_data_src_22000
-                            ) subq_26
-                          ) subq_27
-                        ) subq_28
+                            ) subq_8
+                          ) subq_9
+                        ) subq_10
                         ON
-                          subq_25.customer_id = subq_28.customer_id
-                      ) subq_29
-                    ) subq_30
+                          subq_7.customer_id = subq_10.customer_id
+                      ) subq_11
+                    ) subq_12
                     ON
                       (
-                        subq_23.account_id = subq_30.account_id
+                        subq_5.account_id = subq_12.account_id
                       ) AND (
-                        subq_23.ds_partitioned__day = subq_30.ds_partitioned__day
+                        subq_5.ds_partitioned__day = subq_12.ds_partitioned__day
                       )
-                  ) subq_31
-                ) subq_32
+                  ) subq_13
+                ) subq_14
                 GROUP BY
-                  subq_32.account_id__customer_id__customer_third_hop_id
-              ) subq_33
-            ) subq_34
-          ) subq_35
+                  subq_14.account_id__customer_id__customer_third_hop_id
+              ) subq_15
+            ) subq_16
+          ) subq_17
           ON
-            subq_20.customer_third_hop_id = subq_35.account_id__customer_id__customer_third_hop_id
-        ) subq_36
-      ) subq_37
+            subq_2.customer_third_hop_id = subq_17.account_id__customer_id__customer_third_hop_id
+        ) subq_18
+      ) subq_19
       WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2
-    ) subq_38
-  ) subq_39
-) subq_40
+    ) subq_20
+  ) subq_21
+) subq_22

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_40.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_35.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_71
+    ) subq_35
     ON
       (
-        account_month_txns_src_22000.account_id = subq_71.account_id
+        account_month_txns_src_22000.account_id = subq_35.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_35.ds_partitioned__day
       )
     GROUP BY
-      subq_71.customer_id__customer_third_hop_id
-  ) subq_76
+      subq_35.customer_id__customer_third_hop_id
+  ) subq_40
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
-) subq_78
+    third_hop_table_src_22000.customer_third_hop_id = subq_40.account_id__customer_id__customer_third_hop_id
+) subq_42
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_25.third_hop_count
+  subq_16.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_24.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_23.third_hop_count
+      subq_14.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_22.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_22.third_hop_count
+        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_13.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_21.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_21.third_hop_count
+          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_12.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.customer_third_hop_id AS customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-            , subq_11.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_10.customer_third_hop_id
-              , subq_10.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_9.third_hop_ds__day
-                , subq_9.third_hop_ds__week
-                , subq_9.third_hop_ds__month
-                , subq_9.third_hop_ds__quarter
-                , subq_9.third_hop_ds__year
-                , subq_9.third_hop_ds__extract_year
-                , subq_9.third_hop_ds__extract_quarter
-                , subq_9.third_hop_ds__extract_month
-                , subq_9.third_hop_ds__extract_day
-                , subq_9.third_hop_ds__extract_dow
-                , subq_9.third_hop_ds__extract_doy
-                , subq_9.customer_third_hop_id__third_hop_ds__day
-                , subq_9.customer_third_hop_id__third_hop_ds__week
-                , subq_9.customer_third_hop_id__third_hop_ds__month
-                , subq_9.customer_third_hop_id__third_hop_ds__quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_9.third_hop_ds__day AS metric_time__day
-                , subq_9.third_hop_ds__week AS metric_time__week
-                , subq_9.third_hop_ds__month AS metric_time__month
-                , subq_9.third_hop_ds__quarter AS metric_time__quarter
-                , subq_9.third_hop_ds__year AS metric_time__year
-                , subq_9.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_9.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_9.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_9.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_9.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_9.customer_third_hop_id
-                , subq_9.value
-                , subq_9.customer_third_hop_id__value
-                , subq_9.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,151 +101,151 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_19.customer_id__customer_third_hop_id
-              , subq_19.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_10.customer_id__customer_third_hop_id
+              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_18.customer_id__customer_third_hop_id
-                , subq_18.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_9.customer_id__customer_third_hop_id
+                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_17.customer_id__customer_third_hop_id
-                  , SUM(subq_17.customers_with_other_data) AS customers_with_other_data
+                  subq_8.customer_id__customer_third_hop_id
+                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_16.customer_id__customer_third_hop_id
-                    , subq_16.customers_with_other_data
+                    subq_7.customer_id__customer_third_hop_id
+                    , subq_7.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_15.customer_id__customer_third_hop_id
-                      , subq_15.customer_id__country
-                      , subq_15.customers_with_other_data
+                      subq_6.customer_id__customer_third_hop_id
+                      , subq_6.customer_id__country
+                      , subq_6.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_14.customer_id__customer_third_hop_id
-                        , subq_14.customer_id__country
-                        , subq_14.customers_with_other_data
+                        subq_5.customer_id__customer_third_hop_id
+                        , subq_5.customer_id__country
+                        , subq_5.customers_with_other_data
                       FROM (
                         -- Constrain Output with WHERE
                         SELECT
-                          subq_13.acquired_ds__day
-                          , subq_13.acquired_ds__week
-                          , subq_13.acquired_ds__month
-                          , subq_13.acquired_ds__quarter
-                          , subq_13.acquired_ds__year
-                          , subq_13.acquired_ds__extract_year
-                          , subq_13.acquired_ds__extract_quarter
-                          , subq_13.acquired_ds__extract_month
-                          , subq_13.acquired_ds__extract_day
-                          , subq_13.acquired_ds__extract_dow
-                          , subq_13.acquired_ds__extract_doy
-                          , subq_13.customer_id__acquired_ds__day
-                          , subq_13.customer_id__acquired_ds__week
-                          , subq_13.customer_id__acquired_ds__month
-                          , subq_13.customer_id__acquired_ds__quarter
-                          , subq_13.customer_id__acquired_ds__year
-                          , subq_13.customer_id__acquired_ds__extract_year
-                          , subq_13.customer_id__acquired_ds__extract_quarter
-                          , subq_13.customer_id__acquired_ds__extract_month
-                          , subq_13.customer_id__acquired_ds__extract_day
-                          , subq_13.customer_id__acquired_ds__extract_dow
-                          , subq_13.customer_id__acquired_ds__extract_doy
-                          , subq_13.customer_third_hop_id__acquired_ds__day
-                          , subq_13.customer_third_hop_id__acquired_ds__week
-                          , subq_13.customer_third_hop_id__acquired_ds__month
-                          , subq_13.customer_third_hop_id__acquired_ds__quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_13.metric_time__day
-                          , subq_13.metric_time__week
-                          , subq_13.metric_time__month
-                          , subq_13.metric_time__quarter
-                          , subq_13.metric_time__year
-                          , subq_13.metric_time__extract_year
-                          , subq_13.metric_time__extract_quarter
-                          , subq_13.metric_time__extract_month
-                          , subq_13.metric_time__extract_day
-                          , subq_13.metric_time__extract_dow
-                          , subq_13.metric_time__extract_doy
-                          , subq_13.customer_id
-                          , subq_13.customer_third_hop_id
-                          , subq_13.customer_id__customer_third_hop_id
-                          , subq_13.customer_third_hop_id__customer_id
-                          , subq_13.country
-                          , subq_13.customer_id__country
-                          , subq_13.customer_third_hop_id__country
-                          , subq_13.customers_with_other_data
+                          subq_4.acquired_ds__day
+                          , subq_4.acquired_ds__week
+                          , subq_4.acquired_ds__month
+                          , subq_4.acquired_ds__quarter
+                          , subq_4.acquired_ds__year
+                          , subq_4.acquired_ds__extract_year
+                          , subq_4.acquired_ds__extract_quarter
+                          , subq_4.acquired_ds__extract_month
+                          , subq_4.acquired_ds__extract_day
+                          , subq_4.acquired_ds__extract_dow
+                          , subq_4.acquired_ds__extract_doy
+                          , subq_4.customer_id__acquired_ds__day
+                          , subq_4.customer_id__acquired_ds__week
+                          , subq_4.customer_id__acquired_ds__month
+                          , subq_4.customer_id__acquired_ds__quarter
+                          , subq_4.customer_id__acquired_ds__year
+                          , subq_4.customer_id__acquired_ds__extract_year
+                          , subq_4.customer_id__acquired_ds__extract_quarter
+                          , subq_4.customer_id__acquired_ds__extract_month
+                          , subq_4.customer_id__acquired_ds__extract_day
+                          , subq_4.customer_id__acquired_ds__extract_dow
+                          , subq_4.customer_id__acquired_ds__extract_doy
+                          , subq_4.customer_third_hop_id__acquired_ds__day
+                          , subq_4.customer_third_hop_id__acquired_ds__week
+                          , subq_4.customer_third_hop_id__acquired_ds__month
+                          , subq_4.customer_third_hop_id__acquired_ds__quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_4.metric_time__day
+                          , subq_4.metric_time__week
+                          , subq_4.metric_time__month
+                          , subq_4.metric_time__quarter
+                          , subq_4.metric_time__year
+                          , subq_4.metric_time__extract_year
+                          , subq_4.metric_time__extract_quarter
+                          , subq_4.metric_time__extract_month
+                          , subq_4.metric_time__extract_day
+                          , subq_4.metric_time__extract_dow
+                          , subq_4.metric_time__extract_doy
+                          , subq_4.customer_id
+                          , subq_4.customer_third_hop_id
+                          , subq_4.customer_id__customer_third_hop_id
+                          , subq_4.customer_third_hop_id__customer_id
+                          , subq_4.country
+                          , subq_4.customer_id__country
+                          , subq_4.customer_third_hop_id__country
+                          , subq_4.customers_with_other_data
                         FROM (
                           -- Metric Time Dimension 'acquired_ds'
                           SELECT
-                            subq_12.acquired_ds__day
-                            , subq_12.acquired_ds__week
-                            , subq_12.acquired_ds__month
-                            , subq_12.acquired_ds__quarter
-                            , subq_12.acquired_ds__year
-                            , subq_12.acquired_ds__extract_year
-                            , subq_12.acquired_ds__extract_quarter
-                            , subq_12.acquired_ds__extract_month
-                            , subq_12.acquired_ds__extract_day
-                            , subq_12.acquired_ds__extract_dow
-                            , subq_12.acquired_ds__extract_doy
-                            , subq_12.customer_id__acquired_ds__day
-                            , subq_12.customer_id__acquired_ds__week
-                            , subq_12.customer_id__acquired_ds__month
-                            , subq_12.customer_id__acquired_ds__quarter
-                            , subq_12.customer_id__acquired_ds__year
-                            , subq_12.customer_id__acquired_ds__extract_year
-                            , subq_12.customer_id__acquired_ds__extract_quarter
-                            , subq_12.customer_id__acquired_ds__extract_month
-                            , subq_12.customer_id__acquired_ds__extract_day
-                            , subq_12.customer_id__acquired_ds__extract_dow
-                            , subq_12.customer_id__acquired_ds__extract_doy
-                            , subq_12.customer_third_hop_id__acquired_ds__day
-                            , subq_12.customer_third_hop_id__acquired_ds__week
-                            , subq_12.customer_third_hop_id__acquired_ds__month
-                            , subq_12.customer_third_hop_id__acquired_ds__quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_12.acquired_ds__day AS metric_time__day
-                            , subq_12.acquired_ds__week AS metric_time__week
-                            , subq_12.acquired_ds__month AS metric_time__month
-                            , subq_12.acquired_ds__quarter AS metric_time__quarter
-                            , subq_12.acquired_ds__year AS metric_time__year
-                            , subq_12.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_12.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_12.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_12.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_12.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_12.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_12.customer_id
-                            , subq_12.customer_third_hop_id
-                            , subq_12.customer_id__customer_third_hop_id
-                            , subq_12.customer_third_hop_id__customer_id
-                            , subq_12.country
-                            , subq_12.customer_id__country
-                            , subq_12.customer_third_hop_id__country
-                            , subq_12.customers_with_other_data
+                            subq_3.acquired_ds__day
+                            , subq_3.acquired_ds__week
+                            , subq_3.acquired_ds__month
+                            , subq_3.acquired_ds__quarter
+                            , subq_3.acquired_ds__year
+                            , subq_3.acquired_ds__extract_year
+                            , subq_3.acquired_ds__extract_quarter
+                            , subq_3.acquired_ds__extract_month
+                            , subq_3.acquired_ds__extract_day
+                            , subq_3.acquired_ds__extract_dow
+                            , subq_3.acquired_ds__extract_doy
+                            , subq_3.customer_id__acquired_ds__day
+                            , subq_3.customer_id__acquired_ds__week
+                            , subq_3.customer_id__acquired_ds__month
+                            , subq_3.customer_id__acquired_ds__quarter
+                            , subq_3.customer_id__acquired_ds__year
+                            , subq_3.customer_id__acquired_ds__extract_year
+                            , subq_3.customer_id__acquired_ds__extract_quarter
+                            , subq_3.customer_id__acquired_ds__extract_month
+                            , subq_3.customer_id__acquired_ds__extract_day
+                            , subq_3.customer_id__acquired_ds__extract_dow
+                            , subq_3.customer_id__acquired_ds__extract_doy
+                            , subq_3.customer_third_hop_id__acquired_ds__day
+                            , subq_3.customer_third_hop_id__acquired_ds__week
+                            , subq_3.customer_third_hop_id__acquired_ds__month
+                            , subq_3.customer_third_hop_id__acquired_ds__quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_3.acquired_ds__day AS metric_time__day
+                            , subq_3.acquired_ds__week AS metric_time__week
+                            , subq_3.acquired_ds__month AS metric_time__month
+                            , subq_3.acquired_ds__quarter AS metric_time__quarter
+                            , subq_3.acquired_ds__year AS metric_time__year
+                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                            , subq_3.customer_id
+                            , subq_3.customer_third_hop_id
+                            , subq_3.customer_id__customer_third_hop_id
+                            , subq_3.customer_third_hop_id__customer_id
+                            , subq_3.country
+                            , subq_3.customer_id__country
+                            , subq_3.customer_third_hop_id__country
+                            , subq_3.customers_with_other_data
                           FROM (
                             -- Read Elements From Semantic Model 'customer_other_data'
                             SELECT
@@ -291,24 +291,24 @@ FROM (
                               , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                               , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                             FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_12
-                        ) subq_13
+                          ) subq_3
+                        ) subq_4
                         WHERE customer_id__country = 'paraguay'
-                      ) subq_14
-                    ) subq_15
+                      ) subq_5
+                    ) subq_6
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_16
-                ) subq_17
+                  ) subq_7
+                ) subq_8
                 GROUP BY
-                  subq_17.customer_id__customer_third_hop_id
-              ) subq_18
-            ) subq_19
-          ) subq_20
+                  subq_8.customer_id__customer_third_hop_id
+              ) subq_9
+            ) subq_10
+          ) subq_11
           ON
-            subq_11.customer_third_hop_id = subq_20.customer_id__customer_third_hop_id
-        ) subq_21
-      ) subq_22
+            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
+        ) subq_12
+      ) subq_13
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_23
-  ) subq_24
-) subq_25
+    ) subq_14
+  ) subq_15
+) subq_16

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_39
+      ) subq_21
       WHERE customer_id__country = 'paraguay'
-    ) subq_41
+    ) subq_23
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_46
+  ) subq_28
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
-) subq_48
+    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
+) subq_30
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookers
-        , subq_14.bookers
+        subq_10.listing__bookers
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'listing__bookers']
         SELECT
-          subq_13.listing__bookers
-          , subq_13.bookers
+          subq_9.listing__bookers
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookers AS listing__bookers
-            , subq_6.bookers AS bookers
+            subq_2.listing AS listing
+            , subq_8.listing__bookers AS listing__bookers
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.bookers
+              subq_1.listing
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookers
+              subq_7.listing
+              , subq_7.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookers AS listing__bookers
+                subq_6.listing
+                , subq_6.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , COUNT(DISTINCT subq_9.bookers) AS bookers
+                  subq_5.listing
+                  , COUNT(DISTINCT subq_5.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookers
+                    subq_4.listing
+                    , subq_4.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookers > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_30.listing__bookers AS listing__bookers
-    , subq_24.bookers AS bookers
+    subq_22.listing__bookers AS listing__bookers
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_metric_in_where_filter__plan0.sql
@@ -1,112 +1,112 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time__day
-  , subq_17.listings AS active_listings
+  subq_13.metric_time__day
+  , subq_13.listings AS active_listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.metric_time__day
-    , SUM(subq_16.listings) AS listings
+    subq_12.metric_time__day
+    , SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'metric_time__day']
     SELECT
-      subq_15.metric_time__day
-      , subq_15.listings
+      subq_11.metric_time__day
+      , subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.metric_time__day
-        , subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.metric_time__day
+        , subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
         SELECT
-          subq_13.metric_time__day
-          , subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.metric_time__day
+          , subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.metric_time__day AS metric_time__day
-            , subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']
             SELECT
-              subq_5.metric_time__day
-              , subq_5.listing
-              , subq_5.listings
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -167,130 +167,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -383,21 +383,21 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
+    ) subq_11
+  ) subq_12
   GROUP BY
-    subq_16.metric_time__day
-) subq_17
+    subq_12.metric_time__day
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_24.metric_time__day AS metric_time__day
-    , subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_16.metric_time__day AS metric_time__day
+    , subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.user__revenue_all_time
-        , subq_14.listings
+        subq_10.user__revenue_all_time
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__revenue_all_time']
         SELECT
-          subq_13.user__revenue_all_time
-          , subq_13.listings
+          subq_9.user__revenue_all_time
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.user AS user
-            , subq_12.user__revenue_all_time AS user__revenue_all_time
-            , subq_6.listings AS listings
+            subq_2.user AS user
+            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_5.user
-              , subq_5.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,68 +160,68 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__revenue_all_time']
             SELECT
-              subq_11.user
-              , subq_11.user__revenue_all_time
+              subq_7.user
+              , subq_7.user__revenue_all_time
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.user
-                , subq_10.txn_revenue AS user__revenue_all_time
+                subq_6.user
+                , subq_6.txn_revenue AS user__revenue_all_time
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.user
-                  , SUM(subq_9.txn_revenue) AS txn_revenue
+                  subq_5.user
+                  , SUM(subq_5.txn_revenue) AS txn_revenue
                 FROM (
                   -- Pass Only Elements: ['txn_revenue', 'user']
                   SELECT
-                    subq_8.user
-                    , subq_8.txn_revenue
+                    subq_4.user
+                    , subq_4.txn_revenue
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.revenue_instance__ds__day
-                      , subq_7.revenue_instance__ds__week
-                      , subq_7.revenue_instance__ds__month
-                      , subq_7.revenue_instance__ds__quarter
-                      , subq_7.revenue_instance__ds__year
-                      , subq_7.revenue_instance__ds__extract_year
-                      , subq_7.revenue_instance__ds__extract_quarter
-                      , subq_7.revenue_instance__ds__extract_month
-                      , subq_7.revenue_instance__ds__extract_day
-                      , subq_7.revenue_instance__ds__extract_dow
-                      , subq_7.revenue_instance__ds__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.user
-                      , subq_7.revenue_instance__user
-                      , subq_7.txn_revenue
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.revenue_instance__ds__day
+                      , subq_3.revenue_instance__ds__week
+                      , subq_3.revenue_instance__ds__month
+                      , subq_3.revenue_instance__ds__quarter
+                      , subq_3.revenue_instance__ds__year
+                      , subq_3.revenue_instance__ds__extract_year
+                      , subq_3.revenue_instance__ds__extract_quarter
+                      , subq_3.revenue_instance__ds__extract_month
+                      , subq_3.revenue_instance__ds__extract_day
+                      , subq_3.revenue_instance__ds__extract_dow
+                      , subq_3.revenue_instance__ds__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.user
+                      , subq_3.revenue_instance__user
+                      , subq_3.txn_revenue
                     FROM (
                       -- Read Elements From Semantic Model 'revenue'
                       SELECT
@@ -251,19 +251,19 @@ FROM (
                         , revenue_src_28000.user_id AS user
                         , revenue_src_28000.user_id AS revenue_instance__user
                       FROM ***************************.fct_revenue revenue_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.user
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.user
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.user = subq_12.user
-        ) subq_13
-      ) subq_14
+            subq_2.user = subq_8.user
+        ) subq_9
+      ) subq_10
       WHERE user__revenue_all_time > 1
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_30.user__revenue_all_time AS user__revenue_all_time
-    , subq_24.listings AS listings
+    subq_22.user__revenue_all_time AS user__revenue_all_time
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.user = subq_30.user
-) subq_32
+    subq_16.user = subq_22.user
+) subq_24
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__views_times_booking_value
-        , subq_28.listings
+        subq_17.listing__views_times_booking_value
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
         SELECT
-          subq_27.listing__views_times_booking_value
-          , subq_27.listings
+          subq_16.listing__views_times_booking_value
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__views_times_booking_value AS listing__views_times_booking_value
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
             SELECT
-              subq_25.listing
-              , subq_25.listing__views_times_booking_value
+              subq_14.listing
+              , subq_14.listing__views_times_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
+                subq_13.listing
                 , booking_value * views AS listing__views_times_booking_value
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.booking_value) AS booking_value
-                  , MAX(subq_23.views) AS views
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.booking_value) AS booking_value
+                  , MAX(subq_12.views) AS views
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.booking_value
+                    subq_6.listing
+                    , subq_6.booking_value
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.booking_value) AS booking_value
+                      subq_5.listing
+                      , SUM(subq_5.booking_value) AS booking_value
                     FROM (
                       -- Pass Only Elements: ['booking_value', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.booking_value
+                        subq_4.listing
+                        , subq_4.booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,91 +387,91 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.views
+                    subq_11.listing
+                    , subq_11.views
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , SUM(subq_21.views) AS views
+                      subq_10.listing
+                      , SUM(subq_10.views) AS views
                     FROM (
                       -- Pass Only Elements: ['views', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.views
+                        subq_9.listing
+                        , subq_9.views
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.view__ds__day
-                          , subq_19.view__ds__week
-                          , subq_19.view__ds__month
-                          , subq_19.view__ds__quarter
-                          , subq_19.view__ds__year
-                          , subq_19.view__ds__extract_year
-                          , subq_19.view__ds__extract_quarter
-                          , subq_19.view__ds__extract_month
-                          , subq_19.view__ds__extract_day
-                          , subq_19.view__ds__extract_dow
-                          , subq_19.view__ds__extract_doy
-                          , subq_19.view__ds_partitioned__day
-                          , subq_19.view__ds_partitioned__week
-                          , subq_19.view__ds_partitioned__month
-                          , subq_19.view__ds_partitioned__quarter
-                          , subq_19.view__ds_partitioned__year
-                          , subq_19.view__ds_partitioned__extract_year
-                          , subq_19.view__ds_partitioned__extract_quarter
-                          , subq_19.view__ds_partitioned__extract_month
-                          , subq_19.view__ds_partitioned__extract_day
-                          , subq_19.view__ds_partitioned__extract_dow
-                          , subq_19.view__ds_partitioned__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.user
-                          , subq_19.view__listing
-                          , subq_19.view__user
-                          , subq_19.views
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.view__ds__day
+                          , subq_8.view__ds__week
+                          , subq_8.view__ds__month
+                          , subq_8.view__ds__quarter
+                          , subq_8.view__ds__year
+                          , subq_8.view__ds__extract_year
+                          , subq_8.view__ds__extract_quarter
+                          , subq_8.view__ds__extract_month
+                          , subq_8.view__ds__extract_day
+                          , subq_8.view__ds__extract_dow
+                          , subq_8.view__ds__extract_doy
+                          , subq_8.view__ds_partitioned__day
+                          , subq_8.view__ds_partitioned__week
+                          , subq_8.view__ds_partitioned__month
+                          , subq_8.view__ds_partitioned__quarter
+                          , subq_8.view__ds_partitioned__year
+                          , subq_8.view__ds_partitioned__extract_year
+                          , subq_8.view__ds_partitioned__extract_quarter
+                          , subq_8.view__ds_partitioned__extract_month
+                          , subq_8.view__ds_partitioned__extract_day
+                          , subq_8.view__ds_partitioned__extract_dow
+                          , subq_8.view__ds_partitioned__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.user
+                          , subq_8.view__listing
+                          , subq_8.view__user
+                          , subq_8.views
                         FROM (
                           -- Read Elements From Semantic Model 'views_source'
                           SELECT
@@ -525,25 +525,25 @@ FROM (
                             , views_source_src_28000.listing_id AS view__listing
                             , views_source_src_28000.user_id AS view__user
                           FROM ***************************.fct_views views_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__views_times_booking_value > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_45.listings AS listings
+    subq_36.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_50.listing, subq_55.listing) AS listing
-        , MAX(subq_50.booking_value) AS booking_value
-        , MAX(subq_55.views) AS views
+        COALESCE(subq_28.listing, subq_33.listing) AS listing
+        , MAX(subq_28.booking_value) AS booking_value
+        , MAX(subq_33.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_50
+      ) subq_28
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_53
+        ) subq_31
         GROUP BY
           listing
-      ) subq_55
+      ) subq_33
       ON
-        subq_50.listing = subq_55.listing
+        subq_28.listing = subq_33.listing
       GROUP BY
-        COALESCE(subq_50.listing, subq_55.listing)
-    ) subq_56
-  ) subq_58
+        COALESCE(subq_28.listing, subq_33.listing)
+    ) subq_34
+  ) subq_36
   ON
-    subq_45.listing = subq_58.listing
-) subq_60
+    subq_23.listing = subq_36.listing
+) subq_38
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -1,108 +1,108 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_19.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_18.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_17.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.listing__bookings
-        , subq_24.listing__bookers
-        , subq_24.listings
+        subq_16.listing__bookings
+        , subq_16.listing__bookers
+        , subq_16.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
         SELECT
-          subq_23.listing__bookings
-          , subq_23.listing__bookers
-          , subq_23.listings
+          subq_15.listing__bookings
+          , subq_15.listing__bookers
+          , subq_15.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_10.listing AS listing
-            , subq_16.listing__bookings AS listing__bookings
-            , subq_22.listing__bookers AS listing__bookers
-            , subq_10.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']
             SELECT
-              subq_9.listing
-              , subq_9.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_8.ds__day
-                , subq_8.ds__week
-                , subq_8.ds__month
-                , subq_8.ds__quarter
-                , subq_8.ds__year
-                , subq_8.ds__extract_year
-                , subq_8.ds__extract_quarter
-                , subq_8.ds__extract_month
-                , subq_8.ds__extract_day
-                , subq_8.ds__extract_dow
-                , subq_8.ds__extract_doy
-                , subq_8.created_at__day
-                , subq_8.created_at__week
-                , subq_8.created_at__month
-                , subq_8.created_at__quarter
-                , subq_8.created_at__year
-                , subq_8.created_at__extract_year
-                , subq_8.created_at__extract_quarter
-                , subq_8.created_at__extract_month
-                , subq_8.created_at__extract_day
-                , subq_8.created_at__extract_dow
-                , subq_8.created_at__extract_doy
-                , subq_8.listing__ds__day
-                , subq_8.listing__ds__week
-                , subq_8.listing__ds__month
-                , subq_8.listing__ds__quarter
-                , subq_8.listing__ds__year
-                , subq_8.listing__ds__extract_year
-                , subq_8.listing__ds__extract_quarter
-                , subq_8.listing__ds__extract_month
-                , subq_8.listing__ds__extract_day
-                , subq_8.listing__ds__extract_dow
-                , subq_8.listing__ds__extract_doy
-                , subq_8.listing__created_at__day
-                , subq_8.listing__created_at__week
-                , subq_8.listing__created_at__month
-                , subq_8.listing__created_at__quarter
-                , subq_8.listing__created_at__year
-                , subq_8.listing__created_at__extract_year
-                , subq_8.listing__created_at__extract_quarter
-                , subq_8.listing__created_at__extract_month
-                , subq_8.listing__created_at__extract_day
-                , subq_8.listing__created_at__extract_dow
-                , subq_8.listing__created_at__extract_doy
-                , subq_8.ds__day AS metric_time__day
-                , subq_8.ds__week AS metric_time__week
-                , subq_8.ds__month AS metric_time__month
-                , subq_8.ds__quarter AS metric_time__quarter
-                , subq_8.ds__year AS metric_time__year
-                , subq_8.ds__extract_year AS metric_time__extract_year
-                , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_8.ds__extract_month AS metric_time__extract_month
-                , subq_8.ds__extract_day AS metric_time__extract_day
-                , subq_8.ds__extract_dow AS metric_time__extract_dow
-                , subq_8.ds__extract_doy AS metric_time__extract_doy
-                , subq_8.listing
-                , subq_8.user
-                , subq_8.listing__user
-                , subq_8.country_latest
-                , subq_8.is_lux_latest
-                , subq_8.capacity_latest
-                , subq_8.listing__country_latest
-                , subq_8.listing__is_lux_latest
-                , subq_8.listing__capacity_latest
-                , subq_8.listings
-                , subq_8.largest_listing
-                , subq_8.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -163,130 +163,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_8
-            ) subq_9
-          ) subq_10
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_15.listing
-              , subq_15.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_14.listing
-                , subq_14.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_13.listing
-                  , SUM(subq_13.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_12.listing
-                    , subq_12.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_11.ds__day
-                      , subq_11.ds__week
-                      , subq_11.ds__month
-                      , subq_11.ds__quarter
-                      , subq_11.ds__year
-                      , subq_11.ds__extract_year
-                      , subq_11.ds__extract_quarter
-                      , subq_11.ds__extract_month
-                      , subq_11.ds__extract_day
-                      , subq_11.ds__extract_dow
-                      , subq_11.ds__extract_doy
-                      , subq_11.ds_partitioned__day
-                      , subq_11.ds_partitioned__week
-                      , subq_11.ds_partitioned__month
-                      , subq_11.ds_partitioned__quarter
-                      , subq_11.ds_partitioned__year
-                      , subq_11.ds_partitioned__extract_year
-                      , subq_11.ds_partitioned__extract_quarter
-                      , subq_11.ds_partitioned__extract_month
-                      , subq_11.ds_partitioned__extract_day
-                      , subq_11.ds_partitioned__extract_dow
-                      , subq_11.ds_partitioned__extract_doy
-                      , subq_11.paid_at__day
-                      , subq_11.paid_at__week
-                      , subq_11.paid_at__month
-                      , subq_11.paid_at__quarter
-                      , subq_11.paid_at__year
-                      , subq_11.paid_at__extract_year
-                      , subq_11.paid_at__extract_quarter
-                      , subq_11.paid_at__extract_month
-                      , subq_11.paid_at__extract_day
-                      , subq_11.paid_at__extract_dow
-                      , subq_11.paid_at__extract_doy
-                      , subq_11.booking__ds__day
-                      , subq_11.booking__ds__week
-                      , subq_11.booking__ds__month
-                      , subq_11.booking__ds__quarter
-                      , subq_11.booking__ds__year
-                      , subq_11.booking__ds__extract_year
-                      , subq_11.booking__ds__extract_quarter
-                      , subq_11.booking__ds__extract_month
-                      , subq_11.booking__ds__extract_day
-                      , subq_11.booking__ds__extract_dow
-                      , subq_11.booking__ds__extract_doy
-                      , subq_11.booking__ds_partitioned__day
-                      , subq_11.booking__ds_partitioned__week
-                      , subq_11.booking__ds_partitioned__month
-                      , subq_11.booking__ds_partitioned__quarter
-                      , subq_11.booking__ds_partitioned__year
-                      , subq_11.booking__ds_partitioned__extract_year
-                      , subq_11.booking__ds_partitioned__extract_quarter
-                      , subq_11.booking__ds_partitioned__extract_month
-                      , subq_11.booking__ds_partitioned__extract_day
-                      , subq_11.booking__ds_partitioned__extract_dow
-                      , subq_11.booking__ds_partitioned__extract_doy
-                      , subq_11.booking__paid_at__day
-                      , subq_11.booking__paid_at__week
-                      , subq_11.booking__paid_at__month
-                      , subq_11.booking__paid_at__quarter
-                      , subq_11.booking__paid_at__year
-                      , subq_11.booking__paid_at__extract_year
-                      , subq_11.booking__paid_at__extract_quarter
-                      , subq_11.booking__paid_at__extract_month
-                      , subq_11.booking__paid_at__extract_day
-                      , subq_11.booking__paid_at__extract_dow
-                      , subq_11.booking__paid_at__extract_doy
-                      , subq_11.ds__day AS metric_time__day
-                      , subq_11.ds__week AS metric_time__week
-                      , subq_11.ds__month AS metric_time__month
-                      , subq_11.ds__quarter AS metric_time__quarter
-                      , subq_11.ds__year AS metric_time__year
-                      , subq_11.ds__extract_year AS metric_time__extract_year
-                      , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_11.ds__extract_month AS metric_time__extract_month
-                      , subq_11.ds__extract_day AS metric_time__extract_day
-                      , subq_11.ds__extract_dow AS metric_time__extract_dow
-                      , subq_11.ds__extract_doy AS metric_time__extract_doy
-                      , subq_11.listing
-                      , subq_11.guest
-                      , subq_11.host
-                      , subq_11.booking__listing
-                      , subq_11.booking__guest
-                      , subq_11.booking__host
-                      , subq_11.is_instant
-                      , subq_11.booking__is_instant
-                      , subq_11.bookings
-                      , subq_11.instant_bookings
-                      , subq_11.booking_value
-                      , subq_11.max_booking_value
-                      , subq_11.min_booking_value
-                      , subq_11.bookers
-                      , subq_11.average_booking_value
-                      , subq_11.referred_bookings
-                      , subq_11.median_booking_value
-                      , subq_11.booking_value_p99
-                      , subq_11.discrete_booking_value_p99
-                      , subq_11.approximate_continuous_booking_value_p99
-                      , subq_11.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -379,137 +379,137 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_11
-                  ) subq_12
-                ) subq_13
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_13.listing
-              ) subq_14
-            ) subq_15
-          ) subq_16
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_10.listing = subq_16.listing
+            subq_2.listing = subq_8.listing
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_21.listing
-              , subq_21.listing__bookers
+              subq_13.listing
+              , subq_13.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing
-                , subq_20.bookers AS listing__bookers
+                subq_12.listing
+                , subq_12.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing
-                  , COUNT(DISTINCT subq_19.bookers) AS bookers
+                  subq_11.listing
+                  , COUNT(DISTINCT subq_11.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_18.listing
-                    , subq_18.bookers
+                    subq_10.listing
+                    , subq_10.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.ds_partitioned__day
-                      , subq_17.ds_partitioned__week
-                      , subq_17.ds_partitioned__month
-                      , subq_17.ds_partitioned__quarter
-                      , subq_17.ds_partitioned__year
-                      , subq_17.ds_partitioned__extract_year
-                      , subq_17.ds_partitioned__extract_quarter
-                      , subq_17.ds_partitioned__extract_month
-                      , subq_17.ds_partitioned__extract_day
-                      , subq_17.ds_partitioned__extract_dow
-                      , subq_17.ds_partitioned__extract_doy
-                      , subq_17.paid_at__day
-                      , subq_17.paid_at__week
-                      , subq_17.paid_at__month
-                      , subq_17.paid_at__quarter
-                      , subq_17.paid_at__year
-                      , subq_17.paid_at__extract_year
-                      , subq_17.paid_at__extract_quarter
-                      , subq_17.paid_at__extract_month
-                      , subq_17.paid_at__extract_day
-                      , subq_17.paid_at__extract_dow
-                      , subq_17.paid_at__extract_doy
-                      , subq_17.booking__ds__day
-                      , subq_17.booking__ds__week
-                      , subq_17.booking__ds__month
-                      , subq_17.booking__ds__quarter
-                      , subq_17.booking__ds__year
-                      , subq_17.booking__ds__extract_year
-                      , subq_17.booking__ds__extract_quarter
-                      , subq_17.booking__ds__extract_month
-                      , subq_17.booking__ds__extract_day
-                      , subq_17.booking__ds__extract_dow
-                      , subq_17.booking__ds__extract_doy
-                      , subq_17.booking__ds_partitioned__day
-                      , subq_17.booking__ds_partitioned__week
-                      , subq_17.booking__ds_partitioned__month
-                      , subq_17.booking__ds_partitioned__quarter
-                      , subq_17.booking__ds_partitioned__year
-                      , subq_17.booking__ds_partitioned__extract_year
-                      , subq_17.booking__ds_partitioned__extract_quarter
-                      , subq_17.booking__ds_partitioned__extract_month
-                      , subq_17.booking__ds_partitioned__extract_day
-                      , subq_17.booking__ds_partitioned__extract_dow
-                      , subq_17.booking__ds_partitioned__extract_doy
-                      , subq_17.booking__paid_at__day
-                      , subq_17.booking__paid_at__week
-                      , subq_17.booking__paid_at__month
-                      , subq_17.booking__paid_at__quarter
-                      , subq_17.booking__paid_at__year
-                      , subq_17.booking__paid_at__extract_year
-                      , subq_17.booking__paid_at__extract_quarter
-                      , subq_17.booking__paid_at__extract_month
-                      , subq_17.booking__paid_at__extract_day
-                      , subq_17.booking__paid_at__extract_dow
-                      , subq_17.booking__paid_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.guest
-                      , subq_17.host
-                      , subq_17.booking__listing
-                      , subq_17.booking__guest
-                      , subq_17.booking__host
-                      , subq_17.is_instant
-                      , subq_17.booking__is_instant
-                      , subq_17.bookings
-                      , subq_17.instant_bookings
-                      , subq_17.booking_value
-                      , subq_17.max_booking_value
-                      , subq_17.min_booking_value
-                      , subq_17.bookers
-                      , subq_17.average_booking_value
-                      , subq_17.referred_bookings
-                      , subq_17.median_booking_value
-                      , subq_17.booking_value_p99
-                      , subq_17.discrete_booking_value_p99
-                      , subq_17.approximate_continuous_booking_value_p99
-                      , subq_17.approximate_discrete_booking_value_p99
+                      subq_9.ds__day
+                      , subq_9.ds__week
+                      , subq_9.ds__month
+                      , subq_9.ds__quarter
+                      , subq_9.ds__year
+                      , subq_9.ds__extract_year
+                      , subq_9.ds__extract_quarter
+                      , subq_9.ds__extract_month
+                      , subq_9.ds__extract_day
+                      , subq_9.ds__extract_dow
+                      , subq_9.ds__extract_doy
+                      , subq_9.ds_partitioned__day
+                      , subq_9.ds_partitioned__week
+                      , subq_9.ds_partitioned__month
+                      , subq_9.ds_partitioned__quarter
+                      , subq_9.ds_partitioned__year
+                      , subq_9.ds_partitioned__extract_year
+                      , subq_9.ds_partitioned__extract_quarter
+                      , subq_9.ds_partitioned__extract_month
+                      , subq_9.ds_partitioned__extract_day
+                      , subq_9.ds_partitioned__extract_dow
+                      , subq_9.ds_partitioned__extract_doy
+                      , subq_9.paid_at__day
+                      , subq_9.paid_at__week
+                      , subq_9.paid_at__month
+                      , subq_9.paid_at__quarter
+                      , subq_9.paid_at__year
+                      , subq_9.paid_at__extract_year
+                      , subq_9.paid_at__extract_quarter
+                      , subq_9.paid_at__extract_month
+                      , subq_9.paid_at__extract_day
+                      , subq_9.paid_at__extract_dow
+                      , subq_9.paid_at__extract_doy
+                      , subq_9.booking__ds__day
+                      , subq_9.booking__ds__week
+                      , subq_9.booking__ds__month
+                      , subq_9.booking__ds__quarter
+                      , subq_9.booking__ds__year
+                      , subq_9.booking__ds__extract_year
+                      , subq_9.booking__ds__extract_quarter
+                      , subq_9.booking__ds__extract_month
+                      , subq_9.booking__ds__extract_day
+                      , subq_9.booking__ds__extract_dow
+                      , subq_9.booking__ds__extract_doy
+                      , subq_9.booking__ds_partitioned__day
+                      , subq_9.booking__ds_partitioned__week
+                      , subq_9.booking__ds_partitioned__month
+                      , subq_9.booking__ds_partitioned__quarter
+                      , subq_9.booking__ds_partitioned__year
+                      , subq_9.booking__ds_partitioned__extract_year
+                      , subq_9.booking__ds_partitioned__extract_quarter
+                      , subq_9.booking__ds_partitioned__extract_month
+                      , subq_9.booking__ds_partitioned__extract_day
+                      , subq_9.booking__ds_partitioned__extract_dow
+                      , subq_9.booking__ds_partitioned__extract_doy
+                      , subq_9.booking__paid_at__day
+                      , subq_9.booking__paid_at__week
+                      , subq_9.booking__paid_at__month
+                      , subq_9.booking__paid_at__quarter
+                      , subq_9.booking__paid_at__year
+                      , subq_9.booking__paid_at__extract_year
+                      , subq_9.booking__paid_at__extract_quarter
+                      , subq_9.booking__paid_at__extract_month
+                      , subq_9.booking__paid_at__extract_day
+                      , subq_9.booking__paid_at__extract_dow
+                      , subq_9.booking__paid_at__extract_doy
+                      , subq_9.ds__day AS metric_time__day
+                      , subq_9.ds__week AS metric_time__week
+                      , subq_9.ds__month AS metric_time__month
+                      , subq_9.ds__quarter AS metric_time__quarter
+                      , subq_9.ds__year AS metric_time__year
+                      , subq_9.ds__extract_year AS metric_time__extract_year
+                      , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_9.ds__extract_month AS metric_time__extract_month
+                      , subq_9.ds__extract_day AS metric_time__extract_day
+                      , subq_9.ds__extract_dow AS metric_time__extract_dow
+                      , subq_9.ds__extract_doy AS metric_time__extract_doy
+                      , subq_9.listing
+                      , subq_9.guest
+                      , subq_9.host
+                      , subq_9.booking__listing
+                      , subq_9.booking__guest
+                      , subq_9.booking__host
+                      , subq_9.is_instant
+                      , subq_9.booking__is_instant
+                      , subq_9.bookings
+                      , subq_9.instant_bookings
+                      , subq_9.booking_value
+                      , subq_9.max_booking_value
+                      , subq_9.min_booking_value
+                      , subq_9.bookers
+                      , subq_9.average_booking_value
+                      , subq_9.referred_bookings
+                      , subq_9.median_booking_value
+                      , subq_9.booking_value_p99
+                      , subq_9.discrete_booking_value_p99
+                      , subq_9.approximate_continuous_booking_value_p99
+                      , subq_9.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -602,19 +602,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_9
+                  ) subq_10
+                ) subq_11
                 GROUP BY
-                  subq_19.listing
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_11.listing
+              ) subq_12
+            ) subq_13
+          ) subq_14
           ON
-            subq_10.listing = subq_22.listing
-        ) subq_23
-      ) subq_24
+            subq_2.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       WHERE listing__bookings > 2 AND listing__bookers > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_17
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_44.listing__bookings AS listing__bookings
-    , subq_50.listing__bookers AS listing__bookers
-    , subq_38.listings AS listings
+    subq_28.listing__bookings AS listing__bookings
+    , subq_34.listing__bookers AS listing__bookers
+    , subq_22.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_38
+  ) subq_22
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_41
+    ) subq_25
     GROUP BY
       listing
-  ) subq_44
+  ) subq_28
   ON
-    subq_38.listing = subq_44.listing
+    subq_22.listing = subq_28.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_50
+  ) subq_34
   ON
-    subq_38.listing = subq_50.listing
-) subq_52
+    subq_22.listing = subq_34.listing
+) subq_36
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__bookings_per_booker
-        , subq_28.listings
+        subq_17.listing__bookings_per_booker
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
         SELECT
-          subq_27.listing__bookings_per_booker
-          , subq_27.listings
+          subq_16.listing__bookings_per_booker
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__bookings_per_booker AS listing__bookings_per_booker
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings_per_booker']
             SELECT
-              subq_25.listing
-              , subq_25.listing__bookings_per_booker
+              subq_14.listing
+              , subq_14.listing__bookings_per_booker
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
-                , CAST(subq_24.bookings AS DOUBLE) / CAST(NULLIF(subq_24.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+                subq_13.listing
+                , CAST(subq_13.bookings AS DOUBLE) / CAST(NULLIF(subq_13.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.bookings) AS bookings
-                  , MAX(subq_23.bookers) AS bookers
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.bookings) AS bookings
+                  , MAX(subq_12.bookers) AS bookers
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.bookings
+                    subq_6.listing
+                    , subq_6.bookings
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.bookings) AS bookings
+                      subq_5.listing
+                      , SUM(subq_5.bookings) AS bookings
                     FROM (
                       -- Pass Only Elements: ['bookings', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.bookings
+                        subq_4.listing
+                        , subq_4.bookings
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,129 +387,129 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.bookers
+                    subq_11.listing
+                    , subq_11.bookers
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , COUNT(DISTINCT subq_21.bookers) AS bookers
+                      subq_10.listing
+                      , COUNT(DISTINCT subq_10.bookers) AS bookers
                     FROM (
                       -- Pass Only Elements: ['bookers', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.bookers
+                        subq_9.listing
+                        , subq_9.bookers
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.paid_at__day
-                          , subq_19.paid_at__week
-                          , subq_19.paid_at__month
-                          , subq_19.paid_at__quarter
-                          , subq_19.paid_at__year
-                          , subq_19.paid_at__extract_year
-                          , subq_19.paid_at__extract_quarter
-                          , subq_19.paid_at__extract_month
-                          , subq_19.paid_at__extract_day
-                          , subq_19.paid_at__extract_dow
-                          , subq_19.paid_at__extract_doy
-                          , subq_19.booking__ds__day
-                          , subq_19.booking__ds__week
-                          , subq_19.booking__ds__month
-                          , subq_19.booking__ds__quarter
-                          , subq_19.booking__ds__year
-                          , subq_19.booking__ds__extract_year
-                          , subq_19.booking__ds__extract_quarter
-                          , subq_19.booking__ds__extract_month
-                          , subq_19.booking__ds__extract_day
-                          , subq_19.booking__ds__extract_dow
-                          , subq_19.booking__ds__extract_doy
-                          , subq_19.booking__ds_partitioned__day
-                          , subq_19.booking__ds_partitioned__week
-                          , subq_19.booking__ds_partitioned__month
-                          , subq_19.booking__ds_partitioned__quarter
-                          , subq_19.booking__ds_partitioned__year
-                          , subq_19.booking__ds_partitioned__extract_year
-                          , subq_19.booking__ds_partitioned__extract_quarter
-                          , subq_19.booking__ds_partitioned__extract_month
-                          , subq_19.booking__ds_partitioned__extract_day
-                          , subq_19.booking__ds_partitioned__extract_dow
-                          , subq_19.booking__ds_partitioned__extract_doy
-                          , subq_19.booking__paid_at__day
-                          , subq_19.booking__paid_at__week
-                          , subq_19.booking__paid_at__month
-                          , subq_19.booking__paid_at__quarter
-                          , subq_19.booking__paid_at__year
-                          , subq_19.booking__paid_at__extract_year
-                          , subq_19.booking__paid_at__extract_quarter
-                          , subq_19.booking__paid_at__extract_month
-                          , subq_19.booking__paid_at__extract_day
-                          , subq_19.booking__paid_at__extract_dow
-                          , subq_19.booking__paid_at__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.guest
-                          , subq_19.host
-                          , subq_19.booking__listing
-                          , subq_19.booking__guest
-                          , subq_19.booking__host
-                          , subq_19.is_instant
-                          , subq_19.booking__is_instant
-                          , subq_19.bookings
-                          , subq_19.instant_bookings
-                          , subq_19.booking_value
-                          , subq_19.max_booking_value
-                          , subq_19.min_booking_value
-                          , subq_19.bookers
-                          , subq_19.average_booking_value
-                          , subq_19.referred_bookings
-                          , subq_19.median_booking_value
-                          , subq_19.booking_value_p99
-                          , subq_19.discrete_booking_value_p99
-                          , subq_19.approximate_continuous_booking_value_p99
-                          , subq_19.approximate_discrete_booking_value_p99
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.paid_at__day
+                          , subq_8.paid_at__week
+                          , subq_8.paid_at__month
+                          , subq_8.paid_at__quarter
+                          , subq_8.paid_at__year
+                          , subq_8.paid_at__extract_year
+                          , subq_8.paid_at__extract_quarter
+                          , subq_8.paid_at__extract_month
+                          , subq_8.paid_at__extract_day
+                          , subq_8.paid_at__extract_dow
+                          , subq_8.paid_at__extract_doy
+                          , subq_8.booking__ds__day
+                          , subq_8.booking__ds__week
+                          , subq_8.booking__ds__month
+                          , subq_8.booking__ds__quarter
+                          , subq_8.booking__ds__year
+                          , subq_8.booking__ds__extract_year
+                          , subq_8.booking__ds__extract_quarter
+                          , subq_8.booking__ds__extract_month
+                          , subq_8.booking__ds__extract_day
+                          , subq_8.booking__ds__extract_dow
+                          , subq_8.booking__ds__extract_doy
+                          , subq_8.booking__ds_partitioned__day
+                          , subq_8.booking__ds_partitioned__week
+                          , subq_8.booking__ds_partitioned__month
+                          , subq_8.booking__ds_partitioned__quarter
+                          , subq_8.booking__ds_partitioned__year
+                          , subq_8.booking__ds_partitioned__extract_year
+                          , subq_8.booking__ds_partitioned__extract_quarter
+                          , subq_8.booking__ds_partitioned__extract_month
+                          , subq_8.booking__ds_partitioned__extract_day
+                          , subq_8.booking__ds_partitioned__extract_dow
+                          , subq_8.booking__ds_partitioned__extract_doy
+                          , subq_8.booking__paid_at__day
+                          , subq_8.booking__paid_at__week
+                          , subq_8.booking__paid_at__month
+                          , subq_8.booking__paid_at__quarter
+                          , subq_8.booking__paid_at__year
+                          , subq_8.booking__paid_at__extract_year
+                          , subq_8.booking__paid_at__extract_quarter
+                          , subq_8.booking__paid_at__extract_month
+                          , subq_8.booking__paid_at__extract_day
+                          , subq_8.booking__paid_at__extract_dow
+                          , subq_8.booking__paid_at__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.guest
+                          , subq_8.host
+                          , subq_8.booking__listing
+                          , subq_8.booking__guest
+                          , subq_8.booking__host
+                          , subq_8.is_instant
+                          , subq_8.booking__is_instant
+                          , subq_8.bookings
+                          , subq_8.instant_bookings
+                          , subq_8.booking_value
+                          , subq_8.max_booking_value
+                          , subq_8.min_booking_value
+                          , subq_8.bookers
+                          , subq_8.average_booking_value
+                          , subq_8.referred_bookings
+                          , subq_8.median_booking_value
+                          , subq_8.booking_value_p99
+                          , subq_8.discrete_booking_value_p99
+                          , subq_8.approximate_continuous_booking_value_p99
+                          , subq_8.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -602,25 +602,25 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__bookings_per_booker > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_56.bookings AS DOUBLE) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
-    , subq_45.listings AS listings
+    CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_50.listing, subq_55.listing) AS listing
-      , MAX(subq_50.bookings) AS bookings
-      , MAX(subq_55.bookers) AS bookers
+      COALESCE(subq_28.listing, subq_33.listing) AS listing
+      , MAX(subq_28.bookings) AS bookings
+      , MAX(subq_33.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_48
+      ) subq_26
       GROUP BY
         listing
-    ) subq_50
+    ) subq_28
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_55
+    ) subq_33
     ON
-      subq_50.listing = subq_55.listing
+      subq_28.listing = subq_33.listing
     GROUP BY
-      COALESCE(subq_50.listing, subq_55.listing)
-  ) subq_56
+      COALESCE(subq_28.listing, subq_33.listing)
+  ) subq_34
   ON
-    subq_45.listing = subq_56.listing
-) subq_60
+    subq_23.listing = subq_34.listing
+) subq_38
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings']
         SELECT
-          subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,130 +160,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -376,19 +376,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -1,20 +1,20 @@
 -- Pass Only Elements: ['listing',]
 SELECT
-  subq_12.listing
+  subq_8.listing
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_11.listing
-    , subq_11.lux_listing
-    , subq_11.listing__lux_listing
-    , subq_11.listing__bookings
+    subq_7.listing
+    , subq_7.lux_listing
+    , subq_7.listing__lux_listing
+    , subq_7.listing__bookings
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_4.listing AS listing
-      , subq_4.lux_listing AS lux_listing
-      , subq_4.listing__lux_listing AS listing__lux_listing
-      , subq_10.listing__bookings AS listing__bookings
+      subq_0.listing AS listing
+      , subq_0.lux_listing AS lux_listing
+      , subq_0.listing__lux_listing AS listing__lux_listing
+      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT
@@ -22,128 +22,128 @@ FROM (
         , lux_listing_mapping_src_28000.lux_listing_id AS lux_listing
         , lux_listing_mapping_src_28000.lux_listing_id AS listing__lux_listing
       FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
-    ) subq_4
+    ) subq_0
     FULL OUTER JOIN (
       -- Pass Only Elements: ['listing', 'listing__bookings']
       SELECT
-        subq_9.listing
-        , subq_9.listing__bookings
+        subq_5.listing
+        , subq_5.listing__bookings
       FROM (
         -- Compute Metrics via Expressions
         SELECT
-          subq_8.listing
-          , subq_8.bookings AS listing__bookings
+          subq_4.listing
+          , subq_4.bookings AS listing__bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_7.listing
-            , SUM(subq_7.bookings) AS bookings
+            subq_3.listing
+            , SUM(subq_3.bookings) AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'listing']
             SELECT
-              subq_6.listing
-              , subq_6.bookings
+              subq_2.listing
+              , subq_2.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds__day
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.ds__extract_year
-                , subq_5.ds__extract_quarter
-                , subq_5.ds__extract_month
-                , subq_5.ds__extract_day
-                , subq_5.ds__extract_dow
-                , subq_5.ds__extract_doy
-                , subq_5.ds_partitioned__day
-                , subq_5.ds_partitioned__week
-                , subq_5.ds_partitioned__month
-                , subq_5.ds_partitioned__quarter
-                , subq_5.ds_partitioned__year
-                , subq_5.ds_partitioned__extract_year
-                , subq_5.ds_partitioned__extract_quarter
-                , subq_5.ds_partitioned__extract_month
-                , subq_5.ds_partitioned__extract_day
-                , subq_5.ds_partitioned__extract_dow
-                , subq_5.ds_partitioned__extract_doy
-                , subq_5.paid_at__day
-                , subq_5.paid_at__week
-                , subq_5.paid_at__month
-                , subq_5.paid_at__quarter
-                , subq_5.paid_at__year
-                , subq_5.paid_at__extract_year
-                , subq_5.paid_at__extract_quarter
-                , subq_5.paid_at__extract_month
-                , subq_5.paid_at__extract_day
-                , subq_5.paid_at__extract_dow
-                , subq_5.paid_at__extract_doy
-                , subq_5.booking__ds__day
-                , subq_5.booking__ds__week
-                , subq_5.booking__ds__month
-                , subq_5.booking__ds__quarter
-                , subq_5.booking__ds__year
-                , subq_5.booking__ds__extract_year
-                , subq_5.booking__ds__extract_quarter
-                , subq_5.booking__ds__extract_month
-                , subq_5.booking__ds__extract_day
-                , subq_5.booking__ds__extract_dow
-                , subq_5.booking__ds__extract_doy
-                , subq_5.booking__ds_partitioned__day
-                , subq_5.booking__ds_partitioned__week
-                , subq_5.booking__ds_partitioned__month
-                , subq_5.booking__ds_partitioned__quarter
-                , subq_5.booking__ds_partitioned__year
-                , subq_5.booking__ds_partitioned__extract_year
-                , subq_5.booking__ds_partitioned__extract_quarter
-                , subq_5.booking__ds_partitioned__extract_month
-                , subq_5.booking__ds_partitioned__extract_day
-                , subq_5.booking__ds_partitioned__extract_dow
-                , subq_5.booking__ds_partitioned__extract_doy
-                , subq_5.booking__paid_at__day
-                , subq_5.booking__paid_at__week
-                , subq_5.booking__paid_at__month
-                , subq_5.booking__paid_at__quarter
-                , subq_5.booking__paid_at__year
-                , subq_5.booking__paid_at__extract_year
-                , subq_5.booking__paid_at__extract_quarter
-                , subq_5.booking__paid_at__extract_month
-                , subq_5.booking__paid_at__extract_day
-                , subq_5.booking__paid_at__extract_dow
-                , subq_5.booking__paid_at__extract_doy
-                , subq_5.ds__day AS metric_time__day
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.ds__extract_year AS metric_time__extract_year
-                , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_5.ds__extract_month AS metric_time__extract_month
-                , subq_5.ds__extract_day AS metric_time__extract_day
-                , subq_5.ds__extract_dow AS metric_time__extract_dow
-                , subq_5.ds__extract_doy AS metric_time__extract_doy
-                , subq_5.listing
-                , subq_5.guest
-                , subq_5.host
-                , subq_5.booking__listing
-                , subq_5.booking__guest
-                , subq_5.booking__host
-                , subq_5.is_instant
-                , subq_5.booking__is_instant
-                , subq_5.bookings
-                , subq_5.instant_bookings
-                , subq_5.booking_value
-                , subq_5.max_booking_value
-                , subq_5.min_booking_value
-                , subq_5.bookers
-                , subq_5.average_booking_value
-                , subq_5.referred_bookings
-                , subq_5.median_booking_value
-                , subq_5.booking_value_p99
-                , subq_5.discrete_booking_value_p99
-                , subq_5.approximate_continuous_booking_value_p99
-                , subq_5.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.ds__day AS metric_time__day
+                , subq_1.ds__week AS metric_time__week
+                , subq_1.ds__month AS metric_time__month
+                , subq_1.ds__quarter AS metric_time__quarter
+                , subq_1.ds__year AS metric_time__year
+                , subq_1.ds__extract_year AS metric_time__extract_year
+                , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_1.ds__extract_month AS metric_time__extract_month
+                , subq_1.ds__extract_day AS metric_time__extract_day
+                , subq_1.ds__extract_dow AS metric_time__extract_dow
+                , subq_1.ds__extract_doy AS metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -236,18 +236,18 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_5
-            ) subq_6
-          ) subq_7
+              ) subq_1
+            ) subq_2
+          ) subq_3
           GROUP BY
-            subq_7.listing
-        ) subq_8
-      ) subq_9
-    ) subq_10
+            subq_3.listing
+        ) subq_4
+      ) subq_5
+    ) subq_6
     ON
-      subq_4.listing = subq_10.listing
-  ) subq_11
+      subq_0.listing = subq_6.listing
+  ) subq_7
   WHERE listing__bookings > 2
-) subq_12
+) subq_8
 GROUP BY
-  subq_12.listing
+  subq_8.listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_23.listing__bookings AS listing__bookings
+    , subq_15.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+    ) subq_12
     GROUP BY
       listing
-  ) subq_23
+  ) subq_15
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_23.listing
-) subq_24
+    lux_listing_mapping_src_28000.listing_id = subq_15.listing
+) subq_16
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.guest__booking_value
-        , subq_14.bookers
+        subq_10.guest__booking_value
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'guest__booking_value']
         SELECT
-          subq_13.guest__booking_value
-          , subq_13.bookers
+          subq_9.guest__booking_value
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.guest AS guest
-            , subq_12.guest__booking_value AS guest__booking_value
-            , subq_6.bookers AS bookers
+            subq_2.guest AS guest
+            , subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']
             SELECT
-              subq_5.guest
-              , subq_5.bookers
+              subq_1.guest
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['guest', 'guest__booking_value']
             SELECT
-              subq_11.guest
-              , subq_11.guest__booking_value
+              subq_7.guest
+              , subq_7.guest__booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.guest
-                , subq_10.booking_value AS guest__booking_value
+                subq_6.guest
+                , subq_6.booking_value AS guest__booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.guest
-                  , SUM(subq_9.booking_value) AS booking_value
+                  subq_5.guest
+                  , SUM(subq_5.booking_value) AS booking_value
                 FROM (
                   -- Pass Only Elements: ['booking_value', 'guest']
                   SELECT
-                    subq_8.guest
-                    , subq_8.booking_value
+                    subq_4.guest
+                    , subq_4.booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.guest
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.guest
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.guest = subq_12.guest
-        ) subq_13
-      ) subq_14
+            subq_2.guest = subq_8.guest
+        ) subq_9
+      ) subq_10
       WHERE guest__booking_value > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_30.guest__booking_value AS guest__booking_value
-    , subq_24.bookers AS bookers
+    subq_22.guest__booking_value AS guest__booking_value
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.guest = subq_30.guest
-) subq_32
+    subq_16.guest = subq_22.guest
+) subq_24
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_39.listings
+  subq_24.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_38.listings) AS listings
+    SUM(subq_23.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_37.listings
+      subq_22.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_36.user__visit_buy_conversion_rate
-        , subq_36.listings
+        subq_21.user__visit_buy_conversion_rate
+        , subq_21.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
         SELECT
-          subq_35.user__visit_buy_conversion_rate
-          , subq_35.listings
+          subq_20.user__visit_buy_conversion_rate
+          , subq_20.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_17.user AS user
-            , subq_34.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
-            , subq_17.listings AS listings
+            subq_2.user AS user
+            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_16.user
-              , subq_16.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_15.ds__day
-                , subq_15.ds__week
-                , subq_15.ds__month
-                , subq_15.ds__quarter
-                , subq_15.ds__year
-                , subq_15.ds__extract_year
-                , subq_15.ds__extract_quarter
-                , subq_15.ds__extract_month
-                , subq_15.ds__extract_day
-                , subq_15.ds__extract_dow
-                , subq_15.ds__extract_doy
-                , subq_15.created_at__day
-                , subq_15.created_at__week
-                , subq_15.created_at__month
-                , subq_15.created_at__quarter
-                , subq_15.created_at__year
-                , subq_15.created_at__extract_year
-                , subq_15.created_at__extract_quarter
-                , subq_15.created_at__extract_month
-                , subq_15.created_at__extract_day
-                , subq_15.created_at__extract_dow
-                , subq_15.created_at__extract_doy
-                , subq_15.listing__ds__day
-                , subq_15.listing__ds__week
-                , subq_15.listing__ds__month
-                , subq_15.listing__ds__quarter
-                , subq_15.listing__ds__year
-                , subq_15.listing__ds__extract_year
-                , subq_15.listing__ds__extract_quarter
-                , subq_15.listing__ds__extract_month
-                , subq_15.listing__ds__extract_day
-                , subq_15.listing__ds__extract_dow
-                , subq_15.listing__ds__extract_doy
-                , subq_15.listing__created_at__day
-                , subq_15.listing__created_at__week
-                , subq_15.listing__created_at__month
-                , subq_15.listing__created_at__quarter
-                , subq_15.listing__created_at__year
-                , subq_15.listing__created_at__extract_year
-                , subq_15.listing__created_at__extract_quarter
-                , subq_15.listing__created_at__extract_month
-                , subq_15.listing__created_at__extract_day
-                , subq_15.listing__created_at__extract_dow
-                , subq_15.listing__created_at__extract_doy
-                , subq_15.ds__day AS metric_time__day
-                , subq_15.ds__week AS metric_time__week
-                , subq_15.ds__month AS metric_time__month
-                , subq_15.ds__quarter AS metric_time__quarter
-                , subq_15.ds__year AS metric_time__year
-                , subq_15.ds__extract_year AS metric_time__extract_year
-                , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_15.ds__extract_month AS metric_time__extract_month
-                , subq_15.ds__extract_day AS metric_time__extract_day
-                , subq_15.ds__extract_dow AS metric_time__extract_dow
-                , subq_15.ds__extract_doy AS metric_time__extract_doy
-                , subq_15.listing
-                , subq_15.user
-                , subq_15.listing__user
-                , subq_15.country_latest
-                , subq_15.is_lux_latest
-                , subq_15.capacity_latest
-                , subq_15.listing__country_latest
-                , subq_15.listing__is_lux_latest
-                , subq_15.listing__capacity_latest
-                , subq_15.listings
-                , subq_15.largest_listing
-                , subq_15.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,79 +160,79 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_15
-            ) subq_16
-          ) subq_17
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__visit_buy_conversion_rate']
             SELECT
-              subq_33.user
-              , subq_33.user__visit_buy_conversion_rate
+              subq_18.user
+              , subq_18.user__visit_buy_conversion_rate
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_32.user
-                , CAST(subq_32.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_32.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
+                subq_17.user
+                , CAST(subq_17.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_21.user, subq_31.user) AS user
-                  , MAX(subq_21.visits) AS visits
-                  , MAX(subq_31.buys) AS buys
+                  COALESCE(subq_6.user, subq_16.user) AS user
+                  , MAX(subq_6.visits) AS visits
+                  , MAX(subq_16.buys) AS buys
                 FROM (
                   -- Aggregate Measures
                   SELECT
-                    subq_20.user
-                    , SUM(subq_20.visits) AS visits
+                    subq_5.user
+                    , SUM(subq_5.visits) AS visits
                   FROM (
                     -- Pass Only Elements: ['visits', 'user']
                     SELECT
-                      subq_19.user
-                      , subq_19.visits
+                      subq_4.user
+                      , subq_4.visits
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_18.ds__day
-                        , subq_18.ds__week
-                        , subq_18.ds__month
-                        , subq_18.ds__quarter
-                        , subq_18.ds__year
-                        , subq_18.ds__extract_year
-                        , subq_18.ds__extract_quarter
-                        , subq_18.ds__extract_month
-                        , subq_18.ds__extract_day
-                        , subq_18.ds__extract_dow
-                        , subq_18.ds__extract_doy
-                        , subq_18.visit__ds__day
-                        , subq_18.visit__ds__week
-                        , subq_18.visit__ds__month
-                        , subq_18.visit__ds__quarter
-                        , subq_18.visit__ds__year
-                        , subq_18.visit__ds__extract_year
-                        , subq_18.visit__ds__extract_quarter
-                        , subq_18.visit__ds__extract_month
-                        , subq_18.visit__ds__extract_day
-                        , subq_18.visit__ds__extract_dow
-                        , subq_18.visit__ds__extract_doy
-                        , subq_18.ds__day AS metric_time__day
-                        , subq_18.ds__week AS metric_time__week
-                        , subq_18.ds__month AS metric_time__month
-                        , subq_18.ds__quarter AS metric_time__quarter
-                        , subq_18.ds__year AS metric_time__year
-                        , subq_18.ds__extract_year AS metric_time__extract_year
-                        , subq_18.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_18.ds__extract_month AS metric_time__extract_month
-                        , subq_18.ds__extract_day AS metric_time__extract_day
-                        , subq_18.ds__extract_dow AS metric_time__extract_dow
-                        , subq_18.ds__extract_doy AS metric_time__extract_doy
-                        , subq_18.user
-                        , subq_18.session
-                        , subq_18.visit__user
-                        , subq_18.visit__session
-                        , subq_18.referrer_id
-                        , subq_18.visit__referrer_id
-                        , subq_18.visits
-                        , subq_18.visitors
+                        subq_3.ds__day
+                        , subq_3.ds__week
+                        , subq_3.ds__month
+                        , subq_3.ds__quarter
+                        , subq_3.ds__year
+                        , subq_3.ds__extract_year
+                        , subq_3.ds__extract_quarter
+                        , subq_3.ds__extract_month
+                        , subq_3.ds__extract_day
+                        , subq_3.ds__extract_dow
+                        , subq_3.ds__extract_doy
+                        , subq_3.visit__ds__day
+                        , subq_3.visit__ds__week
+                        , subq_3.visit__ds__month
+                        , subq_3.visit__ds__quarter
+                        , subq_3.visit__ds__year
+                        , subq_3.visit__ds__extract_year
+                        , subq_3.visit__ds__extract_quarter
+                        , subq_3.visit__ds__extract_month
+                        , subq_3.visit__ds__extract_day
+                        , subq_3.visit__ds__extract_dow
+                        , subq_3.visit__ds__extract_doy
+                        , subq_3.ds__day AS metric_time__day
+                        , subq_3.ds__week AS metric_time__week
+                        , subq_3.ds__month AS metric_time__month
+                        , subq_3.ds__quarter AS metric_time__quarter
+                        , subq_3.ds__year AS metric_time__year
+                        , subq_3.ds__extract_year AS metric_time__extract_year
+                        , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_3.ds__extract_month AS metric_time__extract_month
+                        , subq_3.ds__extract_day AS metric_time__extract_day
+                        , subq_3.ds__extract_dow AS metric_time__extract_dow
+                        , subq_3.ds__extract_doy AS metric_time__extract_doy
+                        , subq_3.user
+                        , subq_3.session
+                        , subq_3.visit__user
+                        , subq_3.visit__session
+                        , subq_3.referrer_id
+                        , subq_3.visit__referrer_id
+                        , subq_3.visits
+                        , subq_3.visitors
                       FROM (
                         -- Read Elements From Semantic Model 'visits_source'
                         SELECT
@@ -267,108 +267,108 @@ FROM (
                           , visits_source_src_28000.user_id AS visit__user
                           , visits_source_src_28000.session_id AS visit__session
                         FROM ***************************.fct_visits visits_source_src_28000
-                      ) subq_18
-                    ) subq_19
-                  ) subq_20
+                      ) subq_3
+                    ) subq_4
+                  ) subq_5
                   GROUP BY
-                    subq_20.user
-                ) subq_21
+                    subq_5.user
+                ) subq_6
                 FULL OUTER JOIN (
                   -- Aggregate Measures
                   SELECT
-                    subq_30.user
-                    , SUM(subq_30.buys) AS buys
+                    subq_15.user
+                    , SUM(subq_15.buys) AS buys
                   FROM (
                     -- Pass Only Elements: ['buys', 'user']
                     SELECT
-                      subq_29.user
-                      , subq_29.buys
+                      subq_14.user
+                      , subq_14.buys
                     FROM (
                       -- Find conversions for user within the range of INF
                       SELECT
-                        subq_28.ds__day
-                        , subq_28.user
-                        , subq_28.buys
-                        , subq_28.visits
+                        subq_13.ds__day
+                        , subq_13.user
+                        , subq_13.buys
+                        , subq_13.visits
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          FIRST_VALUE(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_9.visits) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , FIRST_VALUE(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_9.ds__day) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , FIRST_VALUE(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_9.user) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS user
-                          , subq_27.mf_internal_uuid AS mf_internal_uuid
-                          , subq_27.buys AS buys
+                          , subq_12.mf_internal_uuid AS mf_internal_uuid
+                          , subq_12.buys AS buys
                         FROM (
                           -- Pass Only Elements: ['visits', 'ds__day', 'user']
                           SELECT
-                            subq_23.ds__day
-                            , subq_23.user
-                            , subq_23.visits
+                            subq_8.ds__day
+                            , subq_8.user
+                            , subq_8.visits
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_22.ds__day
-                              , subq_22.ds__week
-                              , subq_22.ds__month
-                              , subq_22.ds__quarter
-                              , subq_22.ds__year
-                              , subq_22.ds__extract_year
-                              , subq_22.ds__extract_quarter
-                              , subq_22.ds__extract_month
-                              , subq_22.ds__extract_day
-                              , subq_22.ds__extract_dow
-                              , subq_22.ds__extract_doy
-                              , subq_22.visit__ds__day
-                              , subq_22.visit__ds__week
-                              , subq_22.visit__ds__month
-                              , subq_22.visit__ds__quarter
-                              , subq_22.visit__ds__year
-                              , subq_22.visit__ds__extract_year
-                              , subq_22.visit__ds__extract_quarter
-                              , subq_22.visit__ds__extract_month
-                              , subq_22.visit__ds__extract_day
-                              , subq_22.visit__ds__extract_dow
-                              , subq_22.visit__ds__extract_doy
-                              , subq_22.ds__day AS metric_time__day
-                              , subq_22.ds__week AS metric_time__week
-                              , subq_22.ds__month AS metric_time__month
-                              , subq_22.ds__quarter AS metric_time__quarter
-                              , subq_22.ds__year AS metric_time__year
-                              , subq_22.ds__extract_year AS metric_time__extract_year
-                              , subq_22.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_22.ds__extract_month AS metric_time__extract_month
-                              , subq_22.ds__extract_day AS metric_time__extract_day
-                              , subq_22.ds__extract_dow AS metric_time__extract_dow
-                              , subq_22.ds__extract_doy AS metric_time__extract_doy
-                              , subq_22.user
-                              , subq_22.session
-                              , subq_22.visit__user
-                              , subq_22.visit__session
-                              , subq_22.referrer_id
-                              , subq_22.visit__referrer_id
-                              , subq_22.visits
-                              , subq_22.visitors
+                              subq_7.ds__day
+                              , subq_7.ds__week
+                              , subq_7.ds__month
+                              , subq_7.ds__quarter
+                              , subq_7.ds__year
+                              , subq_7.ds__extract_year
+                              , subq_7.ds__extract_quarter
+                              , subq_7.ds__extract_month
+                              , subq_7.ds__extract_day
+                              , subq_7.ds__extract_dow
+                              , subq_7.ds__extract_doy
+                              , subq_7.visit__ds__day
+                              , subq_7.visit__ds__week
+                              , subq_7.visit__ds__month
+                              , subq_7.visit__ds__quarter
+                              , subq_7.visit__ds__year
+                              , subq_7.visit__ds__extract_year
+                              , subq_7.visit__ds__extract_quarter
+                              , subq_7.visit__ds__extract_month
+                              , subq_7.visit__ds__extract_day
+                              , subq_7.visit__ds__extract_dow
+                              , subq_7.visit__ds__extract_doy
+                              , subq_7.ds__day AS metric_time__day
+                              , subq_7.ds__week AS metric_time__week
+                              , subq_7.ds__month AS metric_time__month
+                              , subq_7.ds__quarter AS metric_time__quarter
+                              , subq_7.ds__year AS metric_time__year
+                              , subq_7.ds__extract_year AS metric_time__extract_year
+                              , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_7.ds__extract_month AS metric_time__extract_month
+                              , subq_7.ds__extract_day AS metric_time__extract_day
+                              , subq_7.ds__extract_dow AS metric_time__extract_dow
+                              , subq_7.ds__extract_doy AS metric_time__extract_doy
+                              , subq_7.user
+                              , subq_7.session
+                              , subq_7.visit__user
+                              , subq_7.visit__session
+                              , subq_7.referrer_id
+                              , subq_7.visit__referrer_id
+                              , subq_7.visits
+                              , subq_7.visitors
                             FROM (
                               -- Read Elements From Semantic Model 'visits_source'
                               SELECT
@@ -403,94 +403,94 @@ FROM (
                                 , visits_source_src_28000.user_id AS visit__user
                                 , visits_source_src_28000.session_id AS visit__session
                               FROM ***************************.fct_visits visits_source_src_28000
-                            ) subq_22
-                          ) subq_23
-                        ) subq_24
+                            ) subq_7
+                          ) subq_8
+                        ) subq_9
                         INNER JOIN (
                           -- Add column with generated UUID
                           SELECT
-                            subq_26.ds__day
-                            , subq_26.ds__week
-                            , subq_26.ds__month
-                            , subq_26.ds__quarter
-                            , subq_26.ds__year
-                            , subq_26.ds__extract_year
-                            , subq_26.ds__extract_quarter
-                            , subq_26.ds__extract_month
-                            , subq_26.ds__extract_day
-                            , subq_26.ds__extract_dow
-                            , subq_26.ds__extract_doy
-                            , subq_26.buy__ds__day
-                            , subq_26.buy__ds__week
-                            , subq_26.buy__ds__month
-                            , subq_26.buy__ds__quarter
-                            , subq_26.buy__ds__year
-                            , subq_26.buy__ds__extract_year
-                            , subq_26.buy__ds__extract_quarter
-                            , subq_26.buy__ds__extract_month
-                            , subq_26.buy__ds__extract_day
-                            , subq_26.buy__ds__extract_dow
-                            , subq_26.buy__ds__extract_doy
-                            , subq_26.metric_time__day
-                            , subq_26.metric_time__week
-                            , subq_26.metric_time__month
-                            , subq_26.metric_time__quarter
-                            , subq_26.metric_time__year
-                            , subq_26.metric_time__extract_year
-                            , subq_26.metric_time__extract_quarter
-                            , subq_26.metric_time__extract_month
-                            , subq_26.metric_time__extract_day
-                            , subq_26.metric_time__extract_dow
-                            , subq_26.metric_time__extract_doy
-                            , subq_26.user
-                            , subq_26.session_id
-                            , subq_26.buy__user
-                            , subq_26.buy__session_id
-                            , subq_26.buys
-                            , subq_26.buyers
+                            subq_11.ds__day
+                            , subq_11.ds__week
+                            , subq_11.ds__month
+                            , subq_11.ds__quarter
+                            , subq_11.ds__year
+                            , subq_11.ds__extract_year
+                            , subq_11.ds__extract_quarter
+                            , subq_11.ds__extract_month
+                            , subq_11.ds__extract_day
+                            , subq_11.ds__extract_dow
+                            , subq_11.ds__extract_doy
+                            , subq_11.buy__ds__day
+                            , subq_11.buy__ds__week
+                            , subq_11.buy__ds__month
+                            , subq_11.buy__ds__quarter
+                            , subq_11.buy__ds__year
+                            , subq_11.buy__ds__extract_year
+                            , subq_11.buy__ds__extract_quarter
+                            , subq_11.buy__ds__extract_month
+                            , subq_11.buy__ds__extract_day
+                            , subq_11.buy__ds__extract_dow
+                            , subq_11.buy__ds__extract_doy
+                            , subq_11.metric_time__day
+                            , subq_11.metric_time__week
+                            , subq_11.metric_time__month
+                            , subq_11.metric_time__quarter
+                            , subq_11.metric_time__year
+                            , subq_11.metric_time__extract_year
+                            , subq_11.metric_time__extract_quarter
+                            , subq_11.metric_time__extract_month
+                            , subq_11.metric_time__extract_day
+                            , subq_11.metric_time__extract_dow
+                            , subq_11.metric_time__extract_doy
+                            , subq_11.user
+                            , subq_11.session_id
+                            , subq_11.buy__user
+                            , subq_11.buy__session_id
+                            , subq_11.buys
+                            , subq_11.buyers
                             , GEN_RANDOM_UUID() AS mf_internal_uuid
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_25.ds__day
-                              , subq_25.ds__week
-                              , subq_25.ds__month
-                              , subq_25.ds__quarter
-                              , subq_25.ds__year
-                              , subq_25.ds__extract_year
-                              , subq_25.ds__extract_quarter
-                              , subq_25.ds__extract_month
-                              , subq_25.ds__extract_day
-                              , subq_25.ds__extract_dow
-                              , subq_25.ds__extract_doy
-                              , subq_25.buy__ds__day
-                              , subq_25.buy__ds__week
-                              , subq_25.buy__ds__month
-                              , subq_25.buy__ds__quarter
-                              , subq_25.buy__ds__year
-                              , subq_25.buy__ds__extract_year
-                              , subq_25.buy__ds__extract_quarter
-                              , subq_25.buy__ds__extract_month
-                              , subq_25.buy__ds__extract_day
-                              , subq_25.buy__ds__extract_dow
-                              , subq_25.buy__ds__extract_doy
-                              , subq_25.ds__day AS metric_time__day
-                              , subq_25.ds__week AS metric_time__week
-                              , subq_25.ds__month AS metric_time__month
-                              , subq_25.ds__quarter AS metric_time__quarter
-                              , subq_25.ds__year AS metric_time__year
-                              , subq_25.ds__extract_year AS metric_time__extract_year
-                              , subq_25.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_25.ds__extract_month AS metric_time__extract_month
-                              , subq_25.ds__extract_day AS metric_time__extract_day
-                              , subq_25.ds__extract_dow AS metric_time__extract_dow
-                              , subq_25.ds__extract_doy AS metric_time__extract_doy
-                              , subq_25.user
-                              , subq_25.session_id
-                              , subq_25.buy__user
-                              , subq_25.buy__session_id
-                              , subq_25.buys
-                              , subq_25.buyers
+                              subq_10.ds__day
+                              , subq_10.ds__week
+                              , subq_10.ds__month
+                              , subq_10.ds__quarter
+                              , subq_10.ds__year
+                              , subq_10.ds__extract_year
+                              , subq_10.ds__extract_quarter
+                              , subq_10.ds__extract_month
+                              , subq_10.ds__extract_day
+                              , subq_10.ds__extract_dow
+                              , subq_10.ds__extract_doy
+                              , subq_10.buy__ds__day
+                              , subq_10.buy__ds__week
+                              , subq_10.buy__ds__month
+                              , subq_10.buy__ds__quarter
+                              , subq_10.buy__ds__year
+                              , subq_10.buy__ds__extract_year
+                              , subq_10.buy__ds__extract_quarter
+                              , subq_10.buy__ds__extract_month
+                              , subq_10.buy__ds__extract_day
+                              , subq_10.buy__ds__extract_dow
+                              , subq_10.buy__ds__extract_doy
+                              , subq_10.ds__day AS metric_time__day
+                              , subq_10.ds__week AS metric_time__week
+                              , subq_10.ds__month AS metric_time__month
+                              , subq_10.ds__quarter AS metric_time__quarter
+                              , subq_10.ds__year AS metric_time__year
+                              , subq_10.ds__extract_year AS metric_time__extract_year
+                              , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_10.ds__extract_month AS metric_time__extract_month
+                              , subq_10.ds__extract_day AS metric_time__extract_day
+                              , subq_10.ds__extract_dow AS metric_time__extract_dow
+                              , subq_10.ds__extract_doy AS metric_time__extract_doy
+                              , subq_10.user
+                              , subq_10.session_id
+                              , subq_10.buy__user
+                              , subq_10.buy__session_id
+                              , subq_10.buys
+                              , subq_10.buyers
                             FROM (
                               -- Read Elements From Semantic Model 'buys_source'
                               SELECT
@@ -523,33 +523,33 @@ FROM (
                                 , buys_source_src_28000.user_id AS buy__user
                                 , buys_source_src_28000.session_id AS buy__session_id
                               FROM ***************************.fct_buys buys_source_src_28000
-                            ) subq_25
-                          ) subq_26
-                        ) subq_27
+                            ) subq_10
+                          ) subq_11
+                        ) subq_12
                         ON
                           (
-                            subq_24.user = subq_27.user
+                            subq_9.user = subq_12.user
                           ) AND (
-                            (subq_24.ds__day <= subq_27.ds__day)
+                            (subq_9.ds__day <= subq_12.ds__day)
                           )
-                      ) subq_28
-                    ) subq_29
-                  ) subq_30
+                      ) subq_13
+                    ) subq_14
+                  ) subq_15
                   GROUP BY
-                    subq_30.user
-                ) subq_31
+                    subq_15.user
+                ) subq_16
                 ON
-                  subq_21.user = subq_31.user
+                  subq_6.user = subq_16.user
                 GROUP BY
-                  COALESCE(subq_21.user, subq_31.user)
-              ) subq_32
-            ) subq_33
-          ) subq_34
+                  COALESCE(subq_6.user, subq_16.user)
+              ) subq_17
+            ) subq_18
+          ) subq_19
           ON
-            subq_17.user = subq_34.user
-        ) subq_35
-      ) subq_36
+            subq_2.user = subq_19.user
+        ) subq_20
+      ) subq_21
       WHERE user__visit_buy_conversion_rate > 2
-    ) subq_37
-  ) subq_38
-) subq_39
+    ) subq_22
+  ) subq_23
+) subq_24

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_72.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
-    , subq_57.listings AS listings
+    CAST(subq_42.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_42.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
+    , subq_27.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_57
+  ) subq_27
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_61.user, subq_71.user) AS user
-      , MAX(subq_61.visits) AS visits
-      , MAX(subq_71.buys) AS buys
+      COALESCE(subq_31.user, subq_41.user) AS user
+      , MAX(subq_31.visits) AS visits
+      , MAX(subq_41.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_60.user
+        subq_30.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_60
+      ) subq_30
       GROUP BY
-        subq_60.user
-    ) subq_61
+        subq_30.user
+    ) subq_31
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_68.user
+        subq_38.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_64.visits) OVER (
+          FIRST_VALUE(subq_34.visits) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_64.ds__day) OVER (
+          , FIRST_VALUE(subq_34.ds__day) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_64.user) OVER (
+          , FIRST_VALUE(subq_34.user) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_67.mf_internal_uuid AS mf_internal_uuid
-          , subq_67.buys AS buys
+          , subq_37.mf_internal_uuid AS mf_internal_uuid
+          , subq_37.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_64
+        ) subq_34
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , GEN_RANDOM_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_67
+        ) subq_37
         ON
           (
-            subq_64.user = subq_67.user
+            subq_34.user = subq_37.user
           ) AND (
-            (subq_64.ds__day <= subq_67.ds__day)
+            (subq_34.ds__day <= subq_37.ds__day)
           )
-      ) subq_68
+      ) subq_38
       GROUP BY
-        subq_68.user
-    ) subq_71
+        subq_38.user
+    ) subq_41
     ON
-      subq_61.user = subq_71.user
+      subq_31.user = subq_41.user
     GROUP BY
-      COALESCE(subq_61.user, subq_71.user)
-  ) subq_72
+      COALESCE(subq_31.user, subq_41.user)
+  ) subq_42
   ON
-    subq_57.user = subq_72.user
-) subq_76
+    subq_27.user = subq_42.user
+) subq_46
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0.sql
@@ -1,106 +1,106 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_18.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_17.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_16.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.user__listing__user__average_booking_value
-        , subq_24.listings
+        subq_15.user__listing__user__average_booking_value
+        , subq_15.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
         SELECT
-          subq_23.user__listing__user__average_booking_value
-          , subq_23.listings
+          subq_14.user__listing__user__average_booking_value
+          , subq_14.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.user AS user
-            , subq_22.listing__user AS user__listing__user
-            , subq_22.listing__user__average_booking_value AS user__listing__user__average_booking_value
-            , subq_11.listings AS listings
+            subq_2.user AS user
+            , subq_13.listing__user AS user__listing__user
+            , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_10.user
-              , subq_10.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds__day
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds__extract_year
-                , subq_9.ds__extract_quarter
-                , subq_9.ds__extract_month
-                , subq_9.ds__extract_day
-                , subq_9.ds__extract_dow
-                , subq_9.ds__extract_doy
-                , subq_9.created_at__day
-                , subq_9.created_at__week
-                , subq_9.created_at__month
-                , subq_9.created_at__quarter
-                , subq_9.created_at__year
-                , subq_9.created_at__extract_year
-                , subq_9.created_at__extract_quarter
-                , subq_9.created_at__extract_month
-                , subq_9.created_at__extract_day
-                , subq_9.created_at__extract_dow
-                , subq_9.created_at__extract_doy
-                , subq_9.listing__ds__day
-                , subq_9.listing__ds__week
-                , subq_9.listing__ds__month
-                , subq_9.listing__ds__quarter
-                , subq_9.listing__ds__year
-                , subq_9.listing__ds__extract_year
-                , subq_9.listing__ds__extract_quarter
-                , subq_9.listing__ds__extract_month
-                , subq_9.listing__ds__extract_day
-                , subq_9.listing__ds__extract_dow
-                , subq_9.listing__ds__extract_doy
-                , subq_9.listing__created_at__day
-                , subq_9.listing__created_at__week
-                , subq_9.listing__created_at__month
-                , subq_9.listing__created_at__quarter
-                , subq_9.listing__created_at__year
-                , subq_9.listing__created_at__extract_year
-                , subq_9.listing__created_at__extract_quarter
-                , subq_9.listing__created_at__extract_month
-                , subq_9.listing__created_at__extract_day
-                , subq_9.listing__created_at__extract_dow
-                , subq_9.listing__created_at__extract_doy
-                , subq_9.ds__day AS metric_time__day
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.ds__extract_year AS metric_time__extract_year
-                , subq_9.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.ds__extract_month AS metric_time__extract_month
-                , subq_9.ds__extract_day AS metric_time__extract_day
-                , subq_9.ds__extract_dow AS metric_time__extract_dow
-                , subq_9.ds__extract_doy AS metric_time__extract_doy
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.listing__user
-                , subq_9.country_latest
-                , subq_9.is_lux_latest
-                , subq_9.capacity_latest
-                , subq_9.listing__country_latest
-                , subq_9.listing__is_lux_latest
-                , subq_9.listing__capacity_latest
-                , subq_9.listings
-                , subq_9.largest_listing
-                , subq_9.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -161,141 +161,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
             SELECT
-              subq_21.listing__user
-              , subq_21.listing__user__average_booking_value
+              subq_12.listing__user
+              , subq_12.listing__user__average_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing__user
-                , subq_20.average_booking_value AS listing__user__average_booking_value
+                subq_11.listing__user
+                , subq_11.average_booking_value AS listing__user__average_booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing__user
-                  , AVG(subq_19.average_booking_value) AS average_booking_value
+                  subq_10.listing__user
+                  , AVG(subq_10.average_booking_value) AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'listing__user']
                   SELECT
-                    subq_18.listing__user
-                    , subq_18.average_booking_value
+                    subq_9.listing__user
+                    , subq_9.average_booking_value
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_14.listing AS listing
-                      , subq_17.user AS listing__user
-                      , subq_14.average_booking_value AS average_booking_value
+                      subq_5.listing AS listing
+                      , subq_8.user AS listing__user
+                      , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']
                       SELECT
-                        subq_13.listing
-                        , subq_13.average_booking_value
+                        subq_4.listing
+                        , subq_4.average_booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_12.ds__day
-                          , subq_12.ds__week
-                          , subq_12.ds__month
-                          , subq_12.ds__quarter
-                          , subq_12.ds__year
-                          , subq_12.ds__extract_year
-                          , subq_12.ds__extract_quarter
-                          , subq_12.ds__extract_month
-                          , subq_12.ds__extract_day
-                          , subq_12.ds__extract_dow
-                          , subq_12.ds__extract_doy
-                          , subq_12.ds_partitioned__day
-                          , subq_12.ds_partitioned__week
-                          , subq_12.ds_partitioned__month
-                          , subq_12.ds_partitioned__quarter
-                          , subq_12.ds_partitioned__year
-                          , subq_12.ds_partitioned__extract_year
-                          , subq_12.ds_partitioned__extract_quarter
-                          , subq_12.ds_partitioned__extract_month
-                          , subq_12.ds_partitioned__extract_day
-                          , subq_12.ds_partitioned__extract_dow
-                          , subq_12.ds_partitioned__extract_doy
-                          , subq_12.paid_at__day
-                          , subq_12.paid_at__week
-                          , subq_12.paid_at__month
-                          , subq_12.paid_at__quarter
-                          , subq_12.paid_at__year
-                          , subq_12.paid_at__extract_year
-                          , subq_12.paid_at__extract_quarter
-                          , subq_12.paid_at__extract_month
-                          , subq_12.paid_at__extract_day
-                          , subq_12.paid_at__extract_dow
-                          , subq_12.paid_at__extract_doy
-                          , subq_12.booking__ds__day
-                          , subq_12.booking__ds__week
-                          , subq_12.booking__ds__month
-                          , subq_12.booking__ds__quarter
-                          , subq_12.booking__ds__year
-                          , subq_12.booking__ds__extract_year
-                          , subq_12.booking__ds__extract_quarter
-                          , subq_12.booking__ds__extract_month
-                          , subq_12.booking__ds__extract_day
-                          , subq_12.booking__ds__extract_dow
-                          , subq_12.booking__ds__extract_doy
-                          , subq_12.booking__ds_partitioned__day
-                          , subq_12.booking__ds_partitioned__week
-                          , subq_12.booking__ds_partitioned__month
-                          , subq_12.booking__ds_partitioned__quarter
-                          , subq_12.booking__ds_partitioned__year
-                          , subq_12.booking__ds_partitioned__extract_year
-                          , subq_12.booking__ds_partitioned__extract_quarter
-                          , subq_12.booking__ds_partitioned__extract_month
-                          , subq_12.booking__ds_partitioned__extract_day
-                          , subq_12.booking__ds_partitioned__extract_dow
-                          , subq_12.booking__ds_partitioned__extract_doy
-                          , subq_12.booking__paid_at__day
-                          , subq_12.booking__paid_at__week
-                          , subq_12.booking__paid_at__month
-                          , subq_12.booking__paid_at__quarter
-                          , subq_12.booking__paid_at__year
-                          , subq_12.booking__paid_at__extract_year
-                          , subq_12.booking__paid_at__extract_quarter
-                          , subq_12.booking__paid_at__extract_month
-                          , subq_12.booking__paid_at__extract_day
-                          , subq_12.booking__paid_at__extract_dow
-                          , subq_12.booking__paid_at__extract_doy
-                          , subq_12.ds__day AS metric_time__day
-                          , subq_12.ds__week AS metric_time__week
-                          , subq_12.ds__month AS metric_time__month
-                          , subq_12.ds__quarter AS metric_time__quarter
-                          , subq_12.ds__year AS metric_time__year
-                          , subq_12.ds__extract_year AS metric_time__extract_year
-                          , subq_12.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_12.ds__extract_month AS metric_time__extract_month
-                          , subq_12.ds__extract_day AS metric_time__extract_day
-                          , subq_12.ds__extract_dow AS metric_time__extract_dow
-                          , subq_12.ds__extract_doy AS metric_time__extract_doy
-                          , subq_12.listing
-                          , subq_12.guest
-                          , subq_12.host
-                          , subq_12.booking__listing
-                          , subq_12.booking__guest
-                          , subq_12.booking__host
-                          , subq_12.is_instant
-                          , subq_12.booking__is_instant
-                          , subq_12.bookings
-                          , subq_12.instant_bookings
-                          , subq_12.booking_value
-                          , subq_12.max_booking_value
-                          , subq_12.min_booking_value
-                          , subq_12.bookers
-                          , subq_12.average_booking_value
-                          , subq_12.referred_bookings
-                          , subq_12.median_booking_value
-                          , subq_12.booking_value_p99
-                          , subq_12.discrete_booking_value_p99
-                          , subq_12.approximate_continuous_booking_value_p99
-                          , subq_12.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -388,84 +388,84 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_12
-                      ) subq_13
-                    ) subq_14
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['listing', 'user']
                       SELECT
-                        subq_16.listing
-                        , subq_16.user
+                        subq_7.listing
+                        , subq_7.user
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_15.ds__day
-                          , subq_15.ds__week
-                          , subq_15.ds__month
-                          , subq_15.ds__quarter
-                          , subq_15.ds__year
-                          , subq_15.ds__extract_year
-                          , subq_15.ds__extract_quarter
-                          , subq_15.ds__extract_month
-                          , subq_15.ds__extract_day
-                          , subq_15.ds__extract_dow
-                          , subq_15.ds__extract_doy
-                          , subq_15.created_at__day
-                          , subq_15.created_at__week
-                          , subq_15.created_at__month
-                          , subq_15.created_at__quarter
-                          , subq_15.created_at__year
-                          , subq_15.created_at__extract_year
-                          , subq_15.created_at__extract_quarter
-                          , subq_15.created_at__extract_month
-                          , subq_15.created_at__extract_day
-                          , subq_15.created_at__extract_dow
-                          , subq_15.created_at__extract_doy
-                          , subq_15.listing__ds__day
-                          , subq_15.listing__ds__week
-                          , subq_15.listing__ds__month
-                          , subq_15.listing__ds__quarter
-                          , subq_15.listing__ds__year
-                          , subq_15.listing__ds__extract_year
-                          , subq_15.listing__ds__extract_quarter
-                          , subq_15.listing__ds__extract_month
-                          , subq_15.listing__ds__extract_day
-                          , subq_15.listing__ds__extract_dow
-                          , subq_15.listing__ds__extract_doy
-                          , subq_15.listing__created_at__day
-                          , subq_15.listing__created_at__week
-                          , subq_15.listing__created_at__month
-                          , subq_15.listing__created_at__quarter
-                          , subq_15.listing__created_at__year
-                          , subq_15.listing__created_at__extract_year
-                          , subq_15.listing__created_at__extract_quarter
-                          , subq_15.listing__created_at__extract_month
-                          , subq_15.listing__created_at__extract_day
-                          , subq_15.listing__created_at__extract_dow
-                          , subq_15.listing__created_at__extract_doy
-                          , subq_15.ds__day AS metric_time__day
-                          , subq_15.ds__week AS metric_time__week
-                          , subq_15.ds__month AS metric_time__month
-                          , subq_15.ds__quarter AS metric_time__quarter
-                          , subq_15.ds__year AS metric_time__year
-                          , subq_15.ds__extract_year AS metric_time__extract_year
-                          , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_15.ds__extract_month AS metric_time__extract_month
-                          , subq_15.ds__extract_day AS metric_time__extract_day
-                          , subq_15.ds__extract_dow AS metric_time__extract_dow
-                          , subq_15.ds__extract_doy AS metric_time__extract_doy
-                          , subq_15.listing
-                          , subq_15.user
-                          , subq_15.listing__user
-                          , subq_15.country_latest
-                          , subq_15.is_lux_latest
-                          , subq_15.capacity_latest
-                          , subq_15.listing__country_latest
-                          , subq_15.listing__is_lux_latest
-                          , subq_15.listing__capacity_latest
-                          , subq_15.listings
-                          , subq_15.largest_listing
-                          , subq_15.smallest_listing
+                          subq_6.ds__day
+                          , subq_6.ds__week
+                          , subq_6.ds__month
+                          , subq_6.ds__quarter
+                          , subq_6.ds__year
+                          , subq_6.ds__extract_year
+                          , subq_6.ds__extract_quarter
+                          , subq_6.ds__extract_month
+                          , subq_6.ds__extract_day
+                          , subq_6.ds__extract_dow
+                          , subq_6.ds__extract_doy
+                          , subq_6.created_at__day
+                          , subq_6.created_at__week
+                          , subq_6.created_at__month
+                          , subq_6.created_at__quarter
+                          , subq_6.created_at__year
+                          , subq_6.created_at__extract_year
+                          , subq_6.created_at__extract_quarter
+                          , subq_6.created_at__extract_month
+                          , subq_6.created_at__extract_day
+                          , subq_6.created_at__extract_dow
+                          , subq_6.created_at__extract_doy
+                          , subq_6.listing__ds__day
+                          , subq_6.listing__ds__week
+                          , subq_6.listing__ds__month
+                          , subq_6.listing__ds__quarter
+                          , subq_6.listing__ds__year
+                          , subq_6.listing__ds__extract_year
+                          , subq_6.listing__ds__extract_quarter
+                          , subq_6.listing__ds__extract_month
+                          , subq_6.listing__ds__extract_day
+                          , subq_6.listing__ds__extract_dow
+                          , subq_6.listing__ds__extract_doy
+                          , subq_6.listing__created_at__day
+                          , subq_6.listing__created_at__week
+                          , subq_6.listing__created_at__month
+                          , subq_6.listing__created_at__quarter
+                          , subq_6.listing__created_at__year
+                          , subq_6.listing__created_at__extract_year
+                          , subq_6.listing__created_at__extract_quarter
+                          , subq_6.listing__created_at__extract_month
+                          , subq_6.listing__created_at__extract_day
+                          , subq_6.listing__created_at__extract_dow
+                          , subq_6.listing__created_at__extract_doy
+                          , subq_6.ds__day AS metric_time__day
+                          , subq_6.ds__week AS metric_time__week
+                          , subq_6.ds__month AS metric_time__month
+                          , subq_6.ds__quarter AS metric_time__quarter
+                          , subq_6.ds__year AS metric_time__year
+                          , subq_6.ds__extract_year AS metric_time__extract_year
+                          , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_6.ds__extract_month AS metric_time__extract_month
+                          , subq_6.ds__extract_day AS metric_time__extract_day
+                          , subq_6.ds__extract_dow AS metric_time__extract_dow
+                          , subq_6.ds__extract_doy AS metric_time__extract_doy
+                          , subq_6.listing
+                          , subq_6.user
+                          , subq_6.listing__user
+                          , subq_6.country_latest
+                          , subq_6.is_lux_latest
+                          , subq_6.capacity_latest
+                          , subq_6.listing__country_latest
+                          , subq_6.listing__is_lux_latest
+                          , subq_6.listing__capacity_latest
+                          , subq_6.listings
+                          , subq_6.largest_listing
+                          , subq_6.smallest_listing
                         FROM (
                           -- Read Elements From Semantic Model 'listings_latest'
                           SELECT
@@ -526,23 +526,23 @@ FROM (
                             , listings_latest_src_28000.user_id AS user
                             , listings_latest_src_28000.user_id AS listing__user
                           FROM ***************************.dim_listings_latest listings_latest_src_28000
-                        ) subq_15
-                      ) subq_16
-                    ) subq_17
+                        ) subq_6
+                      ) subq_7
+                    ) subq_8
                     ON
-                      subq_14.listing = subq_17.listing
-                  ) subq_18
-                ) subq_19
+                      subq_5.listing = subq_8.listing
+                  ) subq_9
+                ) subq_10
                 GROUP BY
-                  subq_19.listing__user
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_10.listing__user
+              ) subq_11
+            ) subq_12
+          ) subq_13
           ON
-            subq_11.user = subq_22.listing__user
-        ) subq_23
-      ) subq_24
+            subq_2.user = subq_13.listing__user
+        ) subq_14
+      ) subq_15
       WHERE user__listing__user__average_booking_value > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_16
+  ) subq_17
+) subq_18

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_39.listings AS listings
+    subq_32.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_21.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_39
+  ) subq_21
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_50
+  ) subq_32
   ON
-    subq_39.user = subq_50.listing__user
-) subq_52
+    subq_21.user = subq_32.listing__user
+) subq_34
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_multi_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_40.third_hop_count
+  subq_22.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_39.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_21.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_38.third_hop_count
+      subq_20.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_37.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-        , subq_37.third_hop_count
+        subq_19.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+        , subq_19.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
         SELECT
-          subq_36.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-          , subq_36.third_hop_count
+          subq_18.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+          , subq_18.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_20.customer_third_hop_id AS customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-            , subq_20.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_19.customer_third_hop_id
-              , subq_19.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_18.third_hop_ds__day
-                , subq_18.third_hop_ds__week
-                , subq_18.third_hop_ds__month
-                , subq_18.third_hop_ds__quarter
-                , subq_18.third_hop_ds__year
-                , subq_18.third_hop_ds__extract_year
-                , subq_18.third_hop_ds__extract_quarter
-                , subq_18.third_hop_ds__extract_month
-                , subq_18.third_hop_ds__extract_day
-                , subq_18.third_hop_ds__extract_dow
-                , subq_18.third_hop_ds__extract_doy
-                , subq_18.customer_third_hop_id__third_hop_ds__day
-                , subq_18.customer_third_hop_id__third_hop_ds__week
-                , subq_18.customer_third_hop_id__third_hop_ds__month
-                , subq_18.customer_third_hop_id__third_hop_ds__quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_18.third_hop_ds__day AS metric_time__day
-                , subq_18.third_hop_ds__week AS metric_time__week
-                , subq_18.third_hop_ds__month AS metric_time__month
-                , subq_18.third_hop_ds__quarter AS metric_time__quarter
-                , subq_18.third_hop_ds__year AS metric_time__year
-                , subq_18.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_18.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_18.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_18.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_18.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_18.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_18.customer_third_hop_id
-                , subq_18.value
-                , subq_18.customer_third_hop_id__value
-                , subq_18.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,105 +101,105 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_18
-            ) subq_19
-          ) subq_20
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
             SELECT
-              subq_34.account_id__customer_id__customer_third_hop_id
-              , subq_34.account_id__customer_id__customer_third_hop_id__txn_count
+              subq_16.account_id__customer_id__customer_third_hop_id
+              , subq_16.account_id__customer_id__customer_third_hop_id__txn_count
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_33.account_id__customer_id__customer_third_hop_id
-                , subq_33.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
+                subq_15.account_id__customer_id__customer_third_hop_id
+                , subq_15.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_32.account_id__customer_id__customer_third_hop_id
-                  , SUM(subq_32.txn_count) AS txn_count
+                  subq_14.account_id__customer_id__customer_third_hop_id
+                  , SUM(subq_14.txn_count) AS txn_count
                 FROM (
                   -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_third_hop_id']
                   SELECT
-                    subq_31.account_id__customer_id__customer_third_hop_id
-                    , subq_31.txn_count
+                    subq_13.account_id__customer_id__customer_third_hop_id
+                    , subq_13.txn_count
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_23.ds_partitioned__day AS ds_partitioned__day
-                      , subq_30.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_23.account_id AS account_id
-                      , subq_30.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
-                      , subq_23.txn_count AS txn_count
+                      subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
+                      , subq_5.account_id AS account_id
+                      , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
                       SELECT
-                        subq_22.ds_partitioned__day
-                        , subq_22.account_id
-                        , subq_22.txn_count
+                        subq_4.ds_partitioned__day
+                        , subq_4.account_id
+                        , subq_4.txn_count
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_21.ds_partitioned__day
-                          , subq_21.ds_partitioned__week
-                          , subq_21.ds_partitioned__month
-                          , subq_21.ds_partitioned__quarter
-                          , subq_21.ds_partitioned__year
-                          , subq_21.ds_partitioned__extract_year
-                          , subq_21.ds_partitioned__extract_quarter
-                          , subq_21.ds_partitioned__extract_month
-                          , subq_21.ds_partitioned__extract_day
-                          , subq_21.ds_partitioned__extract_dow
-                          , subq_21.ds_partitioned__extract_doy
-                          , subq_21.ds__day
-                          , subq_21.ds__week
-                          , subq_21.ds__month
-                          , subq_21.ds__quarter
-                          , subq_21.ds__year
-                          , subq_21.ds__extract_year
-                          , subq_21.ds__extract_quarter
-                          , subq_21.ds__extract_month
-                          , subq_21.ds__extract_day
-                          , subq_21.ds__extract_dow
-                          , subq_21.ds__extract_doy
-                          , subq_21.account_id__ds_partitioned__day
-                          , subq_21.account_id__ds_partitioned__week
-                          , subq_21.account_id__ds_partitioned__month
-                          , subq_21.account_id__ds_partitioned__quarter
-                          , subq_21.account_id__ds_partitioned__year
-                          , subq_21.account_id__ds_partitioned__extract_year
-                          , subq_21.account_id__ds_partitioned__extract_quarter
-                          , subq_21.account_id__ds_partitioned__extract_month
-                          , subq_21.account_id__ds_partitioned__extract_day
-                          , subq_21.account_id__ds_partitioned__extract_dow
-                          , subq_21.account_id__ds_partitioned__extract_doy
-                          , subq_21.account_id__ds__day
-                          , subq_21.account_id__ds__week
-                          , subq_21.account_id__ds__month
-                          , subq_21.account_id__ds__quarter
-                          , subq_21.account_id__ds__year
-                          , subq_21.account_id__ds__extract_year
-                          , subq_21.account_id__ds__extract_quarter
-                          , subq_21.account_id__ds__extract_month
-                          , subq_21.account_id__ds__extract_day
-                          , subq_21.account_id__ds__extract_dow
-                          , subq_21.account_id__ds__extract_doy
-                          , subq_21.ds__day AS metric_time__day
-                          , subq_21.ds__week AS metric_time__week
-                          , subq_21.ds__month AS metric_time__month
-                          , subq_21.ds__quarter AS metric_time__quarter
-                          , subq_21.ds__year AS metric_time__year
-                          , subq_21.ds__extract_year AS metric_time__extract_year
-                          , subq_21.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_21.ds__extract_month AS metric_time__extract_month
-                          , subq_21.ds__extract_day AS metric_time__extract_day
-                          , subq_21.ds__extract_dow AS metric_time__extract_dow
-                          , subq_21.ds__extract_doy AS metric_time__extract_doy
-                          , subq_21.account_id
-                          , subq_21.account_month
-                          , subq_21.account_id__account_month
-                          , subq_21.txn_count
+                          subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.account_id__ds_partitioned__day
+                          , subq_3.account_id__ds_partitioned__week
+                          , subq_3.account_id__ds_partitioned__month
+                          , subq_3.account_id__ds_partitioned__quarter
+                          , subq_3.account_id__ds_partitioned__year
+                          , subq_3.account_id__ds_partitioned__extract_year
+                          , subq_3.account_id__ds_partitioned__extract_quarter
+                          , subq_3.account_id__ds_partitioned__extract_month
+                          , subq_3.account_id__ds_partitioned__extract_day
+                          , subq_3.account_id__ds_partitioned__extract_dow
+                          , subq_3.account_id__ds_partitioned__extract_doy
+                          , subq_3.account_id__ds__day
+                          , subq_3.account_id__ds__week
+                          , subq_3.account_id__ds__month
+                          , subq_3.account_id__ds__quarter
+                          , subq_3.account_id__ds__year
+                          , subq_3.account_id__ds__extract_year
+                          , subq_3.account_id__ds__extract_quarter
+                          , subq_3.account_id__ds__extract_month
+                          , subq_3.account_id__ds__extract_day
+                          , subq_3.account_id__ds__extract_dow
+                          , subq_3.account_id__ds__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.account_id
+                          , subq_3.account_month
+                          , subq_3.account_id__account_month
+                          , subq_3.txn_count
                         FROM (
                           -- Read Elements From Semantic Model 'account_month_txns'
                           SELECT
@@ -252,164 +252,164 @@ FROM (
                             , account_month_txns_src_22000.account_month AS account_id__account_month
                             , account_month_txns_src_22000.account_id
                           FROM ***************************.account_month_txns account_month_txns_src_22000
-                        ) subq_21
-                      ) subq_22
-                    ) subq_23
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['ds_partitioned__day', 'account_id', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_29.ds_partitioned__day
-                        , subq_29.account_id
-                        , subq_29.customer_id__customer_third_hop_id
+                        subq_11.ds_partitioned__day
+                        , subq_11.account_id
+                        , subq_11.customer_id__customer_third_hop_id
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_25.ds_partitioned__day AS ds_partitioned__day
-                          , subq_25.ds_partitioned__week AS ds_partitioned__week
-                          , subq_25.ds_partitioned__month AS ds_partitioned__month
-                          , subq_25.ds_partitioned__quarter AS ds_partitioned__quarter
-                          , subq_25.ds_partitioned__year AS ds_partitioned__year
-                          , subq_25.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                          , subq_25.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                          , subq_25.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                          , subq_25.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                          , subq_25.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                          , subq_25.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                          , subq_25.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-                          , subq_25.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-                          , subq_25.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-                          , subq_25.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-                          , subq_25.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-                          , subq_25.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-                          , subq_25.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-                          , subq_25.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-                          , subq_25.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-                          , subq_25.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-                          , subq_25.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-                          , subq_25.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-                          , subq_25.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-                          , subq_25.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-                          , subq_25.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-                          , subq_25.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-                          , subq_25.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-                          , subq_25.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-                          , subq_25.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-                          , subq_25.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-                          , subq_25.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-                          , subq_25.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-                          , subq_25.metric_time__day AS metric_time__day
-                          , subq_25.metric_time__week AS metric_time__week
-                          , subq_25.metric_time__month AS metric_time__month
-                          , subq_25.metric_time__quarter AS metric_time__quarter
-                          , subq_25.metric_time__year AS metric_time__year
-                          , subq_25.metric_time__extract_year AS metric_time__extract_year
-                          , subq_25.metric_time__extract_quarter AS metric_time__extract_quarter
-                          , subq_25.metric_time__extract_month AS metric_time__extract_month
-                          , subq_25.metric_time__extract_day AS metric_time__extract_day
-                          , subq_25.metric_time__extract_dow AS metric_time__extract_dow
-                          , subq_25.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_28.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_28.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_28.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_28.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_28.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_28.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_28.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_28.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_28.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_28.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_28.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_28.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_28.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_28.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_28.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_28.metric_time__day AS customer_id__metric_time__day
-                          , subq_28.metric_time__week AS customer_id__metric_time__week
-                          , subq_28.metric_time__month AS customer_id__metric_time__month
-                          , subq_28.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_28.metric_time__year AS customer_id__metric_time__year
-                          , subq_28.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_28.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_28.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_28.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_28.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_28.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-                          , subq_25.account_id AS account_id
-                          , subq_25.customer_id AS customer_id
-                          , subq_25.account_id__customer_id AS account_id__customer_id
-                          , subq_25.bridge_account__account_id AS bridge_account__account_id
-                          , subq_25.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_28.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_28.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
-                          , subq_25.extra_dim AS extra_dim
-                          , subq_25.account_id__extra_dim AS account_id__extra_dim
-                          , subq_25.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_28.country AS customer_id__country
-                          , subq_28.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
-                          , subq_25.account_customer_combos AS account_customer_combos
+                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          , subq_7.ds_partitioned__week AS ds_partitioned__week
+                          , subq_7.ds_partitioned__month AS ds_partitioned__month
+                          , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+                          , subq_7.ds_partitioned__year AS ds_partitioned__year
+                          , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                          , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                          , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                          , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                          , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                          , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                          , subq_7.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+                          , subq_7.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+                          , subq_7.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+                          , subq_7.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+                          , subq_7.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+                          , subq_7.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+                          , subq_7.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+                          , subq_7.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+                          , subq_7.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+                          , subq_7.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+                          , subq_7.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+                          , subq_7.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+                          , subq_7.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+                          , subq_7.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+                          , subq_7.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+                          , subq_7.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+                          , subq_7.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+                          , subq_7.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+                          , subq_7.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+                          , subq_7.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+                          , subq_7.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+                          , subq_7.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+                          , subq_7.metric_time__day AS metric_time__day
+                          , subq_7.metric_time__week AS metric_time__week
+                          , subq_7.metric_time__month AS metric_time__month
+                          , subq_7.metric_time__quarter AS metric_time__quarter
+                          , subq_7.metric_time__year AS metric_time__year
+                          , subq_7.metric_time__extract_year AS metric_time__extract_year
+                          , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+                          , subq_7.metric_time__extract_month AS metric_time__extract_month
+                          , subq_7.metric_time__extract_day AS metric_time__extract_day
+                          , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+                          , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_7.account_id AS account_id
+                          , subq_7.customer_id AS customer_id
+                          , subq_7.account_id__customer_id AS account_id__customer_id
+                          , subq_7.bridge_account__account_id AS bridge_account__account_id
+                          , subq_7.bridge_account__customer_id AS bridge_account__customer_id
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.extra_dim AS extra_dim
+                          , subq_7.account_id__extra_dim AS account_id__extra_dim
+                          , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
+                          , subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'
                           SELECT
-                            subq_24.ds_partitioned__day
-                            , subq_24.ds_partitioned__week
-                            , subq_24.ds_partitioned__month
-                            , subq_24.ds_partitioned__quarter
-                            , subq_24.ds_partitioned__year
-                            , subq_24.ds_partitioned__extract_year
-                            , subq_24.ds_partitioned__extract_quarter
-                            , subq_24.ds_partitioned__extract_month
-                            , subq_24.ds_partitioned__extract_day
-                            , subq_24.ds_partitioned__extract_dow
-                            , subq_24.ds_partitioned__extract_doy
-                            , subq_24.account_id__ds_partitioned__day
-                            , subq_24.account_id__ds_partitioned__week
-                            , subq_24.account_id__ds_partitioned__month
-                            , subq_24.account_id__ds_partitioned__quarter
-                            , subq_24.account_id__ds_partitioned__year
-                            , subq_24.account_id__ds_partitioned__extract_year
-                            , subq_24.account_id__ds_partitioned__extract_quarter
-                            , subq_24.account_id__ds_partitioned__extract_month
-                            , subq_24.account_id__ds_partitioned__extract_day
-                            , subq_24.account_id__ds_partitioned__extract_dow
-                            , subq_24.account_id__ds_partitioned__extract_doy
-                            , subq_24.bridge_account__ds_partitioned__day
-                            , subq_24.bridge_account__ds_partitioned__week
-                            , subq_24.bridge_account__ds_partitioned__month
-                            , subq_24.bridge_account__ds_partitioned__quarter
-                            , subq_24.bridge_account__ds_partitioned__year
-                            , subq_24.bridge_account__ds_partitioned__extract_year
-                            , subq_24.bridge_account__ds_partitioned__extract_quarter
-                            , subq_24.bridge_account__ds_partitioned__extract_month
-                            , subq_24.bridge_account__ds_partitioned__extract_day
-                            , subq_24.bridge_account__ds_partitioned__extract_dow
-                            , subq_24.bridge_account__ds_partitioned__extract_doy
-                            , subq_24.ds_partitioned__day AS metric_time__day
-                            , subq_24.ds_partitioned__week AS metric_time__week
-                            , subq_24.ds_partitioned__month AS metric_time__month
-                            , subq_24.ds_partitioned__quarter AS metric_time__quarter
-                            , subq_24.ds_partitioned__year AS metric_time__year
-                            , subq_24.ds_partitioned__extract_year AS metric_time__extract_year
-                            , subq_24.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                            , subq_24.ds_partitioned__extract_month AS metric_time__extract_month
-                            , subq_24.ds_partitioned__extract_day AS metric_time__extract_day
-                            , subq_24.ds_partitioned__extract_dow AS metric_time__extract_dow
-                            , subq_24.ds_partitioned__extract_doy AS metric_time__extract_doy
-                            , subq_24.account_id
-                            , subq_24.customer_id
-                            , subq_24.account_id__customer_id
-                            , subq_24.bridge_account__account_id
-                            , subq_24.bridge_account__customer_id
-                            , subq_24.extra_dim
-                            , subq_24.account_id__extra_dim
-                            , subq_24.bridge_account__extra_dim
-                            , subq_24.account_customer_combos
+                            subq_6.ds_partitioned__day
+                            , subq_6.ds_partitioned__week
+                            , subq_6.ds_partitioned__month
+                            , subq_6.ds_partitioned__quarter
+                            , subq_6.ds_partitioned__year
+                            , subq_6.ds_partitioned__extract_year
+                            , subq_6.ds_partitioned__extract_quarter
+                            , subq_6.ds_partitioned__extract_month
+                            , subq_6.ds_partitioned__extract_day
+                            , subq_6.ds_partitioned__extract_dow
+                            , subq_6.ds_partitioned__extract_doy
+                            , subq_6.account_id__ds_partitioned__day
+                            , subq_6.account_id__ds_partitioned__week
+                            , subq_6.account_id__ds_partitioned__month
+                            , subq_6.account_id__ds_partitioned__quarter
+                            , subq_6.account_id__ds_partitioned__year
+                            , subq_6.account_id__ds_partitioned__extract_year
+                            , subq_6.account_id__ds_partitioned__extract_quarter
+                            , subq_6.account_id__ds_partitioned__extract_month
+                            , subq_6.account_id__ds_partitioned__extract_day
+                            , subq_6.account_id__ds_partitioned__extract_dow
+                            , subq_6.account_id__ds_partitioned__extract_doy
+                            , subq_6.bridge_account__ds_partitioned__day
+                            , subq_6.bridge_account__ds_partitioned__week
+                            , subq_6.bridge_account__ds_partitioned__month
+                            , subq_6.bridge_account__ds_partitioned__quarter
+                            , subq_6.bridge_account__ds_partitioned__year
+                            , subq_6.bridge_account__ds_partitioned__extract_year
+                            , subq_6.bridge_account__ds_partitioned__extract_quarter
+                            , subq_6.bridge_account__ds_partitioned__extract_month
+                            , subq_6.bridge_account__ds_partitioned__extract_day
+                            , subq_6.bridge_account__ds_partitioned__extract_dow
+                            , subq_6.bridge_account__ds_partitioned__extract_doy
+                            , subq_6.ds_partitioned__day AS metric_time__day
+                            , subq_6.ds_partitioned__week AS metric_time__week
+                            , subq_6.ds_partitioned__month AS metric_time__month
+                            , subq_6.ds_partitioned__quarter AS metric_time__quarter
+                            , subq_6.ds_partitioned__year AS metric_time__year
+                            , subq_6.ds_partitioned__extract_year AS metric_time__extract_year
+                            , subq_6.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                            , subq_6.ds_partitioned__extract_month AS metric_time__extract_month
+                            , subq_6.ds_partitioned__extract_day AS metric_time__extract_day
+                            , subq_6.ds_partitioned__extract_dow AS metric_time__extract_dow
+                            , subq_6.ds_partitioned__extract_doy AS metric_time__extract_doy
+                            , subq_6.account_id
+                            , subq_6.customer_id
+                            , subq_6.account_id__customer_id
+                            , subq_6.bridge_account__account_id
+                            , subq_6.bridge_account__customer_id
+                            , subq_6.extra_dim
+                            , subq_6.account_id__extra_dim
+                            , subq_6.bridge_account__extra_dim
+                            , subq_6.account_customer_combos
                           FROM (
                             -- Read Elements From Semantic Model 'bridge_table'
                             SELECT
@@ -456,8 +456,8 @@ FROM (
                               , bridge_table_src_22000.account_id AS bridge_account__account_id
                               , bridge_table_src_22000.customer_id AS bridge_account__customer_id
                             FROM ***************************.bridge_table bridge_table_src_22000
-                          ) subq_24
-                        ) subq_25
+                          ) subq_6
+                        ) subq_7
                         LEFT OUTER JOIN (
                           -- Pass Only Elements: [
                           --   'country',
@@ -513,112 +513,112 @@ FROM (
                           --   'customer_third_hop_id__customer_id',
                           -- ]
                           SELECT
-                            subq_27.acquired_ds__day
-                            , subq_27.acquired_ds__week
-                            , subq_27.acquired_ds__month
-                            , subq_27.acquired_ds__quarter
-                            , subq_27.acquired_ds__year
-                            , subq_27.acquired_ds__extract_year
-                            , subq_27.acquired_ds__extract_quarter
-                            , subq_27.acquired_ds__extract_month
-                            , subq_27.acquired_ds__extract_day
-                            , subq_27.acquired_ds__extract_dow
-                            , subq_27.acquired_ds__extract_doy
-                            , subq_27.customer_id__acquired_ds__day
-                            , subq_27.customer_id__acquired_ds__week
-                            , subq_27.customer_id__acquired_ds__month
-                            , subq_27.customer_id__acquired_ds__quarter
-                            , subq_27.customer_id__acquired_ds__year
-                            , subq_27.customer_id__acquired_ds__extract_year
-                            , subq_27.customer_id__acquired_ds__extract_quarter
-                            , subq_27.customer_id__acquired_ds__extract_month
-                            , subq_27.customer_id__acquired_ds__extract_day
-                            , subq_27.customer_id__acquired_ds__extract_dow
-                            , subq_27.customer_id__acquired_ds__extract_doy
-                            , subq_27.customer_third_hop_id__acquired_ds__day
-                            , subq_27.customer_third_hop_id__acquired_ds__week
-                            , subq_27.customer_third_hop_id__acquired_ds__month
-                            , subq_27.customer_third_hop_id__acquired_ds__quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_27.metric_time__day
-                            , subq_27.metric_time__week
-                            , subq_27.metric_time__month
-                            , subq_27.metric_time__quarter
-                            , subq_27.metric_time__year
-                            , subq_27.metric_time__extract_year
-                            , subq_27.metric_time__extract_quarter
-                            , subq_27.metric_time__extract_month
-                            , subq_27.metric_time__extract_day
-                            , subq_27.metric_time__extract_dow
-                            , subq_27.metric_time__extract_doy
-                            , subq_27.customer_id
-                            , subq_27.customer_third_hop_id
-                            , subq_27.customer_id__customer_third_hop_id
-                            , subq_27.customer_third_hop_id__customer_id
-                            , subq_27.country
-                            , subq_27.customer_id__country
-                            , subq_27.customer_third_hop_id__country
+                            subq_9.acquired_ds__day
+                            , subq_9.acquired_ds__week
+                            , subq_9.acquired_ds__month
+                            , subq_9.acquired_ds__quarter
+                            , subq_9.acquired_ds__year
+                            , subq_9.acquired_ds__extract_year
+                            , subq_9.acquired_ds__extract_quarter
+                            , subq_9.acquired_ds__extract_month
+                            , subq_9.acquired_ds__extract_day
+                            , subq_9.acquired_ds__extract_dow
+                            , subq_9.acquired_ds__extract_doy
+                            , subq_9.customer_id__acquired_ds__day
+                            , subq_9.customer_id__acquired_ds__week
+                            , subq_9.customer_id__acquired_ds__month
+                            , subq_9.customer_id__acquired_ds__quarter
+                            , subq_9.customer_id__acquired_ds__year
+                            , subq_9.customer_id__acquired_ds__extract_year
+                            , subq_9.customer_id__acquired_ds__extract_quarter
+                            , subq_9.customer_id__acquired_ds__extract_month
+                            , subq_9.customer_id__acquired_ds__extract_day
+                            , subq_9.customer_id__acquired_ds__extract_dow
+                            , subq_9.customer_id__acquired_ds__extract_doy
+                            , subq_9.customer_third_hop_id__acquired_ds__day
+                            , subq_9.customer_third_hop_id__acquired_ds__week
+                            , subq_9.customer_third_hop_id__acquired_ds__month
+                            , subq_9.customer_third_hop_id__acquired_ds__quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_9.metric_time__day
+                            , subq_9.metric_time__week
+                            , subq_9.metric_time__month
+                            , subq_9.metric_time__quarter
+                            , subq_9.metric_time__year
+                            , subq_9.metric_time__extract_year
+                            , subq_9.metric_time__extract_quarter
+                            , subq_9.metric_time__extract_month
+                            , subq_9.metric_time__extract_day
+                            , subq_9.metric_time__extract_dow
+                            , subq_9.metric_time__extract_doy
+                            , subq_9.customer_id
+                            , subq_9.customer_third_hop_id
+                            , subq_9.customer_id__customer_third_hop_id
+                            , subq_9.customer_third_hop_id__customer_id
+                            , subq_9.country
+                            , subq_9.customer_id__country
+                            , subq_9.customer_third_hop_id__country
                           FROM (
                             -- Metric Time Dimension 'acquired_ds'
                             SELECT
-                              subq_26.acquired_ds__day
-                              , subq_26.acquired_ds__week
-                              , subq_26.acquired_ds__month
-                              , subq_26.acquired_ds__quarter
-                              , subq_26.acquired_ds__year
-                              , subq_26.acquired_ds__extract_year
-                              , subq_26.acquired_ds__extract_quarter
-                              , subq_26.acquired_ds__extract_month
-                              , subq_26.acquired_ds__extract_day
-                              , subq_26.acquired_ds__extract_dow
-                              , subq_26.acquired_ds__extract_doy
-                              , subq_26.customer_id__acquired_ds__day
-                              , subq_26.customer_id__acquired_ds__week
-                              , subq_26.customer_id__acquired_ds__month
-                              , subq_26.customer_id__acquired_ds__quarter
-                              , subq_26.customer_id__acquired_ds__year
-                              , subq_26.customer_id__acquired_ds__extract_year
-                              , subq_26.customer_id__acquired_ds__extract_quarter
-                              , subq_26.customer_id__acquired_ds__extract_month
-                              , subq_26.customer_id__acquired_ds__extract_day
-                              , subq_26.customer_id__acquired_ds__extract_dow
-                              , subq_26.customer_id__acquired_ds__extract_doy
-                              , subq_26.customer_third_hop_id__acquired_ds__day
-                              , subq_26.customer_third_hop_id__acquired_ds__week
-                              , subq_26.customer_third_hop_id__acquired_ds__month
-                              , subq_26.customer_third_hop_id__acquired_ds__quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_month
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_day
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_dow
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_doy
-                              , subq_26.acquired_ds__day AS metric_time__day
-                              , subq_26.acquired_ds__week AS metric_time__week
-                              , subq_26.acquired_ds__month AS metric_time__month
-                              , subq_26.acquired_ds__quarter AS metric_time__quarter
-                              , subq_26.acquired_ds__year AS metric_time__year
-                              , subq_26.acquired_ds__extract_year AS metric_time__extract_year
-                              , subq_26.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_26.acquired_ds__extract_month AS metric_time__extract_month
-                              , subq_26.acquired_ds__extract_day AS metric_time__extract_day
-                              , subq_26.acquired_ds__extract_dow AS metric_time__extract_dow
-                              , subq_26.acquired_ds__extract_doy AS metric_time__extract_doy
-                              , subq_26.customer_id
-                              , subq_26.customer_third_hop_id
-                              , subq_26.customer_id__customer_third_hop_id
-                              , subq_26.customer_third_hop_id__customer_id
-                              , subq_26.country
-                              , subq_26.customer_id__country
-                              , subq_26.customer_third_hop_id__country
-                              , subq_26.customers_with_other_data
+                              subq_8.acquired_ds__day
+                              , subq_8.acquired_ds__week
+                              , subq_8.acquired_ds__month
+                              , subq_8.acquired_ds__quarter
+                              , subq_8.acquired_ds__year
+                              , subq_8.acquired_ds__extract_year
+                              , subq_8.acquired_ds__extract_quarter
+                              , subq_8.acquired_ds__extract_month
+                              , subq_8.acquired_ds__extract_day
+                              , subq_8.acquired_ds__extract_dow
+                              , subq_8.acquired_ds__extract_doy
+                              , subq_8.customer_id__acquired_ds__day
+                              , subq_8.customer_id__acquired_ds__week
+                              , subq_8.customer_id__acquired_ds__month
+                              , subq_8.customer_id__acquired_ds__quarter
+                              , subq_8.customer_id__acquired_ds__year
+                              , subq_8.customer_id__acquired_ds__extract_year
+                              , subq_8.customer_id__acquired_ds__extract_quarter
+                              , subq_8.customer_id__acquired_ds__extract_month
+                              , subq_8.customer_id__acquired_ds__extract_day
+                              , subq_8.customer_id__acquired_ds__extract_dow
+                              , subq_8.customer_id__acquired_ds__extract_doy
+                              , subq_8.customer_third_hop_id__acquired_ds__day
+                              , subq_8.customer_third_hop_id__acquired_ds__week
+                              , subq_8.customer_third_hop_id__acquired_ds__month
+                              , subq_8.customer_third_hop_id__acquired_ds__quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_month
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_day
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_dow
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_doy
+                              , subq_8.acquired_ds__day AS metric_time__day
+                              , subq_8.acquired_ds__week AS metric_time__week
+                              , subq_8.acquired_ds__month AS metric_time__month
+                              , subq_8.acquired_ds__quarter AS metric_time__quarter
+                              , subq_8.acquired_ds__year AS metric_time__year
+                              , subq_8.acquired_ds__extract_year AS metric_time__extract_year
+                              , subq_8.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_8.acquired_ds__extract_month AS metric_time__extract_month
+                              , subq_8.acquired_ds__extract_day AS metric_time__extract_day
+                              , subq_8.acquired_ds__extract_dow AS metric_time__extract_dow
+                              , subq_8.acquired_ds__extract_doy AS metric_time__extract_doy
+                              , subq_8.customer_id
+                              , subq_8.customer_third_hop_id
+                              , subq_8.customer_id__customer_third_hop_id
+                              , subq_8.customer_third_hop_id__customer_id
+                              , subq_8.country
+                              , subq_8.customer_id__country
+                              , subq_8.customer_third_hop_id__country
+                              , subq_8.customers_with_other_data
                             FROM (
                               -- Read Elements From Semantic Model 'customer_other_data'
                               SELECT
@@ -664,31 +664,31 @@ FROM (
                                 , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                                 , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                               FROM ***************************.customer_other_data customer_other_data_src_22000
-                            ) subq_26
-                          ) subq_27
-                        ) subq_28
+                            ) subq_8
+                          ) subq_9
+                        ) subq_10
                         ON
-                          subq_25.customer_id = subq_28.customer_id
-                      ) subq_29
-                    ) subq_30
+                          subq_7.customer_id = subq_10.customer_id
+                      ) subq_11
+                    ) subq_12
                     ON
                       (
-                        subq_23.account_id = subq_30.account_id
+                        subq_5.account_id = subq_12.account_id
                       ) AND (
-                        subq_23.ds_partitioned__day = subq_30.ds_partitioned__day
+                        subq_5.ds_partitioned__day = subq_12.ds_partitioned__day
                       )
-                  ) subq_31
-                ) subq_32
+                  ) subq_13
+                ) subq_14
                 GROUP BY
-                  subq_32.account_id__customer_id__customer_third_hop_id
-              ) subq_33
-            ) subq_34
-          ) subq_35
+                  subq_14.account_id__customer_id__customer_third_hop_id
+              ) subq_15
+            ) subq_16
+          ) subq_17
           ON
-            subq_20.customer_third_hop_id = subq_35.account_id__customer_id__customer_third_hop_id
-        ) subq_36
-      ) subq_37
+            subq_2.customer_third_hop_id = subq_17.account_id__customer_id__customer_third_hop_id
+        ) subq_18
+      ) subq_19
       WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2
-    ) subq_38
-  ) subq_39
-) subq_40
+    ) subq_20
+  ) subq_21
+) subq_22

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_40.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_35.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_71
+    ) subq_35
     ON
       (
-        account_month_txns_src_22000.account_id = subq_71.account_id
+        account_month_txns_src_22000.account_id = subq_35.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_35.ds_partitioned__day
       )
     GROUP BY
-      subq_71.customer_id__customer_third_hop_id
-  ) subq_76
+      subq_35.customer_id__customer_third_hop_id
+  ) subq_40
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
-) subq_78
+    third_hop_table_src_22000.customer_third_hop_id = subq_40.account_id__customer_id__customer_third_hop_id
+) subq_42
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_25.third_hop_count
+  subq_16.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_24.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_23.third_hop_count
+      subq_14.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_22.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_22.third_hop_count
+        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_13.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_21.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_21.third_hop_count
+          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_12.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.customer_third_hop_id AS customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-            , subq_11.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_10.customer_third_hop_id
-              , subq_10.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_9.third_hop_ds__day
-                , subq_9.third_hop_ds__week
-                , subq_9.third_hop_ds__month
-                , subq_9.third_hop_ds__quarter
-                , subq_9.third_hop_ds__year
-                , subq_9.third_hop_ds__extract_year
-                , subq_9.third_hop_ds__extract_quarter
-                , subq_9.third_hop_ds__extract_month
-                , subq_9.third_hop_ds__extract_day
-                , subq_9.third_hop_ds__extract_dow
-                , subq_9.third_hop_ds__extract_doy
-                , subq_9.customer_third_hop_id__third_hop_ds__day
-                , subq_9.customer_third_hop_id__third_hop_ds__week
-                , subq_9.customer_third_hop_id__third_hop_ds__month
-                , subq_9.customer_third_hop_id__third_hop_ds__quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_9.third_hop_ds__day AS metric_time__day
-                , subq_9.third_hop_ds__week AS metric_time__week
-                , subq_9.third_hop_ds__month AS metric_time__month
-                , subq_9.third_hop_ds__quarter AS metric_time__quarter
-                , subq_9.third_hop_ds__year AS metric_time__year
-                , subq_9.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_9.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_9.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_9.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_9.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_9.customer_third_hop_id
-                , subq_9.value
-                , subq_9.customer_third_hop_id__value
-                , subq_9.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,151 +101,151 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_19.customer_id__customer_third_hop_id
-              , subq_19.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_10.customer_id__customer_third_hop_id
+              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_18.customer_id__customer_third_hop_id
-                , subq_18.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_9.customer_id__customer_third_hop_id
+                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_17.customer_id__customer_third_hop_id
-                  , SUM(subq_17.customers_with_other_data) AS customers_with_other_data
+                  subq_8.customer_id__customer_third_hop_id
+                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_16.customer_id__customer_third_hop_id
-                    , subq_16.customers_with_other_data
+                    subq_7.customer_id__customer_third_hop_id
+                    , subq_7.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_15.customer_id__customer_third_hop_id
-                      , subq_15.customer_id__country
-                      , subq_15.customers_with_other_data
+                      subq_6.customer_id__customer_third_hop_id
+                      , subq_6.customer_id__country
+                      , subq_6.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_14.customer_id__customer_third_hop_id
-                        , subq_14.customer_id__country
-                        , subq_14.customers_with_other_data
+                        subq_5.customer_id__customer_third_hop_id
+                        , subq_5.customer_id__country
+                        , subq_5.customers_with_other_data
                       FROM (
                         -- Constrain Output with WHERE
                         SELECT
-                          subq_13.acquired_ds__day
-                          , subq_13.acquired_ds__week
-                          , subq_13.acquired_ds__month
-                          , subq_13.acquired_ds__quarter
-                          , subq_13.acquired_ds__year
-                          , subq_13.acquired_ds__extract_year
-                          , subq_13.acquired_ds__extract_quarter
-                          , subq_13.acquired_ds__extract_month
-                          , subq_13.acquired_ds__extract_day
-                          , subq_13.acquired_ds__extract_dow
-                          , subq_13.acquired_ds__extract_doy
-                          , subq_13.customer_id__acquired_ds__day
-                          , subq_13.customer_id__acquired_ds__week
-                          , subq_13.customer_id__acquired_ds__month
-                          , subq_13.customer_id__acquired_ds__quarter
-                          , subq_13.customer_id__acquired_ds__year
-                          , subq_13.customer_id__acquired_ds__extract_year
-                          , subq_13.customer_id__acquired_ds__extract_quarter
-                          , subq_13.customer_id__acquired_ds__extract_month
-                          , subq_13.customer_id__acquired_ds__extract_day
-                          , subq_13.customer_id__acquired_ds__extract_dow
-                          , subq_13.customer_id__acquired_ds__extract_doy
-                          , subq_13.customer_third_hop_id__acquired_ds__day
-                          , subq_13.customer_third_hop_id__acquired_ds__week
-                          , subq_13.customer_third_hop_id__acquired_ds__month
-                          , subq_13.customer_third_hop_id__acquired_ds__quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_13.metric_time__day
-                          , subq_13.metric_time__week
-                          , subq_13.metric_time__month
-                          , subq_13.metric_time__quarter
-                          , subq_13.metric_time__year
-                          , subq_13.metric_time__extract_year
-                          , subq_13.metric_time__extract_quarter
-                          , subq_13.metric_time__extract_month
-                          , subq_13.metric_time__extract_day
-                          , subq_13.metric_time__extract_dow
-                          , subq_13.metric_time__extract_doy
-                          , subq_13.customer_id
-                          , subq_13.customer_third_hop_id
-                          , subq_13.customer_id__customer_third_hop_id
-                          , subq_13.customer_third_hop_id__customer_id
-                          , subq_13.country
-                          , subq_13.customer_id__country
-                          , subq_13.customer_third_hop_id__country
-                          , subq_13.customers_with_other_data
+                          subq_4.acquired_ds__day
+                          , subq_4.acquired_ds__week
+                          , subq_4.acquired_ds__month
+                          , subq_4.acquired_ds__quarter
+                          , subq_4.acquired_ds__year
+                          , subq_4.acquired_ds__extract_year
+                          , subq_4.acquired_ds__extract_quarter
+                          , subq_4.acquired_ds__extract_month
+                          , subq_4.acquired_ds__extract_day
+                          , subq_4.acquired_ds__extract_dow
+                          , subq_4.acquired_ds__extract_doy
+                          , subq_4.customer_id__acquired_ds__day
+                          , subq_4.customer_id__acquired_ds__week
+                          , subq_4.customer_id__acquired_ds__month
+                          , subq_4.customer_id__acquired_ds__quarter
+                          , subq_4.customer_id__acquired_ds__year
+                          , subq_4.customer_id__acquired_ds__extract_year
+                          , subq_4.customer_id__acquired_ds__extract_quarter
+                          , subq_4.customer_id__acquired_ds__extract_month
+                          , subq_4.customer_id__acquired_ds__extract_day
+                          , subq_4.customer_id__acquired_ds__extract_dow
+                          , subq_4.customer_id__acquired_ds__extract_doy
+                          , subq_4.customer_third_hop_id__acquired_ds__day
+                          , subq_4.customer_third_hop_id__acquired_ds__week
+                          , subq_4.customer_third_hop_id__acquired_ds__month
+                          , subq_4.customer_third_hop_id__acquired_ds__quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_4.metric_time__day
+                          , subq_4.metric_time__week
+                          , subq_4.metric_time__month
+                          , subq_4.metric_time__quarter
+                          , subq_4.metric_time__year
+                          , subq_4.metric_time__extract_year
+                          , subq_4.metric_time__extract_quarter
+                          , subq_4.metric_time__extract_month
+                          , subq_4.metric_time__extract_day
+                          , subq_4.metric_time__extract_dow
+                          , subq_4.metric_time__extract_doy
+                          , subq_4.customer_id
+                          , subq_4.customer_third_hop_id
+                          , subq_4.customer_id__customer_third_hop_id
+                          , subq_4.customer_third_hop_id__customer_id
+                          , subq_4.country
+                          , subq_4.customer_id__country
+                          , subq_4.customer_third_hop_id__country
+                          , subq_4.customers_with_other_data
                         FROM (
                           -- Metric Time Dimension 'acquired_ds'
                           SELECT
-                            subq_12.acquired_ds__day
-                            , subq_12.acquired_ds__week
-                            , subq_12.acquired_ds__month
-                            , subq_12.acquired_ds__quarter
-                            , subq_12.acquired_ds__year
-                            , subq_12.acquired_ds__extract_year
-                            , subq_12.acquired_ds__extract_quarter
-                            , subq_12.acquired_ds__extract_month
-                            , subq_12.acquired_ds__extract_day
-                            , subq_12.acquired_ds__extract_dow
-                            , subq_12.acquired_ds__extract_doy
-                            , subq_12.customer_id__acquired_ds__day
-                            , subq_12.customer_id__acquired_ds__week
-                            , subq_12.customer_id__acquired_ds__month
-                            , subq_12.customer_id__acquired_ds__quarter
-                            , subq_12.customer_id__acquired_ds__year
-                            , subq_12.customer_id__acquired_ds__extract_year
-                            , subq_12.customer_id__acquired_ds__extract_quarter
-                            , subq_12.customer_id__acquired_ds__extract_month
-                            , subq_12.customer_id__acquired_ds__extract_day
-                            , subq_12.customer_id__acquired_ds__extract_dow
-                            , subq_12.customer_id__acquired_ds__extract_doy
-                            , subq_12.customer_third_hop_id__acquired_ds__day
-                            , subq_12.customer_third_hop_id__acquired_ds__week
-                            , subq_12.customer_third_hop_id__acquired_ds__month
-                            , subq_12.customer_third_hop_id__acquired_ds__quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_12.acquired_ds__day AS metric_time__day
-                            , subq_12.acquired_ds__week AS metric_time__week
-                            , subq_12.acquired_ds__month AS metric_time__month
-                            , subq_12.acquired_ds__quarter AS metric_time__quarter
-                            , subq_12.acquired_ds__year AS metric_time__year
-                            , subq_12.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_12.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_12.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_12.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_12.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_12.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_12.customer_id
-                            , subq_12.customer_third_hop_id
-                            , subq_12.customer_id__customer_third_hop_id
-                            , subq_12.customer_third_hop_id__customer_id
-                            , subq_12.country
-                            , subq_12.customer_id__country
-                            , subq_12.customer_third_hop_id__country
-                            , subq_12.customers_with_other_data
+                            subq_3.acquired_ds__day
+                            , subq_3.acquired_ds__week
+                            , subq_3.acquired_ds__month
+                            , subq_3.acquired_ds__quarter
+                            , subq_3.acquired_ds__year
+                            , subq_3.acquired_ds__extract_year
+                            , subq_3.acquired_ds__extract_quarter
+                            , subq_3.acquired_ds__extract_month
+                            , subq_3.acquired_ds__extract_day
+                            , subq_3.acquired_ds__extract_dow
+                            , subq_3.acquired_ds__extract_doy
+                            , subq_3.customer_id__acquired_ds__day
+                            , subq_3.customer_id__acquired_ds__week
+                            , subq_3.customer_id__acquired_ds__month
+                            , subq_3.customer_id__acquired_ds__quarter
+                            , subq_3.customer_id__acquired_ds__year
+                            , subq_3.customer_id__acquired_ds__extract_year
+                            , subq_3.customer_id__acquired_ds__extract_quarter
+                            , subq_3.customer_id__acquired_ds__extract_month
+                            , subq_3.customer_id__acquired_ds__extract_day
+                            , subq_3.customer_id__acquired_ds__extract_dow
+                            , subq_3.customer_id__acquired_ds__extract_doy
+                            , subq_3.customer_third_hop_id__acquired_ds__day
+                            , subq_3.customer_third_hop_id__acquired_ds__week
+                            , subq_3.customer_third_hop_id__acquired_ds__month
+                            , subq_3.customer_third_hop_id__acquired_ds__quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_3.acquired_ds__day AS metric_time__day
+                            , subq_3.acquired_ds__week AS metric_time__week
+                            , subq_3.acquired_ds__month AS metric_time__month
+                            , subq_3.acquired_ds__quarter AS metric_time__quarter
+                            , subq_3.acquired_ds__year AS metric_time__year
+                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                            , subq_3.customer_id
+                            , subq_3.customer_third_hop_id
+                            , subq_3.customer_id__customer_third_hop_id
+                            , subq_3.customer_third_hop_id__customer_id
+                            , subq_3.country
+                            , subq_3.customer_id__country
+                            , subq_3.customer_third_hop_id__country
+                            , subq_3.customers_with_other_data
                           FROM (
                             -- Read Elements From Semantic Model 'customer_other_data'
                             SELECT
@@ -291,24 +291,24 @@ FROM (
                               , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                               , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                             FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_12
-                        ) subq_13
+                          ) subq_3
+                        ) subq_4
                         WHERE customer_id__country = 'paraguay'
-                      ) subq_14
-                    ) subq_15
+                      ) subq_5
+                    ) subq_6
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_16
-                ) subq_17
+                  ) subq_7
+                ) subq_8
                 GROUP BY
-                  subq_17.customer_id__customer_third_hop_id
-              ) subq_18
-            ) subq_19
-          ) subq_20
+                  subq_8.customer_id__customer_third_hop_id
+              ) subq_9
+            ) subq_10
+          ) subq_11
           ON
-            subq_11.customer_third_hop_id = subq_20.customer_id__customer_third_hop_id
-        ) subq_21
-      ) subq_22
+            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
+        ) subq_12
+      ) subq_13
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_23
-  ) subq_24
-) subq_25
+    ) subq_14
+  ) subq_15
+) subq_16

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_39
+      ) subq_21
       WHERE customer_id__country = 'paraguay'
-    ) subq_41
+    ) subq_23
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_46
+  ) subq_28
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
-) subq_48
+    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
+) subq_30
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookers
-        , subq_14.bookers
+        subq_10.listing__bookers
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'listing__bookers']
         SELECT
-          subq_13.listing__bookers
-          , subq_13.bookers
+          subq_9.listing__bookers
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookers AS listing__bookers
-            , subq_6.bookers AS bookers
+            subq_2.listing AS listing
+            , subq_8.listing__bookers AS listing__bookers
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.bookers
+              subq_1.listing
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookers
+              subq_7.listing
+              , subq_7.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookers AS listing__bookers
+                subq_6.listing
+                , subq_6.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , COUNT(DISTINCT subq_9.bookers) AS bookers
+                  subq_5.listing
+                  , COUNT(DISTINCT subq_5.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookers
+                    subq_4.listing
+                    , subq_4.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookers > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_30.listing__bookers AS listing__bookers
-    , subq_24.bookers AS bookers
+    subq_22.listing__bookers AS listing__bookers
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_with_metric_in_where_filter__plan0.sql
@@ -1,112 +1,112 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time__day
-  , subq_17.listings AS active_listings
+  subq_13.metric_time__day
+  , subq_13.listings AS active_listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.metric_time__day
-    , SUM(subq_16.listings) AS listings
+    subq_12.metric_time__day
+    , SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'metric_time__day']
     SELECT
-      subq_15.metric_time__day
-      , subq_15.listings
+      subq_11.metric_time__day
+      , subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.metric_time__day
-        , subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.metric_time__day
+        , subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
         SELECT
-          subq_13.metric_time__day
-          , subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.metric_time__day
+          , subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.metric_time__day AS metric_time__day
-            , subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']
             SELECT
-              subq_5.metric_time__day
-              , subq_5.listing
-              , subq_5.listings
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -167,130 +167,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -383,21 +383,21 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
+    ) subq_11
+  ) subq_12
   GROUP BY
-    subq_16.metric_time__day
-) subq_17
+    subq_12.metric_time__day
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_24.metric_time__day AS metric_time__day
-    , subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_16.metric_time__day AS metric_time__day
+    , subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.user__revenue_all_time
-        , subq_14.listings
+        subq_10.user__revenue_all_time
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__revenue_all_time']
         SELECT
-          subq_13.user__revenue_all_time
-          , subq_13.listings
+          subq_9.user__revenue_all_time
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.user AS user
-            , subq_12.user__revenue_all_time AS user__revenue_all_time
-            , subq_6.listings AS listings
+            subq_2.user AS user
+            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_5.user
-              , subq_5.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,68 +160,68 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__revenue_all_time']
             SELECT
-              subq_11.user
-              , subq_11.user__revenue_all_time
+              subq_7.user
+              , subq_7.user__revenue_all_time
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.user
-                , subq_10.txn_revenue AS user__revenue_all_time
+                subq_6.user
+                , subq_6.txn_revenue AS user__revenue_all_time
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.user
-                  , SUM(subq_9.txn_revenue) AS txn_revenue
+                  subq_5.user
+                  , SUM(subq_5.txn_revenue) AS txn_revenue
                 FROM (
                   -- Pass Only Elements: ['txn_revenue', 'user']
                   SELECT
-                    subq_8.user
-                    , subq_8.txn_revenue
+                    subq_4.user
+                    , subq_4.txn_revenue
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.revenue_instance__ds__day
-                      , subq_7.revenue_instance__ds__week
-                      , subq_7.revenue_instance__ds__month
-                      , subq_7.revenue_instance__ds__quarter
-                      , subq_7.revenue_instance__ds__year
-                      , subq_7.revenue_instance__ds__extract_year
-                      , subq_7.revenue_instance__ds__extract_quarter
-                      , subq_7.revenue_instance__ds__extract_month
-                      , subq_7.revenue_instance__ds__extract_day
-                      , subq_7.revenue_instance__ds__extract_dow
-                      , subq_7.revenue_instance__ds__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.user
-                      , subq_7.revenue_instance__user
-                      , subq_7.txn_revenue
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.revenue_instance__ds__day
+                      , subq_3.revenue_instance__ds__week
+                      , subq_3.revenue_instance__ds__month
+                      , subq_3.revenue_instance__ds__quarter
+                      , subq_3.revenue_instance__ds__year
+                      , subq_3.revenue_instance__ds__extract_year
+                      , subq_3.revenue_instance__ds__extract_quarter
+                      , subq_3.revenue_instance__ds__extract_month
+                      , subq_3.revenue_instance__ds__extract_day
+                      , subq_3.revenue_instance__ds__extract_dow
+                      , subq_3.revenue_instance__ds__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.user
+                      , subq_3.revenue_instance__user
+                      , subq_3.txn_revenue
                     FROM (
                       -- Read Elements From Semantic Model 'revenue'
                       SELECT
@@ -251,19 +251,19 @@ FROM (
                         , revenue_src_28000.user_id AS user
                         , revenue_src_28000.user_id AS revenue_instance__user
                       FROM ***************************.fct_revenue revenue_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.user
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.user
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.user = subq_12.user
-        ) subq_13
-      ) subq_14
+            subq_2.user = subq_8.user
+        ) subq_9
+      ) subq_10
       WHERE user__revenue_all_time > 1
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_30.user__revenue_all_time AS user__revenue_all_time
-    , subq_24.listings AS listings
+    subq_22.user__revenue_all_time AS user__revenue_all_time
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.user = subq_30.user
-) subq_32
+    subq_16.user = subq_22.user
+) subq_24
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__views_times_booking_value
-        , subq_28.listings
+        subq_17.listing__views_times_booking_value
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
         SELECT
-          subq_27.listing__views_times_booking_value
-          , subq_27.listings
+          subq_16.listing__views_times_booking_value
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__views_times_booking_value AS listing__views_times_booking_value
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
             SELECT
-              subq_25.listing
-              , subq_25.listing__views_times_booking_value
+              subq_14.listing
+              , subq_14.listing__views_times_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
+                subq_13.listing
                 , booking_value * views AS listing__views_times_booking_value
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.booking_value) AS booking_value
-                  , MAX(subq_23.views) AS views
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.booking_value) AS booking_value
+                  , MAX(subq_12.views) AS views
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.booking_value
+                    subq_6.listing
+                    , subq_6.booking_value
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.booking_value) AS booking_value
+                      subq_5.listing
+                      , SUM(subq_5.booking_value) AS booking_value
                     FROM (
                       -- Pass Only Elements: ['booking_value', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.booking_value
+                        subq_4.listing
+                        , subq_4.booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,91 +387,91 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.views
+                    subq_11.listing
+                    , subq_11.views
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , SUM(subq_21.views) AS views
+                      subq_10.listing
+                      , SUM(subq_10.views) AS views
                     FROM (
                       -- Pass Only Elements: ['views', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.views
+                        subq_9.listing
+                        , subq_9.views
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.view__ds__day
-                          , subq_19.view__ds__week
-                          , subq_19.view__ds__month
-                          , subq_19.view__ds__quarter
-                          , subq_19.view__ds__year
-                          , subq_19.view__ds__extract_year
-                          , subq_19.view__ds__extract_quarter
-                          , subq_19.view__ds__extract_month
-                          , subq_19.view__ds__extract_day
-                          , subq_19.view__ds__extract_dow
-                          , subq_19.view__ds__extract_doy
-                          , subq_19.view__ds_partitioned__day
-                          , subq_19.view__ds_partitioned__week
-                          , subq_19.view__ds_partitioned__month
-                          , subq_19.view__ds_partitioned__quarter
-                          , subq_19.view__ds_partitioned__year
-                          , subq_19.view__ds_partitioned__extract_year
-                          , subq_19.view__ds_partitioned__extract_quarter
-                          , subq_19.view__ds_partitioned__extract_month
-                          , subq_19.view__ds_partitioned__extract_day
-                          , subq_19.view__ds_partitioned__extract_dow
-                          , subq_19.view__ds_partitioned__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.user
-                          , subq_19.view__listing
-                          , subq_19.view__user
-                          , subq_19.views
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.view__ds__day
+                          , subq_8.view__ds__week
+                          , subq_8.view__ds__month
+                          , subq_8.view__ds__quarter
+                          , subq_8.view__ds__year
+                          , subq_8.view__ds__extract_year
+                          , subq_8.view__ds__extract_quarter
+                          , subq_8.view__ds__extract_month
+                          , subq_8.view__ds__extract_day
+                          , subq_8.view__ds__extract_dow
+                          , subq_8.view__ds__extract_doy
+                          , subq_8.view__ds_partitioned__day
+                          , subq_8.view__ds_partitioned__week
+                          , subq_8.view__ds_partitioned__month
+                          , subq_8.view__ds_partitioned__quarter
+                          , subq_8.view__ds_partitioned__year
+                          , subq_8.view__ds_partitioned__extract_year
+                          , subq_8.view__ds_partitioned__extract_quarter
+                          , subq_8.view__ds_partitioned__extract_month
+                          , subq_8.view__ds_partitioned__extract_day
+                          , subq_8.view__ds_partitioned__extract_dow
+                          , subq_8.view__ds_partitioned__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.user
+                          , subq_8.view__listing
+                          , subq_8.view__user
+                          , subq_8.views
                         FROM (
                           -- Read Elements From Semantic Model 'views_source'
                           SELECT
@@ -525,25 +525,25 @@ FROM (
                             , views_source_src_28000.listing_id AS view__listing
                             , views_source_src_28000.user_id AS view__user
                           FROM ***************************.fct_views views_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__views_times_booking_value > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_45.listings AS listings
+    subq_36.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_50.listing, subq_55.listing) AS listing
-        , MAX(subq_50.booking_value) AS booking_value
-        , MAX(subq_55.views) AS views
+        COALESCE(subq_28.listing, subq_33.listing) AS listing
+        , MAX(subq_28.booking_value) AS booking_value
+        , MAX(subq_33.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_50
+      ) subq_28
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_53
+        ) subq_31
         GROUP BY
           listing
-      ) subq_55
+      ) subq_33
       ON
-        subq_50.listing = subq_55.listing
+        subq_28.listing = subq_33.listing
       GROUP BY
-        COALESCE(subq_50.listing, subq_55.listing)
-    ) subq_56
-  ) subq_58
+        COALESCE(subq_28.listing, subq_33.listing)
+    ) subq_34
+  ) subq_36
   ON
-    subq_45.listing = subq_58.listing
-) subq_60
+    subq_23.listing = subq_36.listing
+) subq_38
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -1,108 +1,108 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_19.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_18.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_17.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.listing__bookings
-        , subq_24.listing__bookers
-        , subq_24.listings
+        subq_16.listing__bookings
+        , subq_16.listing__bookers
+        , subq_16.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
         SELECT
-          subq_23.listing__bookings
-          , subq_23.listing__bookers
-          , subq_23.listings
+          subq_15.listing__bookings
+          , subq_15.listing__bookers
+          , subq_15.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_10.listing AS listing
-            , subq_16.listing__bookings AS listing__bookings
-            , subq_22.listing__bookers AS listing__bookers
-            , subq_10.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']
             SELECT
-              subq_9.listing
-              , subq_9.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_8.ds__day
-                , subq_8.ds__week
-                , subq_8.ds__month
-                , subq_8.ds__quarter
-                , subq_8.ds__year
-                , subq_8.ds__extract_year
-                , subq_8.ds__extract_quarter
-                , subq_8.ds__extract_month
-                , subq_8.ds__extract_day
-                , subq_8.ds__extract_dow
-                , subq_8.ds__extract_doy
-                , subq_8.created_at__day
-                , subq_8.created_at__week
-                , subq_8.created_at__month
-                , subq_8.created_at__quarter
-                , subq_8.created_at__year
-                , subq_8.created_at__extract_year
-                , subq_8.created_at__extract_quarter
-                , subq_8.created_at__extract_month
-                , subq_8.created_at__extract_day
-                , subq_8.created_at__extract_dow
-                , subq_8.created_at__extract_doy
-                , subq_8.listing__ds__day
-                , subq_8.listing__ds__week
-                , subq_8.listing__ds__month
-                , subq_8.listing__ds__quarter
-                , subq_8.listing__ds__year
-                , subq_8.listing__ds__extract_year
-                , subq_8.listing__ds__extract_quarter
-                , subq_8.listing__ds__extract_month
-                , subq_8.listing__ds__extract_day
-                , subq_8.listing__ds__extract_dow
-                , subq_8.listing__ds__extract_doy
-                , subq_8.listing__created_at__day
-                , subq_8.listing__created_at__week
-                , subq_8.listing__created_at__month
-                , subq_8.listing__created_at__quarter
-                , subq_8.listing__created_at__year
-                , subq_8.listing__created_at__extract_year
-                , subq_8.listing__created_at__extract_quarter
-                , subq_8.listing__created_at__extract_month
-                , subq_8.listing__created_at__extract_day
-                , subq_8.listing__created_at__extract_dow
-                , subq_8.listing__created_at__extract_doy
-                , subq_8.ds__day AS metric_time__day
-                , subq_8.ds__week AS metric_time__week
-                , subq_8.ds__month AS metric_time__month
-                , subq_8.ds__quarter AS metric_time__quarter
-                , subq_8.ds__year AS metric_time__year
-                , subq_8.ds__extract_year AS metric_time__extract_year
-                , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_8.ds__extract_month AS metric_time__extract_month
-                , subq_8.ds__extract_day AS metric_time__extract_day
-                , subq_8.ds__extract_dow AS metric_time__extract_dow
-                , subq_8.ds__extract_doy AS metric_time__extract_doy
-                , subq_8.listing
-                , subq_8.user
-                , subq_8.listing__user
-                , subq_8.country_latest
-                , subq_8.is_lux_latest
-                , subq_8.capacity_latest
-                , subq_8.listing__country_latest
-                , subq_8.listing__is_lux_latest
-                , subq_8.listing__capacity_latest
-                , subq_8.listings
-                , subq_8.largest_listing
-                , subq_8.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -163,130 +163,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_8
-            ) subq_9
-          ) subq_10
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_15.listing
-              , subq_15.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_14.listing
-                , subq_14.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_13.listing
-                  , SUM(subq_13.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_12.listing
-                    , subq_12.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_11.ds__day
-                      , subq_11.ds__week
-                      , subq_11.ds__month
-                      , subq_11.ds__quarter
-                      , subq_11.ds__year
-                      , subq_11.ds__extract_year
-                      , subq_11.ds__extract_quarter
-                      , subq_11.ds__extract_month
-                      , subq_11.ds__extract_day
-                      , subq_11.ds__extract_dow
-                      , subq_11.ds__extract_doy
-                      , subq_11.ds_partitioned__day
-                      , subq_11.ds_partitioned__week
-                      , subq_11.ds_partitioned__month
-                      , subq_11.ds_partitioned__quarter
-                      , subq_11.ds_partitioned__year
-                      , subq_11.ds_partitioned__extract_year
-                      , subq_11.ds_partitioned__extract_quarter
-                      , subq_11.ds_partitioned__extract_month
-                      , subq_11.ds_partitioned__extract_day
-                      , subq_11.ds_partitioned__extract_dow
-                      , subq_11.ds_partitioned__extract_doy
-                      , subq_11.paid_at__day
-                      , subq_11.paid_at__week
-                      , subq_11.paid_at__month
-                      , subq_11.paid_at__quarter
-                      , subq_11.paid_at__year
-                      , subq_11.paid_at__extract_year
-                      , subq_11.paid_at__extract_quarter
-                      , subq_11.paid_at__extract_month
-                      , subq_11.paid_at__extract_day
-                      , subq_11.paid_at__extract_dow
-                      , subq_11.paid_at__extract_doy
-                      , subq_11.booking__ds__day
-                      , subq_11.booking__ds__week
-                      , subq_11.booking__ds__month
-                      , subq_11.booking__ds__quarter
-                      , subq_11.booking__ds__year
-                      , subq_11.booking__ds__extract_year
-                      , subq_11.booking__ds__extract_quarter
-                      , subq_11.booking__ds__extract_month
-                      , subq_11.booking__ds__extract_day
-                      , subq_11.booking__ds__extract_dow
-                      , subq_11.booking__ds__extract_doy
-                      , subq_11.booking__ds_partitioned__day
-                      , subq_11.booking__ds_partitioned__week
-                      , subq_11.booking__ds_partitioned__month
-                      , subq_11.booking__ds_partitioned__quarter
-                      , subq_11.booking__ds_partitioned__year
-                      , subq_11.booking__ds_partitioned__extract_year
-                      , subq_11.booking__ds_partitioned__extract_quarter
-                      , subq_11.booking__ds_partitioned__extract_month
-                      , subq_11.booking__ds_partitioned__extract_day
-                      , subq_11.booking__ds_partitioned__extract_dow
-                      , subq_11.booking__ds_partitioned__extract_doy
-                      , subq_11.booking__paid_at__day
-                      , subq_11.booking__paid_at__week
-                      , subq_11.booking__paid_at__month
-                      , subq_11.booking__paid_at__quarter
-                      , subq_11.booking__paid_at__year
-                      , subq_11.booking__paid_at__extract_year
-                      , subq_11.booking__paid_at__extract_quarter
-                      , subq_11.booking__paid_at__extract_month
-                      , subq_11.booking__paid_at__extract_day
-                      , subq_11.booking__paid_at__extract_dow
-                      , subq_11.booking__paid_at__extract_doy
-                      , subq_11.ds__day AS metric_time__day
-                      , subq_11.ds__week AS metric_time__week
-                      , subq_11.ds__month AS metric_time__month
-                      , subq_11.ds__quarter AS metric_time__quarter
-                      , subq_11.ds__year AS metric_time__year
-                      , subq_11.ds__extract_year AS metric_time__extract_year
-                      , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_11.ds__extract_month AS metric_time__extract_month
-                      , subq_11.ds__extract_day AS metric_time__extract_day
-                      , subq_11.ds__extract_dow AS metric_time__extract_dow
-                      , subq_11.ds__extract_doy AS metric_time__extract_doy
-                      , subq_11.listing
-                      , subq_11.guest
-                      , subq_11.host
-                      , subq_11.booking__listing
-                      , subq_11.booking__guest
-                      , subq_11.booking__host
-                      , subq_11.is_instant
-                      , subq_11.booking__is_instant
-                      , subq_11.bookings
-                      , subq_11.instant_bookings
-                      , subq_11.booking_value
-                      , subq_11.max_booking_value
-                      , subq_11.min_booking_value
-                      , subq_11.bookers
-                      , subq_11.average_booking_value
-                      , subq_11.referred_bookings
-                      , subq_11.median_booking_value
-                      , subq_11.booking_value_p99
-                      , subq_11.discrete_booking_value_p99
-                      , subq_11.approximate_continuous_booking_value_p99
-                      , subq_11.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -379,137 +379,137 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_11
-                  ) subq_12
-                ) subq_13
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_13.listing
-              ) subq_14
-            ) subq_15
-          ) subq_16
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_10.listing = subq_16.listing
+            subq_2.listing = subq_8.listing
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_21.listing
-              , subq_21.listing__bookers
+              subq_13.listing
+              , subq_13.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing
-                , subq_20.bookers AS listing__bookers
+                subq_12.listing
+                , subq_12.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing
-                  , COUNT(DISTINCT subq_19.bookers) AS bookers
+                  subq_11.listing
+                  , COUNT(DISTINCT subq_11.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_18.listing
-                    , subq_18.bookers
+                    subq_10.listing
+                    , subq_10.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.ds_partitioned__day
-                      , subq_17.ds_partitioned__week
-                      , subq_17.ds_partitioned__month
-                      , subq_17.ds_partitioned__quarter
-                      , subq_17.ds_partitioned__year
-                      , subq_17.ds_partitioned__extract_year
-                      , subq_17.ds_partitioned__extract_quarter
-                      , subq_17.ds_partitioned__extract_month
-                      , subq_17.ds_partitioned__extract_day
-                      , subq_17.ds_partitioned__extract_dow
-                      , subq_17.ds_partitioned__extract_doy
-                      , subq_17.paid_at__day
-                      , subq_17.paid_at__week
-                      , subq_17.paid_at__month
-                      , subq_17.paid_at__quarter
-                      , subq_17.paid_at__year
-                      , subq_17.paid_at__extract_year
-                      , subq_17.paid_at__extract_quarter
-                      , subq_17.paid_at__extract_month
-                      , subq_17.paid_at__extract_day
-                      , subq_17.paid_at__extract_dow
-                      , subq_17.paid_at__extract_doy
-                      , subq_17.booking__ds__day
-                      , subq_17.booking__ds__week
-                      , subq_17.booking__ds__month
-                      , subq_17.booking__ds__quarter
-                      , subq_17.booking__ds__year
-                      , subq_17.booking__ds__extract_year
-                      , subq_17.booking__ds__extract_quarter
-                      , subq_17.booking__ds__extract_month
-                      , subq_17.booking__ds__extract_day
-                      , subq_17.booking__ds__extract_dow
-                      , subq_17.booking__ds__extract_doy
-                      , subq_17.booking__ds_partitioned__day
-                      , subq_17.booking__ds_partitioned__week
-                      , subq_17.booking__ds_partitioned__month
-                      , subq_17.booking__ds_partitioned__quarter
-                      , subq_17.booking__ds_partitioned__year
-                      , subq_17.booking__ds_partitioned__extract_year
-                      , subq_17.booking__ds_partitioned__extract_quarter
-                      , subq_17.booking__ds_partitioned__extract_month
-                      , subq_17.booking__ds_partitioned__extract_day
-                      , subq_17.booking__ds_partitioned__extract_dow
-                      , subq_17.booking__ds_partitioned__extract_doy
-                      , subq_17.booking__paid_at__day
-                      , subq_17.booking__paid_at__week
-                      , subq_17.booking__paid_at__month
-                      , subq_17.booking__paid_at__quarter
-                      , subq_17.booking__paid_at__year
-                      , subq_17.booking__paid_at__extract_year
-                      , subq_17.booking__paid_at__extract_quarter
-                      , subq_17.booking__paid_at__extract_month
-                      , subq_17.booking__paid_at__extract_day
-                      , subq_17.booking__paid_at__extract_dow
-                      , subq_17.booking__paid_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.guest
-                      , subq_17.host
-                      , subq_17.booking__listing
-                      , subq_17.booking__guest
-                      , subq_17.booking__host
-                      , subq_17.is_instant
-                      , subq_17.booking__is_instant
-                      , subq_17.bookings
-                      , subq_17.instant_bookings
-                      , subq_17.booking_value
-                      , subq_17.max_booking_value
-                      , subq_17.min_booking_value
-                      , subq_17.bookers
-                      , subq_17.average_booking_value
-                      , subq_17.referred_bookings
-                      , subq_17.median_booking_value
-                      , subq_17.booking_value_p99
-                      , subq_17.discrete_booking_value_p99
-                      , subq_17.approximate_continuous_booking_value_p99
-                      , subq_17.approximate_discrete_booking_value_p99
+                      subq_9.ds__day
+                      , subq_9.ds__week
+                      , subq_9.ds__month
+                      , subq_9.ds__quarter
+                      , subq_9.ds__year
+                      , subq_9.ds__extract_year
+                      , subq_9.ds__extract_quarter
+                      , subq_9.ds__extract_month
+                      , subq_9.ds__extract_day
+                      , subq_9.ds__extract_dow
+                      , subq_9.ds__extract_doy
+                      , subq_9.ds_partitioned__day
+                      , subq_9.ds_partitioned__week
+                      , subq_9.ds_partitioned__month
+                      , subq_9.ds_partitioned__quarter
+                      , subq_9.ds_partitioned__year
+                      , subq_9.ds_partitioned__extract_year
+                      , subq_9.ds_partitioned__extract_quarter
+                      , subq_9.ds_partitioned__extract_month
+                      , subq_9.ds_partitioned__extract_day
+                      , subq_9.ds_partitioned__extract_dow
+                      , subq_9.ds_partitioned__extract_doy
+                      , subq_9.paid_at__day
+                      , subq_9.paid_at__week
+                      , subq_9.paid_at__month
+                      , subq_9.paid_at__quarter
+                      , subq_9.paid_at__year
+                      , subq_9.paid_at__extract_year
+                      , subq_9.paid_at__extract_quarter
+                      , subq_9.paid_at__extract_month
+                      , subq_9.paid_at__extract_day
+                      , subq_9.paid_at__extract_dow
+                      , subq_9.paid_at__extract_doy
+                      , subq_9.booking__ds__day
+                      , subq_9.booking__ds__week
+                      , subq_9.booking__ds__month
+                      , subq_9.booking__ds__quarter
+                      , subq_9.booking__ds__year
+                      , subq_9.booking__ds__extract_year
+                      , subq_9.booking__ds__extract_quarter
+                      , subq_9.booking__ds__extract_month
+                      , subq_9.booking__ds__extract_day
+                      , subq_9.booking__ds__extract_dow
+                      , subq_9.booking__ds__extract_doy
+                      , subq_9.booking__ds_partitioned__day
+                      , subq_9.booking__ds_partitioned__week
+                      , subq_9.booking__ds_partitioned__month
+                      , subq_9.booking__ds_partitioned__quarter
+                      , subq_9.booking__ds_partitioned__year
+                      , subq_9.booking__ds_partitioned__extract_year
+                      , subq_9.booking__ds_partitioned__extract_quarter
+                      , subq_9.booking__ds_partitioned__extract_month
+                      , subq_9.booking__ds_partitioned__extract_day
+                      , subq_9.booking__ds_partitioned__extract_dow
+                      , subq_9.booking__ds_partitioned__extract_doy
+                      , subq_9.booking__paid_at__day
+                      , subq_9.booking__paid_at__week
+                      , subq_9.booking__paid_at__month
+                      , subq_9.booking__paid_at__quarter
+                      , subq_9.booking__paid_at__year
+                      , subq_9.booking__paid_at__extract_year
+                      , subq_9.booking__paid_at__extract_quarter
+                      , subq_9.booking__paid_at__extract_month
+                      , subq_9.booking__paid_at__extract_day
+                      , subq_9.booking__paid_at__extract_dow
+                      , subq_9.booking__paid_at__extract_doy
+                      , subq_9.ds__day AS metric_time__day
+                      , subq_9.ds__week AS metric_time__week
+                      , subq_9.ds__month AS metric_time__month
+                      , subq_9.ds__quarter AS metric_time__quarter
+                      , subq_9.ds__year AS metric_time__year
+                      , subq_9.ds__extract_year AS metric_time__extract_year
+                      , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_9.ds__extract_month AS metric_time__extract_month
+                      , subq_9.ds__extract_day AS metric_time__extract_day
+                      , subq_9.ds__extract_dow AS metric_time__extract_dow
+                      , subq_9.ds__extract_doy AS metric_time__extract_doy
+                      , subq_9.listing
+                      , subq_9.guest
+                      , subq_9.host
+                      , subq_9.booking__listing
+                      , subq_9.booking__guest
+                      , subq_9.booking__host
+                      , subq_9.is_instant
+                      , subq_9.booking__is_instant
+                      , subq_9.bookings
+                      , subq_9.instant_bookings
+                      , subq_9.booking_value
+                      , subq_9.max_booking_value
+                      , subq_9.min_booking_value
+                      , subq_9.bookers
+                      , subq_9.average_booking_value
+                      , subq_9.referred_bookings
+                      , subq_9.median_booking_value
+                      , subq_9.booking_value_p99
+                      , subq_9.discrete_booking_value_p99
+                      , subq_9.approximate_continuous_booking_value_p99
+                      , subq_9.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -602,19 +602,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_9
+                  ) subq_10
+                ) subq_11
                 GROUP BY
-                  subq_19.listing
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_11.listing
+              ) subq_12
+            ) subq_13
+          ) subq_14
           ON
-            subq_10.listing = subq_22.listing
-        ) subq_23
-      ) subq_24
+            subq_2.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       WHERE listing__bookings > 2 AND listing__bookers > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_17
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_44.listing__bookings AS listing__bookings
-    , subq_50.listing__bookers AS listing__bookers
-    , subq_38.listings AS listings
+    subq_28.listing__bookings AS listing__bookings
+    , subq_34.listing__bookers AS listing__bookers
+    , subq_22.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_38
+  ) subq_22
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_41
+    ) subq_25
     GROUP BY
       listing
-  ) subq_44
+  ) subq_28
   ON
-    subq_38.listing = subq_44.listing
+    subq_22.listing = subq_28.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_50
+  ) subq_34
   ON
-    subq_38.listing = subq_50.listing
-) subq_52
+    subq_22.listing = subq_34.listing
+) subq_36
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__bookings_per_booker
-        , subq_28.listings
+        subq_17.listing__bookings_per_booker
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
         SELECT
-          subq_27.listing__bookings_per_booker
-          , subq_27.listings
+          subq_16.listing__bookings_per_booker
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__bookings_per_booker AS listing__bookings_per_booker
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings_per_booker']
             SELECT
-              subq_25.listing
-              , subq_25.listing__bookings_per_booker
+              subq_14.listing
+              , subq_14.listing__bookings_per_booker
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
-                , CAST(subq_24.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_24.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
+                subq_13.listing
+                , CAST(subq_13.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.bookings) AS bookings
-                  , MAX(subq_23.bookers) AS bookers
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.bookings) AS bookings
+                  , MAX(subq_12.bookers) AS bookers
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.bookings
+                    subq_6.listing
+                    , subq_6.bookings
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.bookings) AS bookings
+                      subq_5.listing
+                      , SUM(subq_5.bookings) AS bookings
                     FROM (
                       -- Pass Only Elements: ['bookings', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.bookings
+                        subq_4.listing
+                        , subq_4.bookings
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,129 +387,129 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.bookers
+                    subq_11.listing
+                    , subq_11.bookers
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , COUNT(DISTINCT subq_21.bookers) AS bookers
+                      subq_10.listing
+                      , COUNT(DISTINCT subq_10.bookers) AS bookers
                     FROM (
                       -- Pass Only Elements: ['bookers', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.bookers
+                        subq_9.listing
+                        , subq_9.bookers
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.paid_at__day
-                          , subq_19.paid_at__week
-                          , subq_19.paid_at__month
-                          , subq_19.paid_at__quarter
-                          , subq_19.paid_at__year
-                          , subq_19.paid_at__extract_year
-                          , subq_19.paid_at__extract_quarter
-                          , subq_19.paid_at__extract_month
-                          , subq_19.paid_at__extract_day
-                          , subq_19.paid_at__extract_dow
-                          , subq_19.paid_at__extract_doy
-                          , subq_19.booking__ds__day
-                          , subq_19.booking__ds__week
-                          , subq_19.booking__ds__month
-                          , subq_19.booking__ds__quarter
-                          , subq_19.booking__ds__year
-                          , subq_19.booking__ds__extract_year
-                          , subq_19.booking__ds__extract_quarter
-                          , subq_19.booking__ds__extract_month
-                          , subq_19.booking__ds__extract_day
-                          , subq_19.booking__ds__extract_dow
-                          , subq_19.booking__ds__extract_doy
-                          , subq_19.booking__ds_partitioned__day
-                          , subq_19.booking__ds_partitioned__week
-                          , subq_19.booking__ds_partitioned__month
-                          , subq_19.booking__ds_partitioned__quarter
-                          , subq_19.booking__ds_partitioned__year
-                          , subq_19.booking__ds_partitioned__extract_year
-                          , subq_19.booking__ds_partitioned__extract_quarter
-                          , subq_19.booking__ds_partitioned__extract_month
-                          , subq_19.booking__ds_partitioned__extract_day
-                          , subq_19.booking__ds_partitioned__extract_dow
-                          , subq_19.booking__ds_partitioned__extract_doy
-                          , subq_19.booking__paid_at__day
-                          , subq_19.booking__paid_at__week
-                          , subq_19.booking__paid_at__month
-                          , subq_19.booking__paid_at__quarter
-                          , subq_19.booking__paid_at__year
-                          , subq_19.booking__paid_at__extract_year
-                          , subq_19.booking__paid_at__extract_quarter
-                          , subq_19.booking__paid_at__extract_month
-                          , subq_19.booking__paid_at__extract_day
-                          , subq_19.booking__paid_at__extract_dow
-                          , subq_19.booking__paid_at__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.guest
-                          , subq_19.host
-                          , subq_19.booking__listing
-                          , subq_19.booking__guest
-                          , subq_19.booking__host
-                          , subq_19.is_instant
-                          , subq_19.booking__is_instant
-                          , subq_19.bookings
-                          , subq_19.instant_bookings
-                          , subq_19.booking_value
-                          , subq_19.max_booking_value
-                          , subq_19.min_booking_value
-                          , subq_19.bookers
-                          , subq_19.average_booking_value
-                          , subq_19.referred_bookings
-                          , subq_19.median_booking_value
-                          , subq_19.booking_value_p99
-                          , subq_19.discrete_booking_value_p99
-                          , subq_19.approximate_continuous_booking_value_p99
-                          , subq_19.approximate_discrete_booking_value_p99
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.paid_at__day
+                          , subq_8.paid_at__week
+                          , subq_8.paid_at__month
+                          , subq_8.paid_at__quarter
+                          , subq_8.paid_at__year
+                          , subq_8.paid_at__extract_year
+                          , subq_8.paid_at__extract_quarter
+                          , subq_8.paid_at__extract_month
+                          , subq_8.paid_at__extract_day
+                          , subq_8.paid_at__extract_dow
+                          , subq_8.paid_at__extract_doy
+                          , subq_8.booking__ds__day
+                          , subq_8.booking__ds__week
+                          , subq_8.booking__ds__month
+                          , subq_8.booking__ds__quarter
+                          , subq_8.booking__ds__year
+                          , subq_8.booking__ds__extract_year
+                          , subq_8.booking__ds__extract_quarter
+                          , subq_8.booking__ds__extract_month
+                          , subq_8.booking__ds__extract_day
+                          , subq_8.booking__ds__extract_dow
+                          , subq_8.booking__ds__extract_doy
+                          , subq_8.booking__ds_partitioned__day
+                          , subq_8.booking__ds_partitioned__week
+                          , subq_8.booking__ds_partitioned__month
+                          , subq_8.booking__ds_partitioned__quarter
+                          , subq_8.booking__ds_partitioned__year
+                          , subq_8.booking__ds_partitioned__extract_year
+                          , subq_8.booking__ds_partitioned__extract_quarter
+                          , subq_8.booking__ds_partitioned__extract_month
+                          , subq_8.booking__ds_partitioned__extract_day
+                          , subq_8.booking__ds_partitioned__extract_dow
+                          , subq_8.booking__ds_partitioned__extract_doy
+                          , subq_8.booking__paid_at__day
+                          , subq_8.booking__paid_at__week
+                          , subq_8.booking__paid_at__month
+                          , subq_8.booking__paid_at__quarter
+                          , subq_8.booking__paid_at__year
+                          , subq_8.booking__paid_at__extract_year
+                          , subq_8.booking__paid_at__extract_quarter
+                          , subq_8.booking__paid_at__extract_month
+                          , subq_8.booking__paid_at__extract_day
+                          , subq_8.booking__paid_at__extract_dow
+                          , subq_8.booking__paid_at__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.guest
+                          , subq_8.host
+                          , subq_8.booking__listing
+                          , subq_8.booking__guest
+                          , subq_8.booking__host
+                          , subq_8.is_instant
+                          , subq_8.booking__is_instant
+                          , subq_8.bookings
+                          , subq_8.instant_bookings
+                          , subq_8.booking_value
+                          , subq_8.max_booking_value
+                          , subq_8.min_booking_value
+                          , subq_8.bookers
+                          , subq_8.average_booking_value
+                          , subq_8.referred_bookings
+                          , subq_8.median_booking_value
+                          , subq_8.booking_value_p99
+                          , subq_8.discrete_booking_value_p99
+                          , subq_8.approximate_continuous_booking_value_p99
+                          , subq_8.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -602,25 +602,25 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__bookings_per_booker > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_56.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
-    , subq_45.listings AS listings
+    CAST(subq_34.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_50.listing, subq_55.listing) AS listing
-      , MAX(subq_50.bookings) AS bookings
-      , MAX(subq_55.bookers) AS bookers
+      COALESCE(subq_28.listing, subq_33.listing) AS listing
+      , MAX(subq_28.bookings) AS bookings
+      , MAX(subq_33.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_48
+      ) subq_26
       GROUP BY
         listing
-    ) subq_50
+    ) subq_28
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_55
+    ) subq_33
     ON
-      subq_50.listing = subq_55.listing
+      subq_28.listing = subq_33.listing
     GROUP BY
-      COALESCE(subq_50.listing, subq_55.listing)
-  ) subq_56
+      COALESCE(subq_28.listing, subq_33.listing)
+  ) subq_34
   ON
-    subq_45.listing = subq_56.listing
-) subq_60
+    subq_23.listing = subq_34.listing
+) subq_38
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings']
         SELECT
-          subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,130 +160,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -376,19 +376,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -1,20 +1,20 @@
 -- Pass Only Elements: ['listing',]
 SELECT
-  subq_12.listing
+  subq_8.listing
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_11.listing
-    , subq_11.lux_listing
-    , subq_11.listing__lux_listing
-    , subq_11.listing__bookings
+    subq_7.listing
+    , subq_7.lux_listing
+    , subq_7.listing__lux_listing
+    , subq_7.listing__bookings
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_4.listing AS listing
-      , subq_4.lux_listing AS lux_listing
-      , subq_4.listing__lux_listing AS listing__lux_listing
-      , subq_10.listing__bookings AS listing__bookings
+      subq_0.listing AS listing
+      , subq_0.lux_listing AS lux_listing
+      , subq_0.listing__lux_listing AS listing__lux_listing
+      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT
@@ -22,128 +22,128 @@ FROM (
         , lux_listing_mapping_src_28000.lux_listing_id AS lux_listing
         , lux_listing_mapping_src_28000.lux_listing_id AS listing__lux_listing
       FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
-    ) subq_4
+    ) subq_0
     FULL OUTER JOIN (
       -- Pass Only Elements: ['listing', 'listing__bookings']
       SELECT
-        subq_9.listing
-        , subq_9.listing__bookings
+        subq_5.listing
+        , subq_5.listing__bookings
       FROM (
         -- Compute Metrics via Expressions
         SELECT
-          subq_8.listing
-          , subq_8.bookings AS listing__bookings
+          subq_4.listing
+          , subq_4.bookings AS listing__bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_7.listing
-            , SUM(subq_7.bookings) AS bookings
+            subq_3.listing
+            , SUM(subq_3.bookings) AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'listing']
             SELECT
-              subq_6.listing
-              , subq_6.bookings
+              subq_2.listing
+              , subq_2.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds__day
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.ds__extract_year
-                , subq_5.ds__extract_quarter
-                , subq_5.ds__extract_month
-                , subq_5.ds__extract_day
-                , subq_5.ds__extract_dow
-                , subq_5.ds__extract_doy
-                , subq_5.ds_partitioned__day
-                , subq_5.ds_partitioned__week
-                , subq_5.ds_partitioned__month
-                , subq_5.ds_partitioned__quarter
-                , subq_5.ds_partitioned__year
-                , subq_5.ds_partitioned__extract_year
-                , subq_5.ds_partitioned__extract_quarter
-                , subq_5.ds_partitioned__extract_month
-                , subq_5.ds_partitioned__extract_day
-                , subq_5.ds_partitioned__extract_dow
-                , subq_5.ds_partitioned__extract_doy
-                , subq_5.paid_at__day
-                , subq_5.paid_at__week
-                , subq_5.paid_at__month
-                , subq_5.paid_at__quarter
-                , subq_5.paid_at__year
-                , subq_5.paid_at__extract_year
-                , subq_5.paid_at__extract_quarter
-                , subq_5.paid_at__extract_month
-                , subq_5.paid_at__extract_day
-                , subq_5.paid_at__extract_dow
-                , subq_5.paid_at__extract_doy
-                , subq_5.booking__ds__day
-                , subq_5.booking__ds__week
-                , subq_5.booking__ds__month
-                , subq_5.booking__ds__quarter
-                , subq_5.booking__ds__year
-                , subq_5.booking__ds__extract_year
-                , subq_5.booking__ds__extract_quarter
-                , subq_5.booking__ds__extract_month
-                , subq_5.booking__ds__extract_day
-                , subq_5.booking__ds__extract_dow
-                , subq_5.booking__ds__extract_doy
-                , subq_5.booking__ds_partitioned__day
-                , subq_5.booking__ds_partitioned__week
-                , subq_5.booking__ds_partitioned__month
-                , subq_5.booking__ds_partitioned__quarter
-                , subq_5.booking__ds_partitioned__year
-                , subq_5.booking__ds_partitioned__extract_year
-                , subq_5.booking__ds_partitioned__extract_quarter
-                , subq_5.booking__ds_partitioned__extract_month
-                , subq_5.booking__ds_partitioned__extract_day
-                , subq_5.booking__ds_partitioned__extract_dow
-                , subq_5.booking__ds_partitioned__extract_doy
-                , subq_5.booking__paid_at__day
-                , subq_5.booking__paid_at__week
-                , subq_5.booking__paid_at__month
-                , subq_5.booking__paid_at__quarter
-                , subq_5.booking__paid_at__year
-                , subq_5.booking__paid_at__extract_year
-                , subq_5.booking__paid_at__extract_quarter
-                , subq_5.booking__paid_at__extract_month
-                , subq_5.booking__paid_at__extract_day
-                , subq_5.booking__paid_at__extract_dow
-                , subq_5.booking__paid_at__extract_doy
-                , subq_5.ds__day AS metric_time__day
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.ds__extract_year AS metric_time__extract_year
-                , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_5.ds__extract_month AS metric_time__extract_month
-                , subq_5.ds__extract_day AS metric_time__extract_day
-                , subq_5.ds__extract_dow AS metric_time__extract_dow
-                , subq_5.ds__extract_doy AS metric_time__extract_doy
-                , subq_5.listing
-                , subq_5.guest
-                , subq_5.host
-                , subq_5.booking__listing
-                , subq_5.booking__guest
-                , subq_5.booking__host
-                , subq_5.is_instant
-                , subq_5.booking__is_instant
-                , subq_5.bookings
-                , subq_5.instant_bookings
-                , subq_5.booking_value
-                , subq_5.max_booking_value
-                , subq_5.min_booking_value
-                , subq_5.bookers
-                , subq_5.average_booking_value
-                , subq_5.referred_bookings
-                , subq_5.median_booking_value
-                , subq_5.booking_value_p99
-                , subq_5.discrete_booking_value_p99
-                , subq_5.approximate_continuous_booking_value_p99
-                , subq_5.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.ds__day AS metric_time__day
+                , subq_1.ds__week AS metric_time__week
+                , subq_1.ds__month AS metric_time__month
+                , subq_1.ds__quarter AS metric_time__quarter
+                , subq_1.ds__year AS metric_time__year
+                , subq_1.ds__extract_year AS metric_time__extract_year
+                , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_1.ds__extract_month AS metric_time__extract_month
+                , subq_1.ds__extract_day AS metric_time__extract_day
+                , subq_1.ds__extract_dow AS metric_time__extract_dow
+                , subq_1.ds__extract_doy AS metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -236,18 +236,18 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_5
-            ) subq_6
-          ) subq_7
+              ) subq_1
+            ) subq_2
+          ) subq_3
           GROUP BY
-            subq_7.listing
-        ) subq_8
-      ) subq_9
-    ) subq_10
+            subq_3.listing
+        ) subq_4
+      ) subq_5
+    ) subq_6
     ON
-      subq_4.listing = subq_10.listing
-  ) subq_11
+      subq_0.listing = subq_6.listing
+  ) subq_7
   WHERE listing__bookings > 2
-) subq_12
+) subq_8
 GROUP BY
-  subq_12.listing
+  subq_8.listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_23.listing__bookings AS listing__bookings
+    , subq_15.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+    ) subq_12
     GROUP BY
       listing
-  ) subq_23
+  ) subq_15
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_23.listing
-) subq_24
+    lux_listing_mapping_src_28000.listing_id = subq_15.listing
+) subq_16
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.guest__booking_value
-        , subq_14.bookers
+        subq_10.guest__booking_value
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'guest__booking_value']
         SELECT
-          subq_13.guest__booking_value
-          , subq_13.bookers
+          subq_9.guest__booking_value
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.guest AS guest
-            , subq_12.guest__booking_value AS guest__booking_value
-            , subq_6.bookers AS bookers
+            subq_2.guest AS guest
+            , subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']
             SELECT
-              subq_5.guest
-              , subq_5.bookers
+              subq_1.guest
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['guest', 'guest__booking_value']
             SELECT
-              subq_11.guest
-              , subq_11.guest__booking_value
+              subq_7.guest
+              , subq_7.guest__booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.guest
-                , subq_10.booking_value AS guest__booking_value
+                subq_6.guest
+                , subq_6.booking_value AS guest__booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.guest
-                  , SUM(subq_9.booking_value) AS booking_value
+                  subq_5.guest
+                  , SUM(subq_5.booking_value) AS booking_value
                 FROM (
                   -- Pass Only Elements: ['booking_value', 'guest']
                   SELECT
-                    subq_8.guest
-                    , subq_8.booking_value
+                    subq_4.guest
+                    , subq_4.booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.guest
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.guest
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.guest = subq_12.guest
-        ) subq_13
-      ) subq_14
+            subq_2.guest = subq_8.guest
+        ) subq_9
+      ) subq_10
       WHERE guest__booking_value > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_30.guest__booking_value AS guest__booking_value
-    , subq_24.bookers AS bookers
+    subq_22.guest__booking_value AS guest__booking_value
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.guest = subq_30.guest
-) subq_32
+    subq_16.guest = subq_22.guest
+) subq_24
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_39.listings
+  subq_24.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_38.listings) AS listings
+    SUM(subq_23.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_37.listings
+      subq_22.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_36.user__visit_buy_conversion_rate
-        , subq_36.listings
+        subq_21.user__visit_buy_conversion_rate
+        , subq_21.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
         SELECT
-          subq_35.user__visit_buy_conversion_rate
-          , subq_35.listings
+          subq_20.user__visit_buy_conversion_rate
+          , subq_20.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_17.user AS user
-            , subq_34.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
-            , subq_17.listings AS listings
+            subq_2.user AS user
+            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_16.user
-              , subq_16.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_15.ds__day
-                , subq_15.ds__week
-                , subq_15.ds__month
-                , subq_15.ds__quarter
-                , subq_15.ds__year
-                , subq_15.ds__extract_year
-                , subq_15.ds__extract_quarter
-                , subq_15.ds__extract_month
-                , subq_15.ds__extract_day
-                , subq_15.ds__extract_dow
-                , subq_15.ds__extract_doy
-                , subq_15.created_at__day
-                , subq_15.created_at__week
-                , subq_15.created_at__month
-                , subq_15.created_at__quarter
-                , subq_15.created_at__year
-                , subq_15.created_at__extract_year
-                , subq_15.created_at__extract_quarter
-                , subq_15.created_at__extract_month
-                , subq_15.created_at__extract_day
-                , subq_15.created_at__extract_dow
-                , subq_15.created_at__extract_doy
-                , subq_15.listing__ds__day
-                , subq_15.listing__ds__week
-                , subq_15.listing__ds__month
-                , subq_15.listing__ds__quarter
-                , subq_15.listing__ds__year
-                , subq_15.listing__ds__extract_year
-                , subq_15.listing__ds__extract_quarter
-                , subq_15.listing__ds__extract_month
-                , subq_15.listing__ds__extract_day
-                , subq_15.listing__ds__extract_dow
-                , subq_15.listing__ds__extract_doy
-                , subq_15.listing__created_at__day
-                , subq_15.listing__created_at__week
-                , subq_15.listing__created_at__month
-                , subq_15.listing__created_at__quarter
-                , subq_15.listing__created_at__year
-                , subq_15.listing__created_at__extract_year
-                , subq_15.listing__created_at__extract_quarter
-                , subq_15.listing__created_at__extract_month
-                , subq_15.listing__created_at__extract_day
-                , subq_15.listing__created_at__extract_dow
-                , subq_15.listing__created_at__extract_doy
-                , subq_15.ds__day AS metric_time__day
-                , subq_15.ds__week AS metric_time__week
-                , subq_15.ds__month AS metric_time__month
-                , subq_15.ds__quarter AS metric_time__quarter
-                , subq_15.ds__year AS metric_time__year
-                , subq_15.ds__extract_year AS metric_time__extract_year
-                , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_15.ds__extract_month AS metric_time__extract_month
-                , subq_15.ds__extract_day AS metric_time__extract_day
-                , subq_15.ds__extract_dow AS metric_time__extract_dow
-                , subq_15.ds__extract_doy AS metric_time__extract_doy
-                , subq_15.listing
-                , subq_15.user
-                , subq_15.listing__user
-                , subq_15.country_latest
-                , subq_15.is_lux_latest
-                , subq_15.capacity_latest
-                , subq_15.listing__country_latest
-                , subq_15.listing__is_lux_latest
-                , subq_15.listing__capacity_latest
-                , subq_15.listings
-                , subq_15.largest_listing
-                , subq_15.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,79 +160,79 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_15
-            ) subq_16
-          ) subq_17
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__visit_buy_conversion_rate']
             SELECT
-              subq_33.user
-              , subq_33.user__visit_buy_conversion_rate
+              subq_18.user
+              , subq_18.user__visit_buy_conversion_rate
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_32.user
-                , CAST(subq_32.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_32.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
+                subq_17.user
+                , CAST(subq_17.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_21.user, subq_31.user) AS user
-                  , MAX(subq_21.visits) AS visits
-                  , MAX(subq_31.buys) AS buys
+                  COALESCE(subq_6.user, subq_16.user) AS user
+                  , MAX(subq_6.visits) AS visits
+                  , MAX(subq_16.buys) AS buys
                 FROM (
                   -- Aggregate Measures
                   SELECT
-                    subq_20.user
-                    , SUM(subq_20.visits) AS visits
+                    subq_5.user
+                    , SUM(subq_5.visits) AS visits
                   FROM (
                     -- Pass Only Elements: ['visits', 'user']
                     SELECT
-                      subq_19.user
-                      , subq_19.visits
+                      subq_4.user
+                      , subq_4.visits
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_18.ds__day
-                        , subq_18.ds__week
-                        , subq_18.ds__month
-                        , subq_18.ds__quarter
-                        , subq_18.ds__year
-                        , subq_18.ds__extract_year
-                        , subq_18.ds__extract_quarter
-                        , subq_18.ds__extract_month
-                        , subq_18.ds__extract_day
-                        , subq_18.ds__extract_dow
-                        , subq_18.ds__extract_doy
-                        , subq_18.visit__ds__day
-                        , subq_18.visit__ds__week
-                        , subq_18.visit__ds__month
-                        , subq_18.visit__ds__quarter
-                        , subq_18.visit__ds__year
-                        , subq_18.visit__ds__extract_year
-                        , subq_18.visit__ds__extract_quarter
-                        , subq_18.visit__ds__extract_month
-                        , subq_18.visit__ds__extract_day
-                        , subq_18.visit__ds__extract_dow
-                        , subq_18.visit__ds__extract_doy
-                        , subq_18.ds__day AS metric_time__day
-                        , subq_18.ds__week AS metric_time__week
-                        , subq_18.ds__month AS metric_time__month
-                        , subq_18.ds__quarter AS metric_time__quarter
-                        , subq_18.ds__year AS metric_time__year
-                        , subq_18.ds__extract_year AS metric_time__extract_year
-                        , subq_18.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_18.ds__extract_month AS metric_time__extract_month
-                        , subq_18.ds__extract_day AS metric_time__extract_day
-                        , subq_18.ds__extract_dow AS metric_time__extract_dow
-                        , subq_18.ds__extract_doy AS metric_time__extract_doy
-                        , subq_18.user
-                        , subq_18.session
-                        , subq_18.visit__user
-                        , subq_18.visit__session
-                        , subq_18.referrer_id
-                        , subq_18.visit__referrer_id
-                        , subq_18.visits
-                        , subq_18.visitors
+                        subq_3.ds__day
+                        , subq_3.ds__week
+                        , subq_3.ds__month
+                        , subq_3.ds__quarter
+                        , subq_3.ds__year
+                        , subq_3.ds__extract_year
+                        , subq_3.ds__extract_quarter
+                        , subq_3.ds__extract_month
+                        , subq_3.ds__extract_day
+                        , subq_3.ds__extract_dow
+                        , subq_3.ds__extract_doy
+                        , subq_3.visit__ds__day
+                        , subq_3.visit__ds__week
+                        , subq_3.visit__ds__month
+                        , subq_3.visit__ds__quarter
+                        , subq_3.visit__ds__year
+                        , subq_3.visit__ds__extract_year
+                        , subq_3.visit__ds__extract_quarter
+                        , subq_3.visit__ds__extract_month
+                        , subq_3.visit__ds__extract_day
+                        , subq_3.visit__ds__extract_dow
+                        , subq_3.visit__ds__extract_doy
+                        , subq_3.ds__day AS metric_time__day
+                        , subq_3.ds__week AS metric_time__week
+                        , subq_3.ds__month AS metric_time__month
+                        , subq_3.ds__quarter AS metric_time__quarter
+                        , subq_3.ds__year AS metric_time__year
+                        , subq_3.ds__extract_year AS metric_time__extract_year
+                        , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_3.ds__extract_month AS metric_time__extract_month
+                        , subq_3.ds__extract_day AS metric_time__extract_day
+                        , subq_3.ds__extract_dow AS metric_time__extract_dow
+                        , subq_3.ds__extract_doy AS metric_time__extract_doy
+                        , subq_3.user
+                        , subq_3.session
+                        , subq_3.visit__user
+                        , subq_3.visit__session
+                        , subq_3.referrer_id
+                        , subq_3.visit__referrer_id
+                        , subq_3.visits
+                        , subq_3.visitors
                       FROM (
                         -- Read Elements From Semantic Model 'visits_source'
                         SELECT
@@ -267,108 +267,108 @@ FROM (
                           , visits_source_src_28000.user_id AS visit__user
                           , visits_source_src_28000.session_id AS visit__session
                         FROM ***************************.fct_visits visits_source_src_28000
-                      ) subq_18
-                    ) subq_19
-                  ) subq_20
+                      ) subq_3
+                    ) subq_4
+                  ) subq_5
                   GROUP BY
-                    subq_20.user
-                ) subq_21
+                    subq_5.user
+                ) subq_6
                 FULL OUTER JOIN (
                   -- Aggregate Measures
                   SELECT
-                    subq_30.user
-                    , SUM(subq_30.buys) AS buys
+                    subq_15.user
+                    , SUM(subq_15.buys) AS buys
                   FROM (
                     -- Pass Only Elements: ['buys', 'user']
                     SELECT
-                      subq_29.user
-                      , subq_29.buys
+                      subq_14.user
+                      , subq_14.buys
                     FROM (
                       -- Find conversions for user within the range of INF
                       SELECT
-                        subq_28.ds__day
-                        , subq_28.user
-                        , subq_28.buys
-                        , subq_28.visits
+                        subq_13.ds__day
+                        , subq_13.user
+                        , subq_13.buys
+                        , subq_13.visits
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          FIRST_VALUE(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_9.visits) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , FIRST_VALUE(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_9.ds__day) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , FIRST_VALUE(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_9.user) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS user
-                          , subq_27.mf_internal_uuid AS mf_internal_uuid
-                          , subq_27.buys AS buys
+                          , subq_12.mf_internal_uuid AS mf_internal_uuid
+                          , subq_12.buys AS buys
                         FROM (
                           -- Pass Only Elements: ['visits', 'ds__day', 'user']
                           SELECT
-                            subq_23.ds__day
-                            , subq_23.user
-                            , subq_23.visits
+                            subq_8.ds__day
+                            , subq_8.user
+                            , subq_8.visits
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_22.ds__day
-                              , subq_22.ds__week
-                              , subq_22.ds__month
-                              , subq_22.ds__quarter
-                              , subq_22.ds__year
-                              , subq_22.ds__extract_year
-                              , subq_22.ds__extract_quarter
-                              , subq_22.ds__extract_month
-                              , subq_22.ds__extract_day
-                              , subq_22.ds__extract_dow
-                              , subq_22.ds__extract_doy
-                              , subq_22.visit__ds__day
-                              , subq_22.visit__ds__week
-                              , subq_22.visit__ds__month
-                              , subq_22.visit__ds__quarter
-                              , subq_22.visit__ds__year
-                              , subq_22.visit__ds__extract_year
-                              , subq_22.visit__ds__extract_quarter
-                              , subq_22.visit__ds__extract_month
-                              , subq_22.visit__ds__extract_day
-                              , subq_22.visit__ds__extract_dow
-                              , subq_22.visit__ds__extract_doy
-                              , subq_22.ds__day AS metric_time__day
-                              , subq_22.ds__week AS metric_time__week
-                              , subq_22.ds__month AS metric_time__month
-                              , subq_22.ds__quarter AS metric_time__quarter
-                              , subq_22.ds__year AS metric_time__year
-                              , subq_22.ds__extract_year AS metric_time__extract_year
-                              , subq_22.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_22.ds__extract_month AS metric_time__extract_month
-                              , subq_22.ds__extract_day AS metric_time__extract_day
-                              , subq_22.ds__extract_dow AS metric_time__extract_dow
-                              , subq_22.ds__extract_doy AS metric_time__extract_doy
-                              , subq_22.user
-                              , subq_22.session
-                              , subq_22.visit__user
-                              , subq_22.visit__session
-                              , subq_22.referrer_id
-                              , subq_22.visit__referrer_id
-                              , subq_22.visits
-                              , subq_22.visitors
+                              subq_7.ds__day
+                              , subq_7.ds__week
+                              , subq_7.ds__month
+                              , subq_7.ds__quarter
+                              , subq_7.ds__year
+                              , subq_7.ds__extract_year
+                              , subq_7.ds__extract_quarter
+                              , subq_7.ds__extract_month
+                              , subq_7.ds__extract_day
+                              , subq_7.ds__extract_dow
+                              , subq_7.ds__extract_doy
+                              , subq_7.visit__ds__day
+                              , subq_7.visit__ds__week
+                              , subq_7.visit__ds__month
+                              , subq_7.visit__ds__quarter
+                              , subq_7.visit__ds__year
+                              , subq_7.visit__ds__extract_year
+                              , subq_7.visit__ds__extract_quarter
+                              , subq_7.visit__ds__extract_month
+                              , subq_7.visit__ds__extract_day
+                              , subq_7.visit__ds__extract_dow
+                              , subq_7.visit__ds__extract_doy
+                              , subq_7.ds__day AS metric_time__day
+                              , subq_7.ds__week AS metric_time__week
+                              , subq_7.ds__month AS metric_time__month
+                              , subq_7.ds__quarter AS metric_time__quarter
+                              , subq_7.ds__year AS metric_time__year
+                              , subq_7.ds__extract_year AS metric_time__extract_year
+                              , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_7.ds__extract_month AS metric_time__extract_month
+                              , subq_7.ds__extract_day AS metric_time__extract_day
+                              , subq_7.ds__extract_dow AS metric_time__extract_dow
+                              , subq_7.ds__extract_doy AS metric_time__extract_doy
+                              , subq_7.user
+                              , subq_7.session
+                              , subq_7.visit__user
+                              , subq_7.visit__session
+                              , subq_7.referrer_id
+                              , subq_7.visit__referrer_id
+                              , subq_7.visits
+                              , subq_7.visitors
                             FROM (
                               -- Read Elements From Semantic Model 'visits_source'
                               SELECT
@@ -403,94 +403,94 @@ FROM (
                                 , visits_source_src_28000.user_id AS visit__user
                                 , visits_source_src_28000.session_id AS visit__session
                               FROM ***************************.fct_visits visits_source_src_28000
-                            ) subq_22
-                          ) subq_23
-                        ) subq_24
+                            ) subq_7
+                          ) subq_8
+                        ) subq_9
                         INNER JOIN (
                           -- Add column with generated UUID
                           SELECT
-                            subq_26.ds__day
-                            , subq_26.ds__week
-                            , subq_26.ds__month
-                            , subq_26.ds__quarter
-                            , subq_26.ds__year
-                            , subq_26.ds__extract_year
-                            , subq_26.ds__extract_quarter
-                            , subq_26.ds__extract_month
-                            , subq_26.ds__extract_day
-                            , subq_26.ds__extract_dow
-                            , subq_26.ds__extract_doy
-                            , subq_26.buy__ds__day
-                            , subq_26.buy__ds__week
-                            , subq_26.buy__ds__month
-                            , subq_26.buy__ds__quarter
-                            , subq_26.buy__ds__year
-                            , subq_26.buy__ds__extract_year
-                            , subq_26.buy__ds__extract_quarter
-                            , subq_26.buy__ds__extract_month
-                            , subq_26.buy__ds__extract_day
-                            , subq_26.buy__ds__extract_dow
-                            , subq_26.buy__ds__extract_doy
-                            , subq_26.metric_time__day
-                            , subq_26.metric_time__week
-                            , subq_26.metric_time__month
-                            , subq_26.metric_time__quarter
-                            , subq_26.metric_time__year
-                            , subq_26.metric_time__extract_year
-                            , subq_26.metric_time__extract_quarter
-                            , subq_26.metric_time__extract_month
-                            , subq_26.metric_time__extract_day
-                            , subq_26.metric_time__extract_dow
-                            , subq_26.metric_time__extract_doy
-                            , subq_26.user
-                            , subq_26.session_id
-                            , subq_26.buy__user
-                            , subq_26.buy__session_id
-                            , subq_26.buys
-                            , subq_26.buyers
+                            subq_11.ds__day
+                            , subq_11.ds__week
+                            , subq_11.ds__month
+                            , subq_11.ds__quarter
+                            , subq_11.ds__year
+                            , subq_11.ds__extract_year
+                            , subq_11.ds__extract_quarter
+                            , subq_11.ds__extract_month
+                            , subq_11.ds__extract_day
+                            , subq_11.ds__extract_dow
+                            , subq_11.ds__extract_doy
+                            , subq_11.buy__ds__day
+                            , subq_11.buy__ds__week
+                            , subq_11.buy__ds__month
+                            , subq_11.buy__ds__quarter
+                            , subq_11.buy__ds__year
+                            , subq_11.buy__ds__extract_year
+                            , subq_11.buy__ds__extract_quarter
+                            , subq_11.buy__ds__extract_month
+                            , subq_11.buy__ds__extract_day
+                            , subq_11.buy__ds__extract_dow
+                            , subq_11.buy__ds__extract_doy
+                            , subq_11.metric_time__day
+                            , subq_11.metric_time__week
+                            , subq_11.metric_time__month
+                            , subq_11.metric_time__quarter
+                            , subq_11.metric_time__year
+                            , subq_11.metric_time__extract_year
+                            , subq_11.metric_time__extract_quarter
+                            , subq_11.metric_time__extract_month
+                            , subq_11.metric_time__extract_day
+                            , subq_11.metric_time__extract_dow
+                            , subq_11.metric_time__extract_doy
+                            , subq_11.user
+                            , subq_11.session_id
+                            , subq_11.buy__user
+                            , subq_11.buy__session_id
+                            , subq_11.buys
+                            , subq_11.buyers
                             , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_25.ds__day
-                              , subq_25.ds__week
-                              , subq_25.ds__month
-                              , subq_25.ds__quarter
-                              , subq_25.ds__year
-                              , subq_25.ds__extract_year
-                              , subq_25.ds__extract_quarter
-                              , subq_25.ds__extract_month
-                              , subq_25.ds__extract_day
-                              , subq_25.ds__extract_dow
-                              , subq_25.ds__extract_doy
-                              , subq_25.buy__ds__day
-                              , subq_25.buy__ds__week
-                              , subq_25.buy__ds__month
-                              , subq_25.buy__ds__quarter
-                              , subq_25.buy__ds__year
-                              , subq_25.buy__ds__extract_year
-                              , subq_25.buy__ds__extract_quarter
-                              , subq_25.buy__ds__extract_month
-                              , subq_25.buy__ds__extract_day
-                              , subq_25.buy__ds__extract_dow
-                              , subq_25.buy__ds__extract_doy
-                              , subq_25.ds__day AS metric_time__day
-                              , subq_25.ds__week AS metric_time__week
-                              , subq_25.ds__month AS metric_time__month
-                              , subq_25.ds__quarter AS metric_time__quarter
-                              , subq_25.ds__year AS metric_time__year
-                              , subq_25.ds__extract_year AS metric_time__extract_year
-                              , subq_25.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_25.ds__extract_month AS metric_time__extract_month
-                              , subq_25.ds__extract_day AS metric_time__extract_day
-                              , subq_25.ds__extract_dow AS metric_time__extract_dow
-                              , subq_25.ds__extract_doy AS metric_time__extract_doy
-                              , subq_25.user
-                              , subq_25.session_id
-                              , subq_25.buy__user
-                              , subq_25.buy__session_id
-                              , subq_25.buys
-                              , subq_25.buyers
+                              subq_10.ds__day
+                              , subq_10.ds__week
+                              , subq_10.ds__month
+                              , subq_10.ds__quarter
+                              , subq_10.ds__year
+                              , subq_10.ds__extract_year
+                              , subq_10.ds__extract_quarter
+                              , subq_10.ds__extract_month
+                              , subq_10.ds__extract_day
+                              , subq_10.ds__extract_dow
+                              , subq_10.ds__extract_doy
+                              , subq_10.buy__ds__day
+                              , subq_10.buy__ds__week
+                              , subq_10.buy__ds__month
+                              , subq_10.buy__ds__quarter
+                              , subq_10.buy__ds__year
+                              , subq_10.buy__ds__extract_year
+                              , subq_10.buy__ds__extract_quarter
+                              , subq_10.buy__ds__extract_month
+                              , subq_10.buy__ds__extract_day
+                              , subq_10.buy__ds__extract_dow
+                              , subq_10.buy__ds__extract_doy
+                              , subq_10.ds__day AS metric_time__day
+                              , subq_10.ds__week AS metric_time__week
+                              , subq_10.ds__month AS metric_time__month
+                              , subq_10.ds__quarter AS metric_time__quarter
+                              , subq_10.ds__year AS metric_time__year
+                              , subq_10.ds__extract_year AS metric_time__extract_year
+                              , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_10.ds__extract_month AS metric_time__extract_month
+                              , subq_10.ds__extract_day AS metric_time__extract_day
+                              , subq_10.ds__extract_dow AS metric_time__extract_dow
+                              , subq_10.ds__extract_doy AS metric_time__extract_doy
+                              , subq_10.user
+                              , subq_10.session_id
+                              , subq_10.buy__user
+                              , subq_10.buy__session_id
+                              , subq_10.buys
+                              , subq_10.buyers
                             FROM (
                               -- Read Elements From Semantic Model 'buys_source'
                               SELECT
@@ -523,33 +523,33 @@ FROM (
                                 , buys_source_src_28000.user_id AS buy__user
                                 , buys_source_src_28000.session_id AS buy__session_id
                               FROM ***************************.fct_buys buys_source_src_28000
-                            ) subq_25
-                          ) subq_26
-                        ) subq_27
+                            ) subq_10
+                          ) subq_11
+                        ) subq_12
                         ON
                           (
-                            subq_24.user = subq_27.user
+                            subq_9.user = subq_12.user
                           ) AND (
-                            (subq_24.ds__day <= subq_27.ds__day)
+                            (subq_9.ds__day <= subq_12.ds__day)
                           )
-                      ) subq_28
-                    ) subq_29
-                  ) subq_30
+                      ) subq_13
+                    ) subq_14
+                  ) subq_15
                   GROUP BY
-                    subq_30.user
-                ) subq_31
+                    subq_15.user
+                ) subq_16
                 ON
-                  subq_21.user = subq_31.user
+                  subq_6.user = subq_16.user
                 GROUP BY
-                  COALESCE(subq_21.user, subq_31.user)
-              ) subq_32
-            ) subq_33
-          ) subq_34
+                  COALESCE(subq_6.user, subq_16.user)
+              ) subq_17
+            ) subq_18
+          ) subq_19
           ON
-            subq_17.user = subq_34.user
-        ) subq_35
-      ) subq_36
+            subq_2.user = subq_19.user
+        ) subq_20
+      ) subq_21
       WHERE user__visit_buy_conversion_rate > 2
-    ) subq_37
-  ) subq_38
-) subq_39
+    ) subq_22
+  ) subq_23
+) subq_24

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_72.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
-    , subq_57.listings AS listings
+    CAST(subq_42.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_42.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
+    , subq_27.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_57
+  ) subq_27
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_61.user, subq_71.user) AS user
-      , MAX(subq_61.visits) AS visits
-      , MAX(subq_71.buys) AS buys
+      COALESCE(subq_31.user, subq_41.user) AS user
+      , MAX(subq_31.visits) AS visits
+      , MAX(subq_41.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_60.user
+        subq_30.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_60
+      ) subq_30
       GROUP BY
-        subq_60.user
-    ) subq_61
+        subq_30.user
+    ) subq_31
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_68.user
+        subq_38.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_64.visits) OVER (
+          FIRST_VALUE(subq_34.visits) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_64.ds__day) OVER (
+          , FIRST_VALUE(subq_34.ds__day) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_64.user) OVER (
+          , FIRST_VALUE(subq_34.user) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_67.mf_internal_uuid AS mf_internal_uuid
-          , subq_67.buys AS buys
+          , subq_37.mf_internal_uuid AS mf_internal_uuid
+          , subq_37.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_64
+        ) subq_34
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_67
+        ) subq_37
         ON
           (
-            subq_64.user = subq_67.user
+            subq_34.user = subq_37.user
           ) AND (
-            (subq_64.ds__day <= subq_67.ds__day)
+            (subq_34.ds__day <= subq_37.ds__day)
           )
-      ) subq_68
+      ) subq_38
       GROUP BY
-        subq_68.user
-    ) subq_71
+        subq_38.user
+    ) subq_41
     ON
-      subq_61.user = subq_71.user
+      subq_31.user = subq_41.user
     GROUP BY
-      COALESCE(subq_61.user, subq_71.user)
-  ) subq_72
+      COALESCE(subq_31.user, subq_41.user)
+  ) subq_42
   ON
-    subq_57.user = subq_72.user
-) subq_76
+    subq_27.user = subq_42.user
+) subq_46
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0.sql
@@ -1,106 +1,106 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_18.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_17.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_16.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.user__listing__user__average_booking_value
-        , subq_24.listings
+        subq_15.user__listing__user__average_booking_value
+        , subq_15.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
         SELECT
-          subq_23.user__listing__user__average_booking_value
-          , subq_23.listings
+          subq_14.user__listing__user__average_booking_value
+          , subq_14.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.user AS user
-            , subq_22.listing__user AS user__listing__user
-            , subq_22.listing__user__average_booking_value AS user__listing__user__average_booking_value
-            , subq_11.listings AS listings
+            subq_2.user AS user
+            , subq_13.listing__user AS user__listing__user
+            , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_10.user
-              , subq_10.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds__day
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds__extract_year
-                , subq_9.ds__extract_quarter
-                , subq_9.ds__extract_month
-                , subq_9.ds__extract_day
-                , subq_9.ds__extract_dow
-                , subq_9.ds__extract_doy
-                , subq_9.created_at__day
-                , subq_9.created_at__week
-                , subq_9.created_at__month
-                , subq_9.created_at__quarter
-                , subq_9.created_at__year
-                , subq_9.created_at__extract_year
-                , subq_9.created_at__extract_quarter
-                , subq_9.created_at__extract_month
-                , subq_9.created_at__extract_day
-                , subq_9.created_at__extract_dow
-                , subq_9.created_at__extract_doy
-                , subq_9.listing__ds__day
-                , subq_9.listing__ds__week
-                , subq_9.listing__ds__month
-                , subq_9.listing__ds__quarter
-                , subq_9.listing__ds__year
-                , subq_9.listing__ds__extract_year
-                , subq_9.listing__ds__extract_quarter
-                , subq_9.listing__ds__extract_month
-                , subq_9.listing__ds__extract_day
-                , subq_9.listing__ds__extract_dow
-                , subq_9.listing__ds__extract_doy
-                , subq_9.listing__created_at__day
-                , subq_9.listing__created_at__week
-                , subq_9.listing__created_at__month
-                , subq_9.listing__created_at__quarter
-                , subq_9.listing__created_at__year
-                , subq_9.listing__created_at__extract_year
-                , subq_9.listing__created_at__extract_quarter
-                , subq_9.listing__created_at__extract_month
-                , subq_9.listing__created_at__extract_day
-                , subq_9.listing__created_at__extract_dow
-                , subq_9.listing__created_at__extract_doy
-                , subq_9.ds__day AS metric_time__day
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.ds__extract_year AS metric_time__extract_year
-                , subq_9.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.ds__extract_month AS metric_time__extract_month
-                , subq_9.ds__extract_day AS metric_time__extract_day
-                , subq_9.ds__extract_dow AS metric_time__extract_dow
-                , subq_9.ds__extract_doy AS metric_time__extract_doy
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.listing__user
-                , subq_9.country_latest
-                , subq_9.is_lux_latest
-                , subq_9.capacity_latest
-                , subq_9.listing__country_latest
-                , subq_9.listing__is_lux_latest
-                , subq_9.listing__capacity_latest
-                , subq_9.listings
-                , subq_9.largest_listing
-                , subq_9.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -161,141 +161,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
             SELECT
-              subq_21.listing__user
-              , subq_21.listing__user__average_booking_value
+              subq_12.listing__user
+              , subq_12.listing__user__average_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing__user
-                , subq_20.average_booking_value AS listing__user__average_booking_value
+                subq_11.listing__user
+                , subq_11.average_booking_value AS listing__user__average_booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing__user
-                  , AVG(subq_19.average_booking_value) AS average_booking_value
+                  subq_10.listing__user
+                  , AVG(subq_10.average_booking_value) AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'listing__user']
                   SELECT
-                    subq_18.listing__user
-                    , subq_18.average_booking_value
+                    subq_9.listing__user
+                    , subq_9.average_booking_value
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_14.listing AS listing
-                      , subq_17.user AS listing__user
-                      , subq_14.average_booking_value AS average_booking_value
+                      subq_5.listing AS listing
+                      , subq_8.user AS listing__user
+                      , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']
                       SELECT
-                        subq_13.listing
-                        , subq_13.average_booking_value
+                        subq_4.listing
+                        , subq_4.average_booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_12.ds__day
-                          , subq_12.ds__week
-                          , subq_12.ds__month
-                          , subq_12.ds__quarter
-                          , subq_12.ds__year
-                          , subq_12.ds__extract_year
-                          , subq_12.ds__extract_quarter
-                          , subq_12.ds__extract_month
-                          , subq_12.ds__extract_day
-                          , subq_12.ds__extract_dow
-                          , subq_12.ds__extract_doy
-                          , subq_12.ds_partitioned__day
-                          , subq_12.ds_partitioned__week
-                          , subq_12.ds_partitioned__month
-                          , subq_12.ds_partitioned__quarter
-                          , subq_12.ds_partitioned__year
-                          , subq_12.ds_partitioned__extract_year
-                          , subq_12.ds_partitioned__extract_quarter
-                          , subq_12.ds_partitioned__extract_month
-                          , subq_12.ds_partitioned__extract_day
-                          , subq_12.ds_partitioned__extract_dow
-                          , subq_12.ds_partitioned__extract_doy
-                          , subq_12.paid_at__day
-                          , subq_12.paid_at__week
-                          , subq_12.paid_at__month
-                          , subq_12.paid_at__quarter
-                          , subq_12.paid_at__year
-                          , subq_12.paid_at__extract_year
-                          , subq_12.paid_at__extract_quarter
-                          , subq_12.paid_at__extract_month
-                          , subq_12.paid_at__extract_day
-                          , subq_12.paid_at__extract_dow
-                          , subq_12.paid_at__extract_doy
-                          , subq_12.booking__ds__day
-                          , subq_12.booking__ds__week
-                          , subq_12.booking__ds__month
-                          , subq_12.booking__ds__quarter
-                          , subq_12.booking__ds__year
-                          , subq_12.booking__ds__extract_year
-                          , subq_12.booking__ds__extract_quarter
-                          , subq_12.booking__ds__extract_month
-                          , subq_12.booking__ds__extract_day
-                          , subq_12.booking__ds__extract_dow
-                          , subq_12.booking__ds__extract_doy
-                          , subq_12.booking__ds_partitioned__day
-                          , subq_12.booking__ds_partitioned__week
-                          , subq_12.booking__ds_partitioned__month
-                          , subq_12.booking__ds_partitioned__quarter
-                          , subq_12.booking__ds_partitioned__year
-                          , subq_12.booking__ds_partitioned__extract_year
-                          , subq_12.booking__ds_partitioned__extract_quarter
-                          , subq_12.booking__ds_partitioned__extract_month
-                          , subq_12.booking__ds_partitioned__extract_day
-                          , subq_12.booking__ds_partitioned__extract_dow
-                          , subq_12.booking__ds_partitioned__extract_doy
-                          , subq_12.booking__paid_at__day
-                          , subq_12.booking__paid_at__week
-                          , subq_12.booking__paid_at__month
-                          , subq_12.booking__paid_at__quarter
-                          , subq_12.booking__paid_at__year
-                          , subq_12.booking__paid_at__extract_year
-                          , subq_12.booking__paid_at__extract_quarter
-                          , subq_12.booking__paid_at__extract_month
-                          , subq_12.booking__paid_at__extract_day
-                          , subq_12.booking__paid_at__extract_dow
-                          , subq_12.booking__paid_at__extract_doy
-                          , subq_12.ds__day AS metric_time__day
-                          , subq_12.ds__week AS metric_time__week
-                          , subq_12.ds__month AS metric_time__month
-                          , subq_12.ds__quarter AS metric_time__quarter
-                          , subq_12.ds__year AS metric_time__year
-                          , subq_12.ds__extract_year AS metric_time__extract_year
-                          , subq_12.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_12.ds__extract_month AS metric_time__extract_month
-                          , subq_12.ds__extract_day AS metric_time__extract_day
-                          , subq_12.ds__extract_dow AS metric_time__extract_dow
-                          , subq_12.ds__extract_doy AS metric_time__extract_doy
-                          , subq_12.listing
-                          , subq_12.guest
-                          , subq_12.host
-                          , subq_12.booking__listing
-                          , subq_12.booking__guest
-                          , subq_12.booking__host
-                          , subq_12.is_instant
-                          , subq_12.booking__is_instant
-                          , subq_12.bookings
-                          , subq_12.instant_bookings
-                          , subq_12.booking_value
-                          , subq_12.max_booking_value
-                          , subq_12.min_booking_value
-                          , subq_12.bookers
-                          , subq_12.average_booking_value
-                          , subq_12.referred_bookings
-                          , subq_12.median_booking_value
-                          , subq_12.booking_value_p99
-                          , subq_12.discrete_booking_value_p99
-                          , subq_12.approximate_continuous_booking_value_p99
-                          , subq_12.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -388,84 +388,84 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_12
-                      ) subq_13
-                    ) subq_14
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['listing', 'user']
                       SELECT
-                        subq_16.listing
-                        , subq_16.user
+                        subq_7.listing
+                        , subq_7.user
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_15.ds__day
-                          , subq_15.ds__week
-                          , subq_15.ds__month
-                          , subq_15.ds__quarter
-                          , subq_15.ds__year
-                          , subq_15.ds__extract_year
-                          , subq_15.ds__extract_quarter
-                          , subq_15.ds__extract_month
-                          , subq_15.ds__extract_day
-                          , subq_15.ds__extract_dow
-                          , subq_15.ds__extract_doy
-                          , subq_15.created_at__day
-                          , subq_15.created_at__week
-                          , subq_15.created_at__month
-                          , subq_15.created_at__quarter
-                          , subq_15.created_at__year
-                          , subq_15.created_at__extract_year
-                          , subq_15.created_at__extract_quarter
-                          , subq_15.created_at__extract_month
-                          , subq_15.created_at__extract_day
-                          , subq_15.created_at__extract_dow
-                          , subq_15.created_at__extract_doy
-                          , subq_15.listing__ds__day
-                          , subq_15.listing__ds__week
-                          , subq_15.listing__ds__month
-                          , subq_15.listing__ds__quarter
-                          , subq_15.listing__ds__year
-                          , subq_15.listing__ds__extract_year
-                          , subq_15.listing__ds__extract_quarter
-                          , subq_15.listing__ds__extract_month
-                          , subq_15.listing__ds__extract_day
-                          , subq_15.listing__ds__extract_dow
-                          , subq_15.listing__ds__extract_doy
-                          , subq_15.listing__created_at__day
-                          , subq_15.listing__created_at__week
-                          , subq_15.listing__created_at__month
-                          , subq_15.listing__created_at__quarter
-                          , subq_15.listing__created_at__year
-                          , subq_15.listing__created_at__extract_year
-                          , subq_15.listing__created_at__extract_quarter
-                          , subq_15.listing__created_at__extract_month
-                          , subq_15.listing__created_at__extract_day
-                          , subq_15.listing__created_at__extract_dow
-                          , subq_15.listing__created_at__extract_doy
-                          , subq_15.ds__day AS metric_time__day
-                          , subq_15.ds__week AS metric_time__week
-                          , subq_15.ds__month AS metric_time__month
-                          , subq_15.ds__quarter AS metric_time__quarter
-                          , subq_15.ds__year AS metric_time__year
-                          , subq_15.ds__extract_year AS metric_time__extract_year
-                          , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_15.ds__extract_month AS metric_time__extract_month
-                          , subq_15.ds__extract_day AS metric_time__extract_day
-                          , subq_15.ds__extract_dow AS metric_time__extract_dow
-                          , subq_15.ds__extract_doy AS metric_time__extract_doy
-                          , subq_15.listing
-                          , subq_15.user
-                          , subq_15.listing__user
-                          , subq_15.country_latest
-                          , subq_15.is_lux_latest
-                          , subq_15.capacity_latest
-                          , subq_15.listing__country_latest
-                          , subq_15.listing__is_lux_latest
-                          , subq_15.listing__capacity_latest
-                          , subq_15.listings
-                          , subq_15.largest_listing
-                          , subq_15.smallest_listing
+                          subq_6.ds__day
+                          , subq_6.ds__week
+                          , subq_6.ds__month
+                          , subq_6.ds__quarter
+                          , subq_6.ds__year
+                          , subq_6.ds__extract_year
+                          , subq_6.ds__extract_quarter
+                          , subq_6.ds__extract_month
+                          , subq_6.ds__extract_day
+                          , subq_6.ds__extract_dow
+                          , subq_6.ds__extract_doy
+                          , subq_6.created_at__day
+                          , subq_6.created_at__week
+                          , subq_6.created_at__month
+                          , subq_6.created_at__quarter
+                          , subq_6.created_at__year
+                          , subq_6.created_at__extract_year
+                          , subq_6.created_at__extract_quarter
+                          , subq_6.created_at__extract_month
+                          , subq_6.created_at__extract_day
+                          , subq_6.created_at__extract_dow
+                          , subq_6.created_at__extract_doy
+                          , subq_6.listing__ds__day
+                          , subq_6.listing__ds__week
+                          , subq_6.listing__ds__month
+                          , subq_6.listing__ds__quarter
+                          , subq_6.listing__ds__year
+                          , subq_6.listing__ds__extract_year
+                          , subq_6.listing__ds__extract_quarter
+                          , subq_6.listing__ds__extract_month
+                          , subq_6.listing__ds__extract_day
+                          , subq_6.listing__ds__extract_dow
+                          , subq_6.listing__ds__extract_doy
+                          , subq_6.listing__created_at__day
+                          , subq_6.listing__created_at__week
+                          , subq_6.listing__created_at__month
+                          , subq_6.listing__created_at__quarter
+                          , subq_6.listing__created_at__year
+                          , subq_6.listing__created_at__extract_year
+                          , subq_6.listing__created_at__extract_quarter
+                          , subq_6.listing__created_at__extract_month
+                          , subq_6.listing__created_at__extract_day
+                          , subq_6.listing__created_at__extract_dow
+                          , subq_6.listing__created_at__extract_doy
+                          , subq_6.ds__day AS metric_time__day
+                          , subq_6.ds__week AS metric_time__week
+                          , subq_6.ds__month AS metric_time__month
+                          , subq_6.ds__quarter AS metric_time__quarter
+                          , subq_6.ds__year AS metric_time__year
+                          , subq_6.ds__extract_year AS metric_time__extract_year
+                          , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_6.ds__extract_month AS metric_time__extract_month
+                          , subq_6.ds__extract_day AS metric_time__extract_day
+                          , subq_6.ds__extract_dow AS metric_time__extract_dow
+                          , subq_6.ds__extract_doy AS metric_time__extract_doy
+                          , subq_6.listing
+                          , subq_6.user
+                          , subq_6.listing__user
+                          , subq_6.country_latest
+                          , subq_6.is_lux_latest
+                          , subq_6.capacity_latest
+                          , subq_6.listing__country_latest
+                          , subq_6.listing__is_lux_latest
+                          , subq_6.listing__capacity_latest
+                          , subq_6.listings
+                          , subq_6.largest_listing
+                          , subq_6.smallest_listing
                         FROM (
                           -- Read Elements From Semantic Model 'listings_latest'
                           SELECT
@@ -526,23 +526,23 @@ FROM (
                             , listings_latest_src_28000.user_id AS user
                             , listings_latest_src_28000.user_id AS listing__user
                           FROM ***************************.dim_listings_latest listings_latest_src_28000
-                        ) subq_15
-                      ) subq_16
-                    ) subq_17
+                        ) subq_6
+                      ) subq_7
+                    ) subq_8
                     ON
-                      subq_14.listing = subq_17.listing
-                  ) subq_18
-                ) subq_19
+                      subq_5.listing = subq_8.listing
+                  ) subq_9
+                ) subq_10
                 GROUP BY
-                  subq_19.listing__user
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_10.listing__user
+              ) subq_11
+            ) subq_12
+          ) subq_13
           ON
-            subq_11.user = subq_22.listing__user
-        ) subq_23
-      ) subq_24
+            subq_2.user = subq_13.listing__user
+        ) subq_14
+      ) subq_15
       WHERE user__listing__user__average_booking_value > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_16
+  ) subq_17
+) subq_18

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_39.listings AS listings
+    subq_32.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_21.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_39
+  ) subq_21
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_50
+  ) subq_32
   ON
-    subq_39.user = subq_50.listing__user
-) subq_52
+    subq_21.user = subq_32.listing__user
+) subq_34
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_multi_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_40.third_hop_count
+  subq_22.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_39.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_21.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_38.third_hop_count
+      subq_20.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_37.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-        , subq_37.third_hop_count
+        subq_19.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+        , subq_19.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
         SELECT
-          subq_36.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-          , subq_36.third_hop_count
+          subq_18.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+          , subq_18.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_20.customer_third_hop_id AS customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-            , subq_20.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_19.customer_third_hop_id
-              , subq_19.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_18.third_hop_ds__day
-                , subq_18.third_hop_ds__week
-                , subq_18.third_hop_ds__month
-                , subq_18.third_hop_ds__quarter
-                , subq_18.third_hop_ds__year
-                , subq_18.third_hop_ds__extract_year
-                , subq_18.third_hop_ds__extract_quarter
-                , subq_18.third_hop_ds__extract_month
-                , subq_18.third_hop_ds__extract_day
-                , subq_18.third_hop_ds__extract_dow
-                , subq_18.third_hop_ds__extract_doy
-                , subq_18.customer_third_hop_id__third_hop_ds__day
-                , subq_18.customer_third_hop_id__third_hop_ds__week
-                , subq_18.customer_third_hop_id__third_hop_ds__month
-                , subq_18.customer_third_hop_id__third_hop_ds__quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_18.third_hop_ds__day AS metric_time__day
-                , subq_18.third_hop_ds__week AS metric_time__week
-                , subq_18.third_hop_ds__month AS metric_time__month
-                , subq_18.third_hop_ds__quarter AS metric_time__quarter
-                , subq_18.third_hop_ds__year AS metric_time__year
-                , subq_18.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_18.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_18.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_18.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_18.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_18.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_18.customer_third_hop_id
-                , subq_18.value
-                , subq_18.customer_third_hop_id__value
-                , subq_18.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,105 +101,105 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_18
-            ) subq_19
-          ) subq_20
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
             SELECT
-              subq_34.account_id__customer_id__customer_third_hop_id
-              , subq_34.account_id__customer_id__customer_third_hop_id__txn_count
+              subq_16.account_id__customer_id__customer_third_hop_id
+              , subq_16.account_id__customer_id__customer_third_hop_id__txn_count
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_33.account_id__customer_id__customer_third_hop_id
-                , subq_33.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
+                subq_15.account_id__customer_id__customer_third_hop_id
+                , subq_15.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_32.account_id__customer_id__customer_third_hop_id
-                  , SUM(subq_32.txn_count) AS txn_count
+                  subq_14.account_id__customer_id__customer_third_hop_id
+                  , SUM(subq_14.txn_count) AS txn_count
                 FROM (
                   -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_third_hop_id']
                   SELECT
-                    subq_31.account_id__customer_id__customer_third_hop_id
-                    , subq_31.txn_count
+                    subq_13.account_id__customer_id__customer_third_hop_id
+                    , subq_13.txn_count
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_23.ds_partitioned__day AS ds_partitioned__day
-                      , subq_30.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_23.account_id AS account_id
-                      , subq_30.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
-                      , subq_23.txn_count AS txn_count
+                      subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
+                      , subq_5.account_id AS account_id
+                      , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
                       SELECT
-                        subq_22.ds_partitioned__day
-                        , subq_22.account_id
-                        , subq_22.txn_count
+                        subq_4.ds_partitioned__day
+                        , subq_4.account_id
+                        , subq_4.txn_count
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_21.ds_partitioned__day
-                          , subq_21.ds_partitioned__week
-                          , subq_21.ds_partitioned__month
-                          , subq_21.ds_partitioned__quarter
-                          , subq_21.ds_partitioned__year
-                          , subq_21.ds_partitioned__extract_year
-                          , subq_21.ds_partitioned__extract_quarter
-                          , subq_21.ds_partitioned__extract_month
-                          , subq_21.ds_partitioned__extract_day
-                          , subq_21.ds_partitioned__extract_dow
-                          , subq_21.ds_partitioned__extract_doy
-                          , subq_21.ds__day
-                          , subq_21.ds__week
-                          , subq_21.ds__month
-                          , subq_21.ds__quarter
-                          , subq_21.ds__year
-                          , subq_21.ds__extract_year
-                          , subq_21.ds__extract_quarter
-                          , subq_21.ds__extract_month
-                          , subq_21.ds__extract_day
-                          , subq_21.ds__extract_dow
-                          , subq_21.ds__extract_doy
-                          , subq_21.account_id__ds_partitioned__day
-                          , subq_21.account_id__ds_partitioned__week
-                          , subq_21.account_id__ds_partitioned__month
-                          , subq_21.account_id__ds_partitioned__quarter
-                          , subq_21.account_id__ds_partitioned__year
-                          , subq_21.account_id__ds_partitioned__extract_year
-                          , subq_21.account_id__ds_partitioned__extract_quarter
-                          , subq_21.account_id__ds_partitioned__extract_month
-                          , subq_21.account_id__ds_partitioned__extract_day
-                          , subq_21.account_id__ds_partitioned__extract_dow
-                          , subq_21.account_id__ds_partitioned__extract_doy
-                          , subq_21.account_id__ds__day
-                          , subq_21.account_id__ds__week
-                          , subq_21.account_id__ds__month
-                          , subq_21.account_id__ds__quarter
-                          , subq_21.account_id__ds__year
-                          , subq_21.account_id__ds__extract_year
-                          , subq_21.account_id__ds__extract_quarter
-                          , subq_21.account_id__ds__extract_month
-                          , subq_21.account_id__ds__extract_day
-                          , subq_21.account_id__ds__extract_dow
-                          , subq_21.account_id__ds__extract_doy
-                          , subq_21.ds__day AS metric_time__day
-                          , subq_21.ds__week AS metric_time__week
-                          , subq_21.ds__month AS metric_time__month
-                          , subq_21.ds__quarter AS metric_time__quarter
-                          , subq_21.ds__year AS metric_time__year
-                          , subq_21.ds__extract_year AS metric_time__extract_year
-                          , subq_21.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_21.ds__extract_month AS metric_time__extract_month
-                          , subq_21.ds__extract_day AS metric_time__extract_day
-                          , subq_21.ds__extract_dow AS metric_time__extract_dow
-                          , subq_21.ds__extract_doy AS metric_time__extract_doy
-                          , subq_21.account_id
-                          , subq_21.account_month
-                          , subq_21.account_id__account_month
-                          , subq_21.txn_count
+                          subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.account_id__ds_partitioned__day
+                          , subq_3.account_id__ds_partitioned__week
+                          , subq_3.account_id__ds_partitioned__month
+                          , subq_3.account_id__ds_partitioned__quarter
+                          , subq_3.account_id__ds_partitioned__year
+                          , subq_3.account_id__ds_partitioned__extract_year
+                          , subq_3.account_id__ds_partitioned__extract_quarter
+                          , subq_3.account_id__ds_partitioned__extract_month
+                          , subq_3.account_id__ds_partitioned__extract_day
+                          , subq_3.account_id__ds_partitioned__extract_dow
+                          , subq_3.account_id__ds_partitioned__extract_doy
+                          , subq_3.account_id__ds__day
+                          , subq_3.account_id__ds__week
+                          , subq_3.account_id__ds__month
+                          , subq_3.account_id__ds__quarter
+                          , subq_3.account_id__ds__year
+                          , subq_3.account_id__ds__extract_year
+                          , subq_3.account_id__ds__extract_quarter
+                          , subq_3.account_id__ds__extract_month
+                          , subq_3.account_id__ds__extract_day
+                          , subq_3.account_id__ds__extract_dow
+                          , subq_3.account_id__ds__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.account_id
+                          , subq_3.account_month
+                          , subq_3.account_id__account_month
+                          , subq_3.txn_count
                         FROM (
                           -- Read Elements From Semantic Model 'account_month_txns'
                           SELECT
@@ -252,164 +252,164 @@ FROM (
                             , account_month_txns_src_22000.account_month AS account_id__account_month
                             , account_month_txns_src_22000.account_id
                           FROM ***************************.account_month_txns account_month_txns_src_22000
-                        ) subq_21
-                      ) subq_22
-                    ) subq_23
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['ds_partitioned__day', 'account_id', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_29.ds_partitioned__day
-                        , subq_29.account_id
-                        , subq_29.customer_id__customer_third_hop_id
+                        subq_11.ds_partitioned__day
+                        , subq_11.account_id
+                        , subq_11.customer_id__customer_third_hop_id
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_25.ds_partitioned__day AS ds_partitioned__day
-                          , subq_25.ds_partitioned__week AS ds_partitioned__week
-                          , subq_25.ds_partitioned__month AS ds_partitioned__month
-                          , subq_25.ds_partitioned__quarter AS ds_partitioned__quarter
-                          , subq_25.ds_partitioned__year AS ds_partitioned__year
-                          , subq_25.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                          , subq_25.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                          , subq_25.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                          , subq_25.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                          , subq_25.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                          , subq_25.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                          , subq_25.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-                          , subq_25.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-                          , subq_25.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-                          , subq_25.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-                          , subq_25.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-                          , subq_25.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-                          , subq_25.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-                          , subq_25.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-                          , subq_25.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-                          , subq_25.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-                          , subq_25.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-                          , subq_25.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-                          , subq_25.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-                          , subq_25.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-                          , subq_25.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-                          , subq_25.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-                          , subq_25.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-                          , subq_25.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-                          , subq_25.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-                          , subq_25.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-                          , subq_25.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-                          , subq_25.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-                          , subq_25.metric_time__day AS metric_time__day
-                          , subq_25.metric_time__week AS metric_time__week
-                          , subq_25.metric_time__month AS metric_time__month
-                          , subq_25.metric_time__quarter AS metric_time__quarter
-                          , subq_25.metric_time__year AS metric_time__year
-                          , subq_25.metric_time__extract_year AS metric_time__extract_year
-                          , subq_25.metric_time__extract_quarter AS metric_time__extract_quarter
-                          , subq_25.metric_time__extract_month AS metric_time__extract_month
-                          , subq_25.metric_time__extract_day AS metric_time__extract_day
-                          , subq_25.metric_time__extract_dow AS metric_time__extract_dow
-                          , subq_25.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_28.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_28.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_28.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_28.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_28.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_28.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_28.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_28.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_28.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_28.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_28.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_28.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_28.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_28.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_28.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_28.metric_time__day AS customer_id__metric_time__day
-                          , subq_28.metric_time__week AS customer_id__metric_time__week
-                          , subq_28.metric_time__month AS customer_id__metric_time__month
-                          , subq_28.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_28.metric_time__year AS customer_id__metric_time__year
-                          , subq_28.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_28.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_28.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_28.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_28.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_28.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-                          , subq_25.account_id AS account_id
-                          , subq_25.customer_id AS customer_id
-                          , subq_25.account_id__customer_id AS account_id__customer_id
-                          , subq_25.bridge_account__account_id AS bridge_account__account_id
-                          , subq_25.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_28.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_28.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
-                          , subq_25.extra_dim AS extra_dim
-                          , subq_25.account_id__extra_dim AS account_id__extra_dim
-                          , subq_25.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_28.country AS customer_id__country
-                          , subq_28.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
-                          , subq_25.account_customer_combos AS account_customer_combos
+                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          , subq_7.ds_partitioned__week AS ds_partitioned__week
+                          , subq_7.ds_partitioned__month AS ds_partitioned__month
+                          , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+                          , subq_7.ds_partitioned__year AS ds_partitioned__year
+                          , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                          , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                          , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                          , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                          , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                          , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                          , subq_7.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+                          , subq_7.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+                          , subq_7.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+                          , subq_7.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+                          , subq_7.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+                          , subq_7.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+                          , subq_7.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+                          , subq_7.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+                          , subq_7.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+                          , subq_7.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+                          , subq_7.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+                          , subq_7.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+                          , subq_7.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+                          , subq_7.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+                          , subq_7.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+                          , subq_7.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+                          , subq_7.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+                          , subq_7.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+                          , subq_7.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+                          , subq_7.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+                          , subq_7.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+                          , subq_7.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+                          , subq_7.metric_time__day AS metric_time__day
+                          , subq_7.metric_time__week AS metric_time__week
+                          , subq_7.metric_time__month AS metric_time__month
+                          , subq_7.metric_time__quarter AS metric_time__quarter
+                          , subq_7.metric_time__year AS metric_time__year
+                          , subq_7.metric_time__extract_year AS metric_time__extract_year
+                          , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+                          , subq_7.metric_time__extract_month AS metric_time__extract_month
+                          , subq_7.metric_time__extract_day AS metric_time__extract_day
+                          , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+                          , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_7.account_id AS account_id
+                          , subq_7.customer_id AS customer_id
+                          , subq_7.account_id__customer_id AS account_id__customer_id
+                          , subq_7.bridge_account__account_id AS bridge_account__account_id
+                          , subq_7.bridge_account__customer_id AS bridge_account__customer_id
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.extra_dim AS extra_dim
+                          , subq_7.account_id__extra_dim AS account_id__extra_dim
+                          , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
+                          , subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'
                           SELECT
-                            subq_24.ds_partitioned__day
-                            , subq_24.ds_partitioned__week
-                            , subq_24.ds_partitioned__month
-                            , subq_24.ds_partitioned__quarter
-                            , subq_24.ds_partitioned__year
-                            , subq_24.ds_partitioned__extract_year
-                            , subq_24.ds_partitioned__extract_quarter
-                            , subq_24.ds_partitioned__extract_month
-                            , subq_24.ds_partitioned__extract_day
-                            , subq_24.ds_partitioned__extract_dow
-                            , subq_24.ds_partitioned__extract_doy
-                            , subq_24.account_id__ds_partitioned__day
-                            , subq_24.account_id__ds_partitioned__week
-                            , subq_24.account_id__ds_partitioned__month
-                            , subq_24.account_id__ds_partitioned__quarter
-                            , subq_24.account_id__ds_partitioned__year
-                            , subq_24.account_id__ds_partitioned__extract_year
-                            , subq_24.account_id__ds_partitioned__extract_quarter
-                            , subq_24.account_id__ds_partitioned__extract_month
-                            , subq_24.account_id__ds_partitioned__extract_day
-                            , subq_24.account_id__ds_partitioned__extract_dow
-                            , subq_24.account_id__ds_partitioned__extract_doy
-                            , subq_24.bridge_account__ds_partitioned__day
-                            , subq_24.bridge_account__ds_partitioned__week
-                            , subq_24.bridge_account__ds_partitioned__month
-                            , subq_24.bridge_account__ds_partitioned__quarter
-                            , subq_24.bridge_account__ds_partitioned__year
-                            , subq_24.bridge_account__ds_partitioned__extract_year
-                            , subq_24.bridge_account__ds_partitioned__extract_quarter
-                            , subq_24.bridge_account__ds_partitioned__extract_month
-                            , subq_24.bridge_account__ds_partitioned__extract_day
-                            , subq_24.bridge_account__ds_partitioned__extract_dow
-                            , subq_24.bridge_account__ds_partitioned__extract_doy
-                            , subq_24.ds_partitioned__day AS metric_time__day
-                            , subq_24.ds_partitioned__week AS metric_time__week
-                            , subq_24.ds_partitioned__month AS metric_time__month
-                            , subq_24.ds_partitioned__quarter AS metric_time__quarter
-                            , subq_24.ds_partitioned__year AS metric_time__year
-                            , subq_24.ds_partitioned__extract_year AS metric_time__extract_year
-                            , subq_24.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                            , subq_24.ds_partitioned__extract_month AS metric_time__extract_month
-                            , subq_24.ds_partitioned__extract_day AS metric_time__extract_day
-                            , subq_24.ds_partitioned__extract_dow AS metric_time__extract_dow
-                            , subq_24.ds_partitioned__extract_doy AS metric_time__extract_doy
-                            , subq_24.account_id
-                            , subq_24.customer_id
-                            , subq_24.account_id__customer_id
-                            , subq_24.bridge_account__account_id
-                            , subq_24.bridge_account__customer_id
-                            , subq_24.extra_dim
-                            , subq_24.account_id__extra_dim
-                            , subq_24.bridge_account__extra_dim
-                            , subq_24.account_customer_combos
+                            subq_6.ds_partitioned__day
+                            , subq_6.ds_partitioned__week
+                            , subq_6.ds_partitioned__month
+                            , subq_6.ds_partitioned__quarter
+                            , subq_6.ds_partitioned__year
+                            , subq_6.ds_partitioned__extract_year
+                            , subq_6.ds_partitioned__extract_quarter
+                            , subq_6.ds_partitioned__extract_month
+                            , subq_6.ds_partitioned__extract_day
+                            , subq_6.ds_partitioned__extract_dow
+                            , subq_6.ds_partitioned__extract_doy
+                            , subq_6.account_id__ds_partitioned__day
+                            , subq_6.account_id__ds_partitioned__week
+                            , subq_6.account_id__ds_partitioned__month
+                            , subq_6.account_id__ds_partitioned__quarter
+                            , subq_6.account_id__ds_partitioned__year
+                            , subq_6.account_id__ds_partitioned__extract_year
+                            , subq_6.account_id__ds_partitioned__extract_quarter
+                            , subq_6.account_id__ds_partitioned__extract_month
+                            , subq_6.account_id__ds_partitioned__extract_day
+                            , subq_6.account_id__ds_partitioned__extract_dow
+                            , subq_6.account_id__ds_partitioned__extract_doy
+                            , subq_6.bridge_account__ds_partitioned__day
+                            , subq_6.bridge_account__ds_partitioned__week
+                            , subq_6.bridge_account__ds_partitioned__month
+                            , subq_6.bridge_account__ds_partitioned__quarter
+                            , subq_6.bridge_account__ds_partitioned__year
+                            , subq_6.bridge_account__ds_partitioned__extract_year
+                            , subq_6.bridge_account__ds_partitioned__extract_quarter
+                            , subq_6.bridge_account__ds_partitioned__extract_month
+                            , subq_6.bridge_account__ds_partitioned__extract_day
+                            , subq_6.bridge_account__ds_partitioned__extract_dow
+                            , subq_6.bridge_account__ds_partitioned__extract_doy
+                            , subq_6.ds_partitioned__day AS metric_time__day
+                            , subq_6.ds_partitioned__week AS metric_time__week
+                            , subq_6.ds_partitioned__month AS metric_time__month
+                            , subq_6.ds_partitioned__quarter AS metric_time__quarter
+                            , subq_6.ds_partitioned__year AS metric_time__year
+                            , subq_6.ds_partitioned__extract_year AS metric_time__extract_year
+                            , subq_6.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                            , subq_6.ds_partitioned__extract_month AS metric_time__extract_month
+                            , subq_6.ds_partitioned__extract_day AS metric_time__extract_day
+                            , subq_6.ds_partitioned__extract_dow AS metric_time__extract_dow
+                            , subq_6.ds_partitioned__extract_doy AS metric_time__extract_doy
+                            , subq_6.account_id
+                            , subq_6.customer_id
+                            , subq_6.account_id__customer_id
+                            , subq_6.bridge_account__account_id
+                            , subq_6.bridge_account__customer_id
+                            , subq_6.extra_dim
+                            , subq_6.account_id__extra_dim
+                            , subq_6.bridge_account__extra_dim
+                            , subq_6.account_customer_combos
                           FROM (
                             -- Read Elements From Semantic Model 'bridge_table'
                             SELECT
@@ -456,8 +456,8 @@ FROM (
                               , bridge_table_src_22000.account_id AS bridge_account__account_id
                               , bridge_table_src_22000.customer_id AS bridge_account__customer_id
                             FROM ***************************.bridge_table bridge_table_src_22000
-                          ) subq_24
-                        ) subq_25
+                          ) subq_6
+                        ) subq_7
                         LEFT OUTER JOIN (
                           -- Pass Only Elements: [
                           --   'country',
@@ -513,112 +513,112 @@ FROM (
                           --   'customer_third_hop_id__customer_id',
                           -- ]
                           SELECT
-                            subq_27.acquired_ds__day
-                            , subq_27.acquired_ds__week
-                            , subq_27.acquired_ds__month
-                            , subq_27.acquired_ds__quarter
-                            , subq_27.acquired_ds__year
-                            , subq_27.acquired_ds__extract_year
-                            , subq_27.acquired_ds__extract_quarter
-                            , subq_27.acquired_ds__extract_month
-                            , subq_27.acquired_ds__extract_day
-                            , subq_27.acquired_ds__extract_dow
-                            , subq_27.acquired_ds__extract_doy
-                            , subq_27.customer_id__acquired_ds__day
-                            , subq_27.customer_id__acquired_ds__week
-                            , subq_27.customer_id__acquired_ds__month
-                            , subq_27.customer_id__acquired_ds__quarter
-                            , subq_27.customer_id__acquired_ds__year
-                            , subq_27.customer_id__acquired_ds__extract_year
-                            , subq_27.customer_id__acquired_ds__extract_quarter
-                            , subq_27.customer_id__acquired_ds__extract_month
-                            , subq_27.customer_id__acquired_ds__extract_day
-                            , subq_27.customer_id__acquired_ds__extract_dow
-                            , subq_27.customer_id__acquired_ds__extract_doy
-                            , subq_27.customer_third_hop_id__acquired_ds__day
-                            , subq_27.customer_third_hop_id__acquired_ds__week
-                            , subq_27.customer_third_hop_id__acquired_ds__month
-                            , subq_27.customer_third_hop_id__acquired_ds__quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_27.metric_time__day
-                            , subq_27.metric_time__week
-                            , subq_27.metric_time__month
-                            , subq_27.metric_time__quarter
-                            , subq_27.metric_time__year
-                            , subq_27.metric_time__extract_year
-                            , subq_27.metric_time__extract_quarter
-                            , subq_27.metric_time__extract_month
-                            , subq_27.metric_time__extract_day
-                            , subq_27.metric_time__extract_dow
-                            , subq_27.metric_time__extract_doy
-                            , subq_27.customer_id
-                            , subq_27.customer_third_hop_id
-                            , subq_27.customer_id__customer_third_hop_id
-                            , subq_27.customer_third_hop_id__customer_id
-                            , subq_27.country
-                            , subq_27.customer_id__country
-                            , subq_27.customer_third_hop_id__country
+                            subq_9.acquired_ds__day
+                            , subq_9.acquired_ds__week
+                            , subq_9.acquired_ds__month
+                            , subq_9.acquired_ds__quarter
+                            , subq_9.acquired_ds__year
+                            , subq_9.acquired_ds__extract_year
+                            , subq_9.acquired_ds__extract_quarter
+                            , subq_9.acquired_ds__extract_month
+                            , subq_9.acquired_ds__extract_day
+                            , subq_9.acquired_ds__extract_dow
+                            , subq_9.acquired_ds__extract_doy
+                            , subq_9.customer_id__acquired_ds__day
+                            , subq_9.customer_id__acquired_ds__week
+                            , subq_9.customer_id__acquired_ds__month
+                            , subq_9.customer_id__acquired_ds__quarter
+                            , subq_9.customer_id__acquired_ds__year
+                            , subq_9.customer_id__acquired_ds__extract_year
+                            , subq_9.customer_id__acquired_ds__extract_quarter
+                            , subq_9.customer_id__acquired_ds__extract_month
+                            , subq_9.customer_id__acquired_ds__extract_day
+                            , subq_9.customer_id__acquired_ds__extract_dow
+                            , subq_9.customer_id__acquired_ds__extract_doy
+                            , subq_9.customer_third_hop_id__acquired_ds__day
+                            , subq_9.customer_third_hop_id__acquired_ds__week
+                            , subq_9.customer_third_hop_id__acquired_ds__month
+                            , subq_9.customer_third_hop_id__acquired_ds__quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_9.metric_time__day
+                            , subq_9.metric_time__week
+                            , subq_9.metric_time__month
+                            , subq_9.metric_time__quarter
+                            , subq_9.metric_time__year
+                            , subq_9.metric_time__extract_year
+                            , subq_9.metric_time__extract_quarter
+                            , subq_9.metric_time__extract_month
+                            , subq_9.metric_time__extract_day
+                            , subq_9.metric_time__extract_dow
+                            , subq_9.metric_time__extract_doy
+                            , subq_9.customer_id
+                            , subq_9.customer_third_hop_id
+                            , subq_9.customer_id__customer_third_hop_id
+                            , subq_9.customer_third_hop_id__customer_id
+                            , subq_9.country
+                            , subq_9.customer_id__country
+                            , subq_9.customer_third_hop_id__country
                           FROM (
                             -- Metric Time Dimension 'acquired_ds'
                             SELECT
-                              subq_26.acquired_ds__day
-                              , subq_26.acquired_ds__week
-                              , subq_26.acquired_ds__month
-                              , subq_26.acquired_ds__quarter
-                              , subq_26.acquired_ds__year
-                              , subq_26.acquired_ds__extract_year
-                              , subq_26.acquired_ds__extract_quarter
-                              , subq_26.acquired_ds__extract_month
-                              , subq_26.acquired_ds__extract_day
-                              , subq_26.acquired_ds__extract_dow
-                              , subq_26.acquired_ds__extract_doy
-                              , subq_26.customer_id__acquired_ds__day
-                              , subq_26.customer_id__acquired_ds__week
-                              , subq_26.customer_id__acquired_ds__month
-                              , subq_26.customer_id__acquired_ds__quarter
-                              , subq_26.customer_id__acquired_ds__year
-                              , subq_26.customer_id__acquired_ds__extract_year
-                              , subq_26.customer_id__acquired_ds__extract_quarter
-                              , subq_26.customer_id__acquired_ds__extract_month
-                              , subq_26.customer_id__acquired_ds__extract_day
-                              , subq_26.customer_id__acquired_ds__extract_dow
-                              , subq_26.customer_id__acquired_ds__extract_doy
-                              , subq_26.customer_third_hop_id__acquired_ds__day
-                              , subq_26.customer_third_hop_id__acquired_ds__week
-                              , subq_26.customer_third_hop_id__acquired_ds__month
-                              , subq_26.customer_third_hop_id__acquired_ds__quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_month
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_day
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_dow
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_doy
-                              , subq_26.acquired_ds__day AS metric_time__day
-                              , subq_26.acquired_ds__week AS metric_time__week
-                              , subq_26.acquired_ds__month AS metric_time__month
-                              , subq_26.acquired_ds__quarter AS metric_time__quarter
-                              , subq_26.acquired_ds__year AS metric_time__year
-                              , subq_26.acquired_ds__extract_year AS metric_time__extract_year
-                              , subq_26.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_26.acquired_ds__extract_month AS metric_time__extract_month
-                              , subq_26.acquired_ds__extract_day AS metric_time__extract_day
-                              , subq_26.acquired_ds__extract_dow AS metric_time__extract_dow
-                              , subq_26.acquired_ds__extract_doy AS metric_time__extract_doy
-                              , subq_26.customer_id
-                              , subq_26.customer_third_hop_id
-                              , subq_26.customer_id__customer_third_hop_id
-                              , subq_26.customer_third_hop_id__customer_id
-                              , subq_26.country
-                              , subq_26.customer_id__country
-                              , subq_26.customer_third_hop_id__country
-                              , subq_26.customers_with_other_data
+                              subq_8.acquired_ds__day
+                              , subq_8.acquired_ds__week
+                              , subq_8.acquired_ds__month
+                              , subq_8.acquired_ds__quarter
+                              , subq_8.acquired_ds__year
+                              , subq_8.acquired_ds__extract_year
+                              , subq_8.acquired_ds__extract_quarter
+                              , subq_8.acquired_ds__extract_month
+                              , subq_8.acquired_ds__extract_day
+                              , subq_8.acquired_ds__extract_dow
+                              , subq_8.acquired_ds__extract_doy
+                              , subq_8.customer_id__acquired_ds__day
+                              , subq_8.customer_id__acquired_ds__week
+                              , subq_8.customer_id__acquired_ds__month
+                              , subq_8.customer_id__acquired_ds__quarter
+                              , subq_8.customer_id__acquired_ds__year
+                              , subq_8.customer_id__acquired_ds__extract_year
+                              , subq_8.customer_id__acquired_ds__extract_quarter
+                              , subq_8.customer_id__acquired_ds__extract_month
+                              , subq_8.customer_id__acquired_ds__extract_day
+                              , subq_8.customer_id__acquired_ds__extract_dow
+                              , subq_8.customer_id__acquired_ds__extract_doy
+                              , subq_8.customer_third_hop_id__acquired_ds__day
+                              , subq_8.customer_third_hop_id__acquired_ds__week
+                              , subq_8.customer_third_hop_id__acquired_ds__month
+                              , subq_8.customer_third_hop_id__acquired_ds__quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_month
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_day
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_dow
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_doy
+                              , subq_8.acquired_ds__day AS metric_time__day
+                              , subq_8.acquired_ds__week AS metric_time__week
+                              , subq_8.acquired_ds__month AS metric_time__month
+                              , subq_8.acquired_ds__quarter AS metric_time__quarter
+                              , subq_8.acquired_ds__year AS metric_time__year
+                              , subq_8.acquired_ds__extract_year AS metric_time__extract_year
+                              , subq_8.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_8.acquired_ds__extract_month AS metric_time__extract_month
+                              , subq_8.acquired_ds__extract_day AS metric_time__extract_day
+                              , subq_8.acquired_ds__extract_dow AS metric_time__extract_dow
+                              , subq_8.acquired_ds__extract_doy AS metric_time__extract_doy
+                              , subq_8.customer_id
+                              , subq_8.customer_third_hop_id
+                              , subq_8.customer_id__customer_third_hop_id
+                              , subq_8.customer_third_hop_id__customer_id
+                              , subq_8.country
+                              , subq_8.customer_id__country
+                              , subq_8.customer_third_hop_id__country
+                              , subq_8.customers_with_other_data
                             FROM (
                               -- Read Elements From Semantic Model 'customer_other_data'
                               SELECT
@@ -664,31 +664,31 @@ FROM (
                                 , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                                 , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                               FROM ***************************.customer_other_data customer_other_data_src_22000
-                            ) subq_26
-                          ) subq_27
-                        ) subq_28
+                            ) subq_8
+                          ) subq_9
+                        ) subq_10
                         ON
-                          subq_25.customer_id = subq_28.customer_id
-                      ) subq_29
-                    ) subq_30
+                          subq_7.customer_id = subq_10.customer_id
+                      ) subq_11
+                    ) subq_12
                     ON
                       (
-                        subq_23.account_id = subq_30.account_id
+                        subq_5.account_id = subq_12.account_id
                       ) AND (
-                        subq_23.ds_partitioned__day = subq_30.ds_partitioned__day
+                        subq_5.ds_partitioned__day = subq_12.ds_partitioned__day
                       )
-                  ) subq_31
-                ) subq_32
+                  ) subq_13
+                ) subq_14
                 GROUP BY
-                  subq_32.account_id__customer_id__customer_third_hop_id
-              ) subq_33
-            ) subq_34
-          ) subq_35
+                  subq_14.account_id__customer_id__customer_third_hop_id
+              ) subq_15
+            ) subq_16
+          ) subq_17
           ON
-            subq_20.customer_third_hop_id = subq_35.account_id__customer_id__customer_third_hop_id
-        ) subq_36
-      ) subq_37
+            subq_2.customer_third_hop_id = subq_17.account_id__customer_id__customer_third_hop_id
+        ) subq_18
+      ) subq_19
       WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2
-    ) subq_38
-  ) subq_39
-) subq_40
+    ) subq_20
+  ) subq_21
+) subq_22

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_40.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_35.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_71
+    ) subq_35
     ON
       (
-        account_month_txns_src_22000.account_id = subq_71.account_id
+        account_month_txns_src_22000.account_id = subq_35.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_35.ds_partitioned__day
       )
     GROUP BY
-      subq_71.customer_id__customer_third_hop_id
-  ) subq_76
+      subq_35.customer_id__customer_third_hop_id
+  ) subq_40
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
-) subq_78
+    third_hop_table_src_22000.customer_third_hop_id = subq_40.account_id__customer_id__customer_third_hop_id
+) subq_42
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_25.third_hop_count
+  subq_16.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_24.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_23.third_hop_count
+      subq_14.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_22.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_22.third_hop_count
+        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_13.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_21.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_21.third_hop_count
+          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_12.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.customer_third_hop_id AS customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-            , subq_11.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_10.customer_third_hop_id
-              , subq_10.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_9.third_hop_ds__day
-                , subq_9.third_hop_ds__week
-                , subq_9.third_hop_ds__month
-                , subq_9.third_hop_ds__quarter
-                , subq_9.third_hop_ds__year
-                , subq_9.third_hop_ds__extract_year
-                , subq_9.third_hop_ds__extract_quarter
-                , subq_9.third_hop_ds__extract_month
-                , subq_9.third_hop_ds__extract_day
-                , subq_9.third_hop_ds__extract_dow
-                , subq_9.third_hop_ds__extract_doy
-                , subq_9.customer_third_hop_id__third_hop_ds__day
-                , subq_9.customer_third_hop_id__third_hop_ds__week
-                , subq_9.customer_third_hop_id__third_hop_ds__month
-                , subq_9.customer_third_hop_id__third_hop_ds__quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_9.third_hop_ds__day AS metric_time__day
-                , subq_9.third_hop_ds__week AS metric_time__week
-                , subq_9.third_hop_ds__month AS metric_time__month
-                , subq_9.third_hop_ds__quarter AS metric_time__quarter
-                , subq_9.third_hop_ds__year AS metric_time__year
-                , subq_9.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_9.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_9.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_9.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_9.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_9.customer_third_hop_id
-                , subq_9.value
-                , subq_9.customer_third_hop_id__value
-                , subq_9.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,151 +101,151 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_19.customer_id__customer_third_hop_id
-              , subq_19.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_10.customer_id__customer_third_hop_id
+              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_18.customer_id__customer_third_hop_id
-                , subq_18.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_9.customer_id__customer_third_hop_id
+                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_17.customer_id__customer_third_hop_id
-                  , SUM(subq_17.customers_with_other_data) AS customers_with_other_data
+                  subq_8.customer_id__customer_third_hop_id
+                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_16.customer_id__customer_third_hop_id
-                    , subq_16.customers_with_other_data
+                    subq_7.customer_id__customer_third_hop_id
+                    , subq_7.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_15.customer_id__customer_third_hop_id
-                      , subq_15.customer_id__country
-                      , subq_15.customers_with_other_data
+                      subq_6.customer_id__customer_third_hop_id
+                      , subq_6.customer_id__country
+                      , subq_6.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_14.customer_id__customer_third_hop_id
-                        , subq_14.customer_id__country
-                        , subq_14.customers_with_other_data
+                        subq_5.customer_id__customer_third_hop_id
+                        , subq_5.customer_id__country
+                        , subq_5.customers_with_other_data
                       FROM (
                         -- Constrain Output with WHERE
                         SELECT
-                          subq_13.acquired_ds__day
-                          , subq_13.acquired_ds__week
-                          , subq_13.acquired_ds__month
-                          , subq_13.acquired_ds__quarter
-                          , subq_13.acquired_ds__year
-                          , subq_13.acquired_ds__extract_year
-                          , subq_13.acquired_ds__extract_quarter
-                          , subq_13.acquired_ds__extract_month
-                          , subq_13.acquired_ds__extract_day
-                          , subq_13.acquired_ds__extract_dow
-                          , subq_13.acquired_ds__extract_doy
-                          , subq_13.customer_id__acquired_ds__day
-                          , subq_13.customer_id__acquired_ds__week
-                          , subq_13.customer_id__acquired_ds__month
-                          , subq_13.customer_id__acquired_ds__quarter
-                          , subq_13.customer_id__acquired_ds__year
-                          , subq_13.customer_id__acquired_ds__extract_year
-                          , subq_13.customer_id__acquired_ds__extract_quarter
-                          , subq_13.customer_id__acquired_ds__extract_month
-                          , subq_13.customer_id__acquired_ds__extract_day
-                          , subq_13.customer_id__acquired_ds__extract_dow
-                          , subq_13.customer_id__acquired_ds__extract_doy
-                          , subq_13.customer_third_hop_id__acquired_ds__day
-                          , subq_13.customer_third_hop_id__acquired_ds__week
-                          , subq_13.customer_third_hop_id__acquired_ds__month
-                          , subq_13.customer_third_hop_id__acquired_ds__quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_13.metric_time__day
-                          , subq_13.metric_time__week
-                          , subq_13.metric_time__month
-                          , subq_13.metric_time__quarter
-                          , subq_13.metric_time__year
-                          , subq_13.metric_time__extract_year
-                          , subq_13.metric_time__extract_quarter
-                          , subq_13.metric_time__extract_month
-                          , subq_13.metric_time__extract_day
-                          , subq_13.metric_time__extract_dow
-                          , subq_13.metric_time__extract_doy
-                          , subq_13.customer_id
-                          , subq_13.customer_third_hop_id
-                          , subq_13.customer_id__customer_third_hop_id
-                          , subq_13.customer_third_hop_id__customer_id
-                          , subq_13.country
-                          , subq_13.customer_id__country
-                          , subq_13.customer_third_hop_id__country
-                          , subq_13.customers_with_other_data
+                          subq_4.acquired_ds__day
+                          , subq_4.acquired_ds__week
+                          , subq_4.acquired_ds__month
+                          , subq_4.acquired_ds__quarter
+                          , subq_4.acquired_ds__year
+                          , subq_4.acquired_ds__extract_year
+                          , subq_4.acquired_ds__extract_quarter
+                          , subq_4.acquired_ds__extract_month
+                          , subq_4.acquired_ds__extract_day
+                          , subq_4.acquired_ds__extract_dow
+                          , subq_4.acquired_ds__extract_doy
+                          , subq_4.customer_id__acquired_ds__day
+                          , subq_4.customer_id__acquired_ds__week
+                          , subq_4.customer_id__acquired_ds__month
+                          , subq_4.customer_id__acquired_ds__quarter
+                          , subq_4.customer_id__acquired_ds__year
+                          , subq_4.customer_id__acquired_ds__extract_year
+                          , subq_4.customer_id__acquired_ds__extract_quarter
+                          , subq_4.customer_id__acquired_ds__extract_month
+                          , subq_4.customer_id__acquired_ds__extract_day
+                          , subq_4.customer_id__acquired_ds__extract_dow
+                          , subq_4.customer_id__acquired_ds__extract_doy
+                          , subq_4.customer_third_hop_id__acquired_ds__day
+                          , subq_4.customer_third_hop_id__acquired_ds__week
+                          , subq_4.customer_third_hop_id__acquired_ds__month
+                          , subq_4.customer_third_hop_id__acquired_ds__quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_4.metric_time__day
+                          , subq_4.metric_time__week
+                          , subq_4.metric_time__month
+                          , subq_4.metric_time__quarter
+                          , subq_4.metric_time__year
+                          , subq_4.metric_time__extract_year
+                          , subq_4.metric_time__extract_quarter
+                          , subq_4.metric_time__extract_month
+                          , subq_4.metric_time__extract_day
+                          , subq_4.metric_time__extract_dow
+                          , subq_4.metric_time__extract_doy
+                          , subq_4.customer_id
+                          , subq_4.customer_third_hop_id
+                          , subq_4.customer_id__customer_third_hop_id
+                          , subq_4.customer_third_hop_id__customer_id
+                          , subq_4.country
+                          , subq_4.customer_id__country
+                          , subq_4.customer_third_hop_id__country
+                          , subq_4.customers_with_other_data
                         FROM (
                           -- Metric Time Dimension 'acquired_ds'
                           SELECT
-                            subq_12.acquired_ds__day
-                            , subq_12.acquired_ds__week
-                            , subq_12.acquired_ds__month
-                            , subq_12.acquired_ds__quarter
-                            , subq_12.acquired_ds__year
-                            , subq_12.acquired_ds__extract_year
-                            , subq_12.acquired_ds__extract_quarter
-                            , subq_12.acquired_ds__extract_month
-                            , subq_12.acquired_ds__extract_day
-                            , subq_12.acquired_ds__extract_dow
-                            , subq_12.acquired_ds__extract_doy
-                            , subq_12.customer_id__acquired_ds__day
-                            , subq_12.customer_id__acquired_ds__week
-                            , subq_12.customer_id__acquired_ds__month
-                            , subq_12.customer_id__acquired_ds__quarter
-                            , subq_12.customer_id__acquired_ds__year
-                            , subq_12.customer_id__acquired_ds__extract_year
-                            , subq_12.customer_id__acquired_ds__extract_quarter
-                            , subq_12.customer_id__acquired_ds__extract_month
-                            , subq_12.customer_id__acquired_ds__extract_day
-                            , subq_12.customer_id__acquired_ds__extract_dow
-                            , subq_12.customer_id__acquired_ds__extract_doy
-                            , subq_12.customer_third_hop_id__acquired_ds__day
-                            , subq_12.customer_third_hop_id__acquired_ds__week
-                            , subq_12.customer_third_hop_id__acquired_ds__month
-                            , subq_12.customer_third_hop_id__acquired_ds__quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_12.acquired_ds__day AS metric_time__day
-                            , subq_12.acquired_ds__week AS metric_time__week
-                            , subq_12.acquired_ds__month AS metric_time__month
-                            , subq_12.acquired_ds__quarter AS metric_time__quarter
-                            , subq_12.acquired_ds__year AS metric_time__year
-                            , subq_12.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_12.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_12.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_12.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_12.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_12.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_12.customer_id
-                            , subq_12.customer_third_hop_id
-                            , subq_12.customer_id__customer_third_hop_id
-                            , subq_12.customer_third_hop_id__customer_id
-                            , subq_12.country
-                            , subq_12.customer_id__country
-                            , subq_12.customer_third_hop_id__country
-                            , subq_12.customers_with_other_data
+                            subq_3.acquired_ds__day
+                            , subq_3.acquired_ds__week
+                            , subq_3.acquired_ds__month
+                            , subq_3.acquired_ds__quarter
+                            , subq_3.acquired_ds__year
+                            , subq_3.acquired_ds__extract_year
+                            , subq_3.acquired_ds__extract_quarter
+                            , subq_3.acquired_ds__extract_month
+                            , subq_3.acquired_ds__extract_day
+                            , subq_3.acquired_ds__extract_dow
+                            , subq_3.acquired_ds__extract_doy
+                            , subq_3.customer_id__acquired_ds__day
+                            , subq_3.customer_id__acquired_ds__week
+                            , subq_3.customer_id__acquired_ds__month
+                            , subq_3.customer_id__acquired_ds__quarter
+                            , subq_3.customer_id__acquired_ds__year
+                            , subq_3.customer_id__acquired_ds__extract_year
+                            , subq_3.customer_id__acquired_ds__extract_quarter
+                            , subq_3.customer_id__acquired_ds__extract_month
+                            , subq_3.customer_id__acquired_ds__extract_day
+                            , subq_3.customer_id__acquired_ds__extract_dow
+                            , subq_3.customer_id__acquired_ds__extract_doy
+                            , subq_3.customer_third_hop_id__acquired_ds__day
+                            , subq_3.customer_third_hop_id__acquired_ds__week
+                            , subq_3.customer_third_hop_id__acquired_ds__month
+                            , subq_3.customer_third_hop_id__acquired_ds__quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_3.acquired_ds__day AS metric_time__day
+                            , subq_3.acquired_ds__week AS metric_time__week
+                            , subq_3.acquired_ds__month AS metric_time__month
+                            , subq_3.acquired_ds__quarter AS metric_time__quarter
+                            , subq_3.acquired_ds__year AS metric_time__year
+                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                            , subq_3.customer_id
+                            , subq_3.customer_third_hop_id
+                            , subq_3.customer_id__customer_third_hop_id
+                            , subq_3.customer_third_hop_id__customer_id
+                            , subq_3.country
+                            , subq_3.customer_id__country
+                            , subq_3.customer_third_hop_id__country
+                            , subq_3.customers_with_other_data
                           FROM (
                             -- Read Elements From Semantic Model 'customer_other_data'
                             SELECT
@@ -291,24 +291,24 @@ FROM (
                               , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                               , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                             FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_12
-                        ) subq_13
+                          ) subq_3
+                        ) subq_4
                         WHERE customer_id__country = 'paraguay'
-                      ) subq_14
-                    ) subq_15
+                      ) subq_5
+                    ) subq_6
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_16
-                ) subq_17
+                  ) subq_7
+                ) subq_8
                 GROUP BY
-                  subq_17.customer_id__customer_third_hop_id
-              ) subq_18
-            ) subq_19
-          ) subq_20
+                  subq_8.customer_id__customer_third_hop_id
+              ) subq_9
+            ) subq_10
+          ) subq_11
           ON
-            subq_11.customer_third_hop_id = subq_20.customer_id__customer_third_hop_id
-        ) subq_21
-      ) subq_22
+            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
+        ) subq_12
+      ) subq_13
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_23
-  ) subq_24
-) subq_25
+    ) subq_14
+  ) subq_15
+) subq_16

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_39
+      ) subq_21
       WHERE customer_id__country = 'paraguay'
-    ) subq_41
+    ) subq_23
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_46
+  ) subq_28
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
-) subq_48
+    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
+) subq_30
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookers
-        , subq_14.bookers
+        subq_10.listing__bookers
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'listing__bookers']
         SELECT
-          subq_13.listing__bookers
-          , subq_13.bookers
+          subq_9.listing__bookers
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookers AS listing__bookers
-            , subq_6.bookers AS bookers
+            subq_2.listing AS listing
+            , subq_8.listing__bookers AS listing__bookers
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.bookers
+              subq_1.listing
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookers
+              subq_7.listing
+              , subq_7.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookers AS listing__bookers
+                subq_6.listing
+                , subq_6.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , COUNT(DISTINCT subq_9.bookers) AS bookers
+                  subq_5.listing
+                  , COUNT(DISTINCT subq_5.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookers
+                    subq_4.listing
+                    , subq_4.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookers > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_30.listing__bookers AS listing__bookers
-    , subq_24.bookers AS bookers
+    subq_22.listing__bookers AS listing__bookers
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_with_metric_in_where_filter__plan0.sql
@@ -1,112 +1,112 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time__day
-  , subq_17.listings AS active_listings
+  subq_13.metric_time__day
+  , subq_13.listings AS active_listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.metric_time__day
-    , SUM(subq_16.listings) AS listings
+    subq_12.metric_time__day
+    , SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'metric_time__day']
     SELECT
-      subq_15.metric_time__day
-      , subq_15.listings
+      subq_11.metric_time__day
+      , subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.metric_time__day
-        , subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.metric_time__day
+        , subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
         SELECT
-          subq_13.metric_time__day
-          , subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.metric_time__day
+          , subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.metric_time__day AS metric_time__day
-            , subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']
             SELECT
-              subq_5.metric_time__day
-              , subq_5.listing
-              , subq_5.listings
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -167,130 +167,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -383,21 +383,21 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
+    ) subq_11
+  ) subq_12
   GROUP BY
-    subq_16.metric_time__day
-) subq_17
+    subq_12.metric_time__day
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_24.metric_time__day AS metric_time__day
-    , subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_16.metric_time__day AS metric_time__day
+    , subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.user__revenue_all_time
-        , subq_14.listings
+        subq_10.user__revenue_all_time
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__revenue_all_time']
         SELECT
-          subq_13.user__revenue_all_time
-          , subq_13.listings
+          subq_9.user__revenue_all_time
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.user AS user
-            , subq_12.user__revenue_all_time AS user__revenue_all_time
-            , subq_6.listings AS listings
+            subq_2.user AS user
+            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_5.user
-              , subq_5.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,68 +160,68 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__revenue_all_time']
             SELECT
-              subq_11.user
-              , subq_11.user__revenue_all_time
+              subq_7.user
+              , subq_7.user__revenue_all_time
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.user
-                , subq_10.txn_revenue AS user__revenue_all_time
+                subq_6.user
+                , subq_6.txn_revenue AS user__revenue_all_time
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.user
-                  , SUM(subq_9.txn_revenue) AS txn_revenue
+                  subq_5.user
+                  , SUM(subq_5.txn_revenue) AS txn_revenue
                 FROM (
                   -- Pass Only Elements: ['txn_revenue', 'user']
                   SELECT
-                    subq_8.user
-                    , subq_8.txn_revenue
+                    subq_4.user
+                    , subq_4.txn_revenue
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.revenue_instance__ds__day
-                      , subq_7.revenue_instance__ds__week
-                      , subq_7.revenue_instance__ds__month
-                      , subq_7.revenue_instance__ds__quarter
-                      , subq_7.revenue_instance__ds__year
-                      , subq_7.revenue_instance__ds__extract_year
-                      , subq_7.revenue_instance__ds__extract_quarter
-                      , subq_7.revenue_instance__ds__extract_month
-                      , subq_7.revenue_instance__ds__extract_day
-                      , subq_7.revenue_instance__ds__extract_dow
-                      , subq_7.revenue_instance__ds__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.user
-                      , subq_7.revenue_instance__user
-                      , subq_7.txn_revenue
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.revenue_instance__ds__day
+                      , subq_3.revenue_instance__ds__week
+                      , subq_3.revenue_instance__ds__month
+                      , subq_3.revenue_instance__ds__quarter
+                      , subq_3.revenue_instance__ds__year
+                      , subq_3.revenue_instance__ds__extract_year
+                      , subq_3.revenue_instance__ds__extract_quarter
+                      , subq_3.revenue_instance__ds__extract_month
+                      , subq_3.revenue_instance__ds__extract_day
+                      , subq_3.revenue_instance__ds__extract_dow
+                      , subq_3.revenue_instance__ds__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.user
+                      , subq_3.revenue_instance__user
+                      , subq_3.txn_revenue
                     FROM (
                       -- Read Elements From Semantic Model 'revenue'
                       SELECT
@@ -251,19 +251,19 @@ FROM (
                         , revenue_src_28000.user_id AS user
                         , revenue_src_28000.user_id AS revenue_instance__user
                       FROM ***************************.fct_revenue revenue_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.user
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.user
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.user = subq_12.user
-        ) subq_13
-      ) subq_14
+            subq_2.user = subq_8.user
+        ) subq_9
+      ) subq_10
       WHERE user__revenue_all_time > 1
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_30.user__revenue_all_time AS user__revenue_all_time
-    , subq_24.listings AS listings
+    subq_22.user__revenue_all_time AS user__revenue_all_time
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.user = subq_30.user
-) subq_32
+    subq_16.user = subq_22.user
+) subq_24
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__views_times_booking_value
-        , subq_28.listings
+        subq_17.listing__views_times_booking_value
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
         SELECT
-          subq_27.listing__views_times_booking_value
-          , subq_27.listings
+          subq_16.listing__views_times_booking_value
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__views_times_booking_value AS listing__views_times_booking_value
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
             SELECT
-              subq_25.listing
-              , subq_25.listing__views_times_booking_value
+              subq_14.listing
+              , subq_14.listing__views_times_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
+                subq_13.listing
                 , booking_value * views AS listing__views_times_booking_value
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.booking_value) AS booking_value
-                  , MAX(subq_23.views) AS views
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.booking_value) AS booking_value
+                  , MAX(subq_12.views) AS views
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.booking_value
+                    subq_6.listing
+                    , subq_6.booking_value
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.booking_value) AS booking_value
+                      subq_5.listing
+                      , SUM(subq_5.booking_value) AS booking_value
                     FROM (
                       -- Pass Only Elements: ['booking_value', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.booking_value
+                        subq_4.listing
+                        , subq_4.booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,91 +387,91 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.views
+                    subq_11.listing
+                    , subq_11.views
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , SUM(subq_21.views) AS views
+                      subq_10.listing
+                      , SUM(subq_10.views) AS views
                     FROM (
                       -- Pass Only Elements: ['views', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.views
+                        subq_9.listing
+                        , subq_9.views
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.view__ds__day
-                          , subq_19.view__ds__week
-                          , subq_19.view__ds__month
-                          , subq_19.view__ds__quarter
-                          , subq_19.view__ds__year
-                          , subq_19.view__ds__extract_year
-                          , subq_19.view__ds__extract_quarter
-                          , subq_19.view__ds__extract_month
-                          , subq_19.view__ds__extract_day
-                          , subq_19.view__ds__extract_dow
-                          , subq_19.view__ds__extract_doy
-                          , subq_19.view__ds_partitioned__day
-                          , subq_19.view__ds_partitioned__week
-                          , subq_19.view__ds_partitioned__month
-                          , subq_19.view__ds_partitioned__quarter
-                          , subq_19.view__ds_partitioned__year
-                          , subq_19.view__ds_partitioned__extract_year
-                          , subq_19.view__ds_partitioned__extract_quarter
-                          , subq_19.view__ds_partitioned__extract_month
-                          , subq_19.view__ds_partitioned__extract_day
-                          , subq_19.view__ds_partitioned__extract_dow
-                          , subq_19.view__ds_partitioned__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.user
-                          , subq_19.view__listing
-                          , subq_19.view__user
-                          , subq_19.views
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.view__ds__day
+                          , subq_8.view__ds__week
+                          , subq_8.view__ds__month
+                          , subq_8.view__ds__quarter
+                          , subq_8.view__ds__year
+                          , subq_8.view__ds__extract_year
+                          , subq_8.view__ds__extract_quarter
+                          , subq_8.view__ds__extract_month
+                          , subq_8.view__ds__extract_day
+                          , subq_8.view__ds__extract_dow
+                          , subq_8.view__ds__extract_doy
+                          , subq_8.view__ds_partitioned__day
+                          , subq_8.view__ds_partitioned__week
+                          , subq_8.view__ds_partitioned__month
+                          , subq_8.view__ds_partitioned__quarter
+                          , subq_8.view__ds_partitioned__year
+                          , subq_8.view__ds_partitioned__extract_year
+                          , subq_8.view__ds_partitioned__extract_quarter
+                          , subq_8.view__ds_partitioned__extract_month
+                          , subq_8.view__ds_partitioned__extract_day
+                          , subq_8.view__ds_partitioned__extract_dow
+                          , subq_8.view__ds_partitioned__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.user
+                          , subq_8.view__listing
+                          , subq_8.view__user
+                          , subq_8.views
                         FROM (
                           -- Read Elements From Semantic Model 'views_source'
                           SELECT
@@ -525,25 +525,25 @@ FROM (
                             , views_source_src_28000.listing_id AS view__listing
                             , views_source_src_28000.user_id AS view__user
                           FROM ***************************.fct_views views_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__views_times_booking_value > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_45.listings AS listings
+    subq_36.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_50.listing, subq_55.listing) AS listing
-        , MAX(subq_50.booking_value) AS booking_value
-        , MAX(subq_55.views) AS views
+        COALESCE(subq_28.listing, subq_33.listing) AS listing
+        , MAX(subq_28.booking_value) AS booking_value
+        , MAX(subq_33.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_50
+      ) subq_28
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_53
+        ) subq_31
         GROUP BY
           listing
-      ) subq_55
+      ) subq_33
       ON
-        subq_50.listing = subq_55.listing
+        subq_28.listing = subq_33.listing
       GROUP BY
-        COALESCE(subq_50.listing, subq_55.listing)
-    ) subq_56
-  ) subq_58
+        COALESCE(subq_28.listing, subq_33.listing)
+    ) subq_34
+  ) subq_36
   ON
-    subq_45.listing = subq_58.listing
-) subq_60
+    subq_23.listing = subq_36.listing
+) subq_38
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -1,108 +1,108 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_19.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_18.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_17.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.listing__bookings
-        , subq_24.listing__bookers
-        , subq_24.listings
+        subq_16.listing__bookings
+        , subq_16.listing__bookers
+        , subq_16.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
         SELECT
-          subq_23.listing__bookings
-          , subq_23.listing__bookers
-          , subq_23.listings
+          subq_15.listing__bookings
+          , subq_15.listing__bookers
+          , subq_15.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_10.listing AS listing
-            , subq_16.listing__bookings AS listing__bookings
-            , subq_22.listing__bookers AS listing__bookers
-            , subq_10.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']
             SELECT
-              subq_9.listing
-              , subq_9.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_8.ds__day
-                , subq_8.ds__week
-                , subq_8.ds__month
-                , subq_8.ds__quarter
-                , subq_8.ds__year
-                , subq_8.ds__extract_year
-                , subq_8.ds__extract_quarter
-                , subq_8.ds__extract_month
-                , subq_8.ds__extract_day
-                , subq_8.ds__extract_dow
-                , subq_8.ds__extract_doy
-                , subq_8.created_at__day
-                , subq_8.created_at__week
-                , subq_8.created_at__month
-                , subq_8.created_at__quarter
-                , subq_8.created_at__year
-                , subq_8.created_at__extract_year
-                , subq_8.created_at__extract_quarter
-                , subq_8.created_at__extract_month
-                , subq_8.created_at__extract_day
-                , subq_8.created_at__extract_dow
-                , subq_8.created_at__extract_doy
-                , subq_8.listing__ds__day
-                , subq_8.listing__ds__week
-                , subq_8.listing__ds__month
-                , subq_8.listing__ds__quarter
-                , subq_8.listing__ds__year
-                , subq_8.listing__ds__extract_year
-                , subq_8.listing__ds__extract_quarter
-                , subq_8.listing__ds__extract_month
-                , subq_8.listing__ds__extract_day
-                , subq_8.listing__ds__extract_dow
-                , subq_8.listing__ds__extract_doy
-                , subq_8.listing__created_at__day
-                , subq_8.listing__created_at__week
-                , subq_8.listing__created_at__month
-                , subq_8.listing__created_at__quarter
-                , subq_8.listing__created_at__year
-                , subq_8.listing__created_at__extract_year
-                , subq_8.listing__created_at__extract_quarter
-                , subq_8.listing__created_at__extract_month
-                , subq_8.listing__created_at__extract_day
-                , subq_8.listing__created_at__extract_dow
-                , subq_8.listing__created_at__extract_doy
-                , subq_8.ds__day AS metric_time__day
-                , subq_8.ds__week AS metric_time__week
-                , subq_8.ds__month AS metric_time__month
-                , subq_8.ds__quarter AS metric_time__quarter
-                , subq_8.ds__year AS metric_time__year
-                , subq_8.ds__extract_year AS metric_time__extract_year
-                , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_8.ds__extract_month AS metric_time__extract_month
-                , subq_8.ds__extract_day AS metric_time__extract_day
-                , subq_8.ds__extract_dow AS metric_time__extract_dow
-                , subq_8.ds__extract_doy AS metric_time__extract_doy
-                , subq_8.listing
-                , subq_8.user
-                , subq_8.listing__user
-                , subq_8.country_latest
-                , subq_8.is_lux_latest
-                , subq_8.capacity_latest
-                , subq_8.listing__country_latest
-                , subq_8.listing__is_lux_latest
-                , subq_8.listing__capacity_latest
-                , subq_8.listings
-                , subq_8.largest_listing
-                , subq_8.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -163,130 +163,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_8
-            ) subq_9
-          ) subq_10
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_15.listing
-              , subq_15.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_14.listing
-                , subq_14.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_13.listing
-                  , SUM(subq_13.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_12.listing
-                    , subq_12.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_11.ds__day
-                      , subq_11.ds__week
-                      , subq_11.ds__month
-                      , subq_11.ds__quarter
-                      , subq_11.ds__year
-                      , subq_11.ds__extract_year
-                      , subq_11.ds__extract_quarter
-                      , subq_11.ds__extract_month
-                      , subq_11.ds__extract_day
-                      , subq_11.ds__extract_dow
-                      , subq_11.ds__extract_doy
-                      , subq_11.ds_partitioned__day
-                      , subq_11.ds_partitioned__week
-                      , subq_11.ds_partitioned__month
-                      , subq_11.ds_partitioned__quarter
-                      , subq_11.ds_partitioned__year
-                      , subq_11.ds_partitioned__extract_year
-                      , subq_11.ds_partitioned__extract_quarter
-                      , subq_11.ds_partitioned__extract_month
-                      , subq_11.ds_partitioned__extract_day
-                      , subq_11.ds_partitioned__extract_dow
-                      , subq_11.ds_partitioned__extract_doy
-                      , subq_11.paid_at__day
-                      , subq_11.paid_at__week
-                      , subq_11.paid_at__month
-                      , subq_11.paid_at__quarter
-                      , subq_11.paid_at__year
-                      , subq_11.paid_at__extract_year
-                      , subq_11.paid_at__extract_quarter
-                      , subq_11.paid_at__extract_month
-                      , subq_11.paid_at__extract_day
-                      , subq_11.paid_at__extract_dow
-                      , subq_11.paid_at__extract_doy
-                      , subq_11.booking__ds__day
-                      , subq_11.booking__ds__week
-                      , subq_11.booking__ds__month
-                      , subq_11.booking__ds__quarter
-                      , subq_11.booking__ds__year
-                      , subq_11.booking__ds__extract_year
-                      , subq_11.booking__ds__extract_quarter
-                      , subq_11.booking__ds__extract_month
-                      , subq_11.booking__ds__extract_day
-                      , subq_11.booking__ds__extract_dow
-                      , subq_11.booking__ds__extract_doy
-                      , subq_11.booking__ds_partitioned__day
-                      , subq_11.booking__ds_partitioned__week
-                      , subq_11.booking__ds_partitioned__month
-                      , subq_11.booking__ds_partitioned__quarter
-                      , subq_11.booking__ds_partitioned__year
-                      , subq_11.booking__ds_partitioned__extract_year
-                      , subq_11.booking__ds_partitioned__extract_quarter
-                      , subq_11.booking__ds_partitioned__extract_month
-                      , subq_11.booking__ds_partitioned__extract_day
-                      , subq_11.booking__ds_partitioned__extract_dow
-                      , subq_11.booking__ds_partitioned__extract_doy
-                      , subq_11.booking__paid_at__day
-                      , subq_11.booking__paid_at__week
-                      , subq_11.booking__paid_at__month
-                      , subq_11.booking__paid_at__quarter
-                      , subq_11.booking__paid_at__year
-                      , subq_11.booking__paid_at__extract_year
-                      , subq_11.booking__paid_at__extract_quarter
-                      , subq_11.booking__paid_at__extract_month
-                      , subq_11.booking__paid_at__extract_day
-                      , subq_11.booking__paid_at__extract_dow
-                      , subq_11.booking__paid_at__extract_doy
-                      , subq_11.ds__day AS metric_time__day
-                      , subq_11.ds__week AS metric_time__week
-                      , subq_11.ds__month AS metric_time__month
-                      , subq_11.ds__quarter AS metric_time__quarter
-                      , subq_11.ds__year AS metric_time__year
-                      , subq_11.ds__extract_year AS metric_time__extract_year
-                      , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_11.ds__extract_month AS metric_time__extract_month
-                      , subq_11.ds__extract_day AS metric_time__extract_day
-                      , subq_11.ds__extract_dow AS metric_time__extract_dow
-                      , subq_11.ds__extract_doy AS metric_time__extract_doy
-                      , subq_11.listing
-                      , subq_11.guest
-                      , subq_11.host
-                      , subq_11.booking__listing
-                      , subq_11.booking__guest
-                      , subq_11.booking__host
-                      , subq_11.is_instant
-                      , subq_11.booking__is_instant
-                      , subq_11.bookings
-                      , subq_11.instant_bookings
-                      , subq_11.booking_value
-                      , subq_11.max_booking_value
-                      , subq_11.min_booking_value
-                      , subq_11.bookers
-                      , subq_11.average_booking_value
-                      , subq_11.referred_bookings
-                      , subq_11.median_booking_value
-                      , subq_11.booking_value_p99
-                      , subq_11.discrete_booking_value_p99
-                      , subq_11.approximate_continuous_booking_value_p99
-                      , subq_11.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -379,137 +379,137 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_11
-                  ) subq_12
-                ) subq_13
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_13.listing
-              ) subq_14
-            ) subq_15
-          ) subq_16
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_10.listing = subq_16.listing
+            subq_2.listing = subq_8.listing
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_21.listing
-              , subq_21.listing__bookers
+              subq_13.listing
+              , subq_13.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing
-                , subq_20.bookers AS listing__bookers
+                subq_12.listing
+                , subq_12.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing
-                  , COUNT(DISTINCT subq_19.bookers) AS bookers
+                  subq_11.listing
+                  , COUNT(DISTINCT subq_11.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_18.listing
-                    , subq_18.bookers
+                    subq_10.listing
+                    , subq_10.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.ds_partitioned__day
-                      , subq_17.ds_partitioned__week
-                      , subq_17.ds_partitioned__month
-                      , subq_17.ds_partitioned__quarter
-                      , subq_17.ds_partitioned__year
-                      , subq_17.ds_partitioned__extract_year
-                      , subq_17.ds_partitioned__extract_quarter
-                      , subq_17.ds_partitioned__extract_month
-                      , subq_17.ds_partitioned__extract_day
-                      , subq_17.ds_partitioned__extract_dow
-                      , subq_17.ds_partitioned__extract_doy
-                      , subq_17.paid_at__day
-                      , subq_17.paid_at__week
-                      , subq_17.paid_at__month
-                      , subq_17.paid_at__quarter
-                      , subq_17.paid_at__year
-                      , subq_17.paid_at__extract_year
-                      , subq_17.paid_at__extract_quarter
-                      , subq_17.paid_at__extract_month
-                      , subq_17.paid_at__extract_day
-                      , subq_17.paid_at__extract_dow
-                      , subq_17.paid_at__extract_doy
-                      , subq_17.booking__ds__day
-                      , subq_17.booking__ds__week
-                      , subq_17.booking__ds__month
-                      , subq_17.booking__ds__quarter
-                      , subq_17.booking__ds__year
-                      , subq_17.booking__ds__extract_year
-                      , subq_17.booking__ds__extract_quarter
-                      , subq_17.booking__ds__extract_month
-                      , subq_17.booking__ds__extract_day
-                      , subq_17.booking__ds__extract_dow
-                      , subq_17.booking__ds__extract_doy
-                      , subq_17.booking__ds_partitioned__day
-                      , subq_17.booking__ds_partitioned__week
-                      , subq_17.booking__ds_partitioned__month
-                      , subq_17.booking__ds_partitioned__quarter
-                      , subq_17.booking__ds_partitioned__year
-                      , subq_17.booking__ds_partitioned__extract_year
-                      , subq_17.booking__ds_partitioned__extract_quarter
-                      , subq_17.booking__ds_partitioned__extract_month
-                      , subq_17.booking__ds_partitioned__extract_day
-                      , subq_17.booking__ds_partitioned__extract_dow
-                      , subq_17.booking__ds_partitioned__extract_doy
-                      , subq_17.booking__paid_at__day
-                      , subq_17.booking__paid_at__week
-                      , subq_17.booking__paid_at__month
-                      , subq_17.booking__paid_at__quarter
-                      , subq_17.booking__paid_at__year
-                      , subq_17.booking__paid_at__extract_year
-                      , subq_17.booking__paid_at__extract_quarter
-                      , subq_17.booking__paid_at__extract_month
-                      , subq_17.booking__paid_at__extract_day
-                      , subq_17.booking__paid_at__extract_dow
-                      , subq_17.booking__paid_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.guest
-                      , subq_17.host
-                      , subq_17.booking__listing
-                      , subq_17.booking__guest
-                      , subq_17.booking__host
-                      , subq_17.is_instant
-                      , subq_17.booking__is_instant
-                      , subq_17.bookings
-                      , subq_17.instant_bookings
-                      , subq_17.booking_value
-                      , subq_17.max_booking_value
-                      , subq_17.min_booking_value
-                      , subq_17.bookers
-                      , subq_17.average_booking_value
-                      , subq_17.referred_bookings
-                      , subq_17.median_booking_value
-                      , subq_17.booking_value_p99
-                      , subq_17.discrete_booking_value_p99
-                      , subq_17.approximate_continuous_booking_value_p99
-                      , subq_17.approximate_discrete_booking_value_p99
+                      subq_9.ds__day
+                      , subq_9.ds__week
+                      , subq_9.ds__month
+                      , subq_9.ds__quarter
+                      , subq_9.ds__year
+                      , subq_9.ds__extract_year
+                      , subq_9.ds__extract_quarter
+                      , subq_9.ds__extract_month
+                      , subq_9.ds__extract_day
+                      , subq_9.ds__extract_dow
+                      , subq_9.ds__extract_doy
+                      , subq_9.ds_partitioned__day
+                      , subq_9.ds_partitioned__week
+                      , subq_9.ds_partitioned__month
+                      , subq_9.ds_partitioned__quarter
+                      , subq_9.ds_partitioned__year
+                      , subq_9.ds_partitioned__extract_year
+                      , subq_9.ds_partitioned__extract_quarter
+                      , subq_9.ds_partitioned__extract_month
+                      , subq_9.ds_partitioned__extract_day
+                      , subq_9.ds_partitioned__extract_dow
+                      , subq_9.ds_partitioned__extract_doy
+                      , subq_9.paid_at__day
+                      , subq_9.paid_at__week
+                      , subq_9.paid_at__month
+                      , subq_9.paid_at__quarter
+                      , subq_9.paid_at__year
+                      , subq_9.paid_at__extract_year
+                      , subq_9.paid_at__extract_quarter
+                      , subq_9.paid_at__extract_month
+                      , subq_9.paid_at__extract_day
+                      , subq_9.paid_at__extract_dow
+                      , subq_9.paid_at__extract_doy
+                      , subq_9.booking__ds__day
+                      , subq_9.booking__ds__week
+                      , subq_9.booking__ds__month
+                      , subq_9.booking__ds__quarter
+                      , subq_9.booking__ds__year
+                      , subq_9.booking__ds__extract_year
+                      , subq_9.booking__ds__extract_quarter
+                      , subq_9.booking__ds__extract_month
+                      , subq_9.booking__ds__extract_day
+                      , subq_9.booking__ds__extract_dow
+                      , subq_9.booking__ds__extract_doy
+                      , subq_9.booking__ds_partitioned__day
+                      , subq_9.booking__ds_partitioned__week
+                      , subq_9.booking__ds_partitioned__month
+                      , subq_9.booking__ds_partitioned__quarter
+                      , subq_9.booking__ds_partitioned__year
+                      , subq_9.booking__ds_partitioned__extract_year
+                      , subq_9.booking__ds_partitioned__extract_quarter
+                      , subq_9.booking__ds_partitioned__extract_month
+                      , subq_9.booking__ds_partitioned__extract_day
+                      , subq_9.booking__ds_partitioned__extract_dow
+                      , subq_9.booking__ds_partitioned__extract_doy
+                      , subq_9.booking__paid_at__day
+                      , subq_9.booking__paid_at__week
+                      , subq_9.booking__paid_at__month
+                      , subq_9.booking__paid_at__quarter
+                      , subq_9.booking__paid_at__year
+                      , subq_9.booking__paid_at__extract_year
+                      , subq_9.booking__paid_at__extract_quarter
+                      , subq_9.booking__paid_at__extract_month
+                      , subq_9.booking__paid_at__extract_day
+                      , subq_9.booking__paid_at__extract_dow
+                      , subq_9.booking__paid_at__extract_doy
+                      , subq_9.ds__day AS metric_time__day
+                      , subq_9.ds__week AS metric_time__week
+                      , subq_9.ds__month AS metric_time__month
+                      , subq_9.ds__quarter AS metric_time__quarter
+                      , subq_9.ds__year AS metric_time__year
+                      , subq_9.ds__extract_year AS metric_time__extract_year
+                      , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_9.ds__extract_month AS metric_time__extract_month
+                      , subq_9.ds__extract_day AS metric_time__extract_day
+                      , subq_9.ds__extract_dow AS metric_time__extract_dow
+                      , subq_9.ds__extract_doy AS metric_time__extract_doy
+                      , subq_9.listing
+                      , subq_9.guest
+                      , subq_9.host
+                      , subq_9.booking__listing
+                      , subq_9.booking__guest
+                      , subq_9.booking__host
+                      , subq_9.is_instant
+                      , subq_9.booking__is_instant
+                      , subq_9.bookings
+                      , subq_9.instant_bookings
+                      , subq_9.booking_value
+                      , subq_9.max_booking_value
+                      , subq_9.min_booking_value
+                      , subq_9.bookers
+                      , subq_9.average_booking_value
+                      , subq_9.referred_bookings
+                      , subq_9.median_booking_value
+                      , subq_9.booking_value_p99
+                      , subq_9.discrete_booking_value_p99
+                      , subq_9.approximate_continuous_booking_value_p99
+                      , subq_9.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -602,19 +602,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_9
+                  ) subq_10
+                ) subq_11
                 GROUP BY
-                  subq_19.listing
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_11.listing
+              ) subq_12
+            ) subq_13
+          ) subq_14
           ON
-            subq_10.listing = subq_22.listing
-        ) subq_23
-      ) subq_24
+            subq_2.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       WHERE listing__bookings > 2 AND listing__bookers > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_17
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_44.listing__bookings AS listing__bookings
-    , subq_50.listing__bookers AS listing__bookers
-    , subq_38.listings AS listings
+    subq_28.listing__bookings AS listing__bookings
+    , subq_34.listing__bookers AS listing__bookers
+    , subq_22.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_38
+  ) subq_22
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_41
+    ) subq_25
     GROUP BY
       listing
-  ) subq_44
+  ) subq_28
   ON
-    subq_38.listing = subq_44.listing
+    subq_22.listing = subq_28.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_50
+  ) subq_34
   ON
-    subq_38.listing = subq_50.listing
-) subq_52
+    subq_22.listing = subq_34.listing
+) subq_36
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__bookings_per_booker
-        , subq_28.listings
+        subq_17.listing__bookings_per_booker
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
         SELECT
-          subq_27.listing__bookings_per_booker
-          , subq_27.listings
+          subq_16.listing__bookings_per_booker
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__bookings_per_booker AS listing__bookings_per_booker
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings_per_booker']
             SELECT
-              subq_25.listing
-              , subq_25.listing__bookings_per_booker
+              subq_14.listing
+              , subq_14.listing__bookings_per_booker
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
-                , CAST(subq_24.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_24.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
+                subq_13.listing
+                , CAST(subq_13.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.bookings) AS bookings
-                  , MAX(subq_23.bookers) AS bookers
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.bookings) AS bookings
+                  , MAX(subq_12.bookers) AS bookers
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.bookings
+                    subq_6.listing
+                    , subq_6.bookings
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.bookings) AS bookings
+                      subq_5.listing
+                      , SUM(subq_5.bookings) AS bookings
                     FROM (
                       -- Pass Only Elements: ['bookings', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.bookings
+                        subq_4.listing
+                        , subq_4.bookings
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,129 +387,129 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.bookers
+                    subq_11.listing
+                    , subq_11.bookers
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , COUNT(DISTINCT subq_21.bookers) AS bookers
+                      subq_10.listing
+                      , COUNT(DISTINCT subq_10.bookers) AS bookers
                     FROM (
                       -- Pass Only Elements: ['bookers', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.bookers
+                        subq_9.listing
+                        , subq_9.bookers
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.paid_at__day
-                          , subq_19.paid_at__week
-                          , subq_19.paid_at__month
-                          , subq_19.paid_at__quarter
-                          , subq_19.paid_at__year
-                          , subq_19.paid_at__extract_year
-                          , subq_19.paid_at__extract_quarter
-                          , subq_19.paid_at__extract_month
-                          , subq_19.paid_at__extract_day
-                          , subq_19.paid_at__extract_dow
-                          , subq_19.paid_at__extract_doy
-                          , subq_19.booking__ds__day
-                          , subq_19.booking__ds__week
-                          , subq_19.booking__ds__month
-                          , subq_19.booking__ds__quarter
-                          , subq_19.booking__ds__year
-                          , subq_19.booking__ds__extract_year
-                          , subq_19.booking__ds__extract_quarter
-                          , subq_19.booking__ds__extract_month
-                          , subq_19.booking__ds__extract_day
-                          , subq_19.booking__ds__extract_dow
-                          , subq_19.booking__ds__extract_doy
-                          , subq_19.booking__ds_partitioned__day
-                          , subq_19.booking__ds_partitioned__week
-                          , subq_19.booking__ds_partitioned__month
-                          , subq_19.booking__ds_partitioned__quarter
-                          , subq_19.booking__ds_partitioned__year
-                          , subq_19.booking__ds_partitioned__extract_year
-                          , subq_19.booking__ds_partitioned__extract_quarter
-                          , subq_19.booking__ds_partitioned__extract_month
-                          , subq_19.booking__ds_partitioned__extract_day
-                          , subq_19.booking__ds_partitioned__extract_dow
-                          , subq_19.booking__ds_partitioned__extract_doy
-                          , subq_19.booking__paid_at__day
-                          , subq_19.booking__paid_at__week
-                          , subq_19.booking__paid_at__month
-                          , subq_19.booking__paid_at__quarter
-                          , subq_19.booking__paid_at__year
-                          , subq_19.booking__paid_at__extract_year
-                          , subq_19.booking__paid_at__extract_quarter
-                          , subq_19.booking__paid_at__extract_month
-                          , subq_19.booking__paid_at__extract_day
-                          , subq_19.booking__paid_at__extract_dow
-                          , subq_19.booking__paid_at__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.guest
-                          , subq_19.host
-                          , subq_19.booking__listing
-                          , subq_19.booking__guest
-                          , subq_19.booking__host
-                          , subq_19.is_instant
-                          , subq_19.booking__is_instant
-                          , subq_19.bookings
-                          , subq_19.instant_bookings
-                          , subq_19.booking_value
-                          , subq_19.max_booking_value
-                          , subq_19.min_booking_value
-                          , subq_19.bookers
-                          , subq_19.average_booking_value
-                          , subq_19.referred_bookings
-                          , subq_19.median_booking_value
-                          , subq_19.booking_value_p99
-                          , subq_19.discrete_booking_value_p99
-                          , subq_19.approximate_continuous_booking_value_p99
-                          , subq_19.approximate_discrete_booking_value_p99
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.paid_at__day
+                          , subq_8.paid_at__week
+                          , subq_8.paid_at__month
+                          , subq_8.paid_at__quarter
+                          , subq_8.paid_at__year
+                          , subq_8.paid_at__extract_year
+                          , subq_8.paid_at__extract_quarter
+                          , subq_8.paid_at__extract_month
+                          , subq_8.paid_at__extract_day
+                          , subq_8.paid_at__extract_dow
+                          , subq_8.paid_at__extract_doy
+                          , subq_8.booking__ds__day
+                          , subq_8.booking__ds__week
+                          , subq_8.booking__ds__month
+                          , subq_8.booking__ds__quarter
+                          , subq_8.booking__ds__year
+                          , subq_8.booking__ds__extract_year
+                          , subq_8.booking__ds__extract_quarter
+                          , subq_8.booking__ds__extract_month
+                          , subq_8.booking__ds__extract_day
+                          , subq_8.booking__ds__extract_dow
+                          , subq_8.booking__ds__extract_doy
+                          , subq_8.booking__ds_partitioned__day
+                          , subq_8.booking__ds_partitioned__week
+                          , subq_8.booking__ds_partitioned__month
+                          , subq_8.booking__ds_partitioned__quarter
+                          , subq_8.booking__ds_partitioned__year
+                          , subq_8.booking__ds_partitioned__extract_year
+                          , subq_8.booking__ds_partitioned__extract_quarter
+                          , subq_8.booking__ds_partitioned__extract_month
+                          , subq_8.booking__ds_partitioned__extract_day
+                          , subq_8.booking__ds_partitioned__extract_dow
+                          , subq_8.booking__ds_partitioned__extract_doy
+                          , subq_8.booking__paid_at__day
+                          , subq_8.booking__paid_at__week
+                          , subq_8.booking__paid_at__month
+                          , subq_8.booking__paid_at__quarter
+                          , subq_8.booking__paid_at__year
+                          , subq_8.booking__paid_at__extract_year
+                          , subq_8.booking__paid_at__extract_quarter
+                          , subq_8.booking__paid_at__extract_month
+                          , subq_8.booking__paid_at__extract_day
+                          , subq_8.booking__paid_at__extract_dow
+                          , subq_8.booking__paid_at__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.guest
+                          , subq_8.host
+                          , subq_8.booking__listing
+                          , subq_8.booking__guest
+                          , subq_8.booking__host
+                          , subq_8.is_instant
+                          , subq_8.booking__is_instant
+                          , subq_8.bookings
+                          , subq_8.instant_bookings
+                          , subq_8.booking_value
+                          , subq_8.max_booking_value
+                          , subq_8.min_booking_value
+                          , subq_8.bookers
+                          , subq_8.average_booking_value
+                          , subq_8.referred_bookings
+                          , subq_8.median_booking_value
+                          , subq_8.booking_value_p99
+                          , subq_8.discrete_booking_value_p99
+                          , subq_8.approximate_continuous_booking_value_p99
+                          , subq_8.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -602,25 +602,25 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__bookings_per_booker > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_56.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
-    , subq_45.listings AS listings
+    CAST(subq_34.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_50.listing, subq_55.listing) AS listing
-      , MAX(subq_50.bookings) AS bookings
-      , MAX(subq_55.bookers) AS bookers
+      COALESCE(subq_28.listing, subq_33.listing) AS listing
+      , MAX(subq_28.bookings) AS bookings
+      , MAX(subq_33.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_48
+      ) subq_26
       GROUP BY
         listing
-    ) subq_50
+    ) subq_28
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_55
+    ) subq_33
     ON
-      subq_50.listing = subq_55.listing
+      subq_28.listing = subq_33.listing
     GROUP BY
-      COALESCE(subq_50.listing, subq_55.listing)
-  ) subq_56
+      COALESCE(subq_28.listing, subq_33.listing)
+  ) subq_34
   ON
-    subq_45.listing = subq_56.listing
-) subq_60
+    subq_23.listing = subq_34.listing
+) subq_38
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings']
         SELECT
-          subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,130 +160,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -376,19 +376,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -1,20 +1,20 @@
 -- Pass Only Elements: ['listing',]
 SELECT
-  subq_12.listing
+  subq_8.listing
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_11.listing
-    , subq_11.lux_listing
-    , subq_11.listing__lux_listing
-    , subq_11.listing__bookings
+    subq_7.listing
+    , subq_7.lux_listing
+    , subq_7.listing__lux_listing
+    , subq_7.listing__bookings
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_4.listing AS listing
-      , subq_4.lux_listing AS lux_listing
-      , subq_4.listing__lux_listing AS listing__lux_listing
-      , subq_10.listing__bookings AS listing__bookings
+      subq_0.listing AS listing
+      , subq_0.lux_listing AS lux_listing
+      , subq_0.listing__lux_listing AS listing__lux_listing
+      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT
@@ -22,128 +22,128 @@ FROM (
         , lux_listing_mapping_src_28000.lux_listing_id AS lux_listing
         , lux_listing_mapping_src_28000.lux_listing_id AS listing__lux_listing
       FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
-    ) subq_4
+    ) subq_0
     FULL OUTER JOIN (
       -- Pass Only Elements: ['listing', 'listing__bookings']
       SELECT
-        subq_9.listing
-        , subq_9.listing__bookings
+        subq_5.listing
+        , subq_5.listing__bookings
       FROM (
         -- Compute Metrics via Expressions
         SELECT
-          subq_8.listing
-          , subq_8.bookings AS listing__bookings
+          subq_4.listing
+          , subq_4.bookings AS listing__bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_7.listing
-            , SUM(subq_7.bookings) AS bookings
+            subq_3.listing
+            , SUM(subq_3.bookings) AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'listing']
             SELECT
-              subq_6.listing
-              , subq_6.bookings
+              subq_2.listing
+              , subq_2.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds__day
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.ds__extract_year
-                , subq_5.ds__extract_quarter
-                , subq_5.ds__extract_month
-                , subq_5.ds__extract_day
-                , subq_5.ds__extract_dow
-                , subq_5.ds__extract_doy
-                , subq_5.ds_partitioned__day
-                , subq_5.ds_partitioned__week
-                , subq_5.ds_partitioned__month
-                , subq_5.ds_partitioned__quarter
-                , subq_5.ds_partitioned__year
-                , subq_5.ds_partitioned__extract_year
-                , subq_5.ds_partitioned__extract_quarter
-                , subq_5.ds_partitioned__extract_month
-                , subq_5.ds_partitioned__extract_day
-                , subq_5.ds_partitioned__extract_dow
-                , subq_5.ds_partitioned__extract_doy
-                , subq_5.paid_at__day
-                , subq_5.paid_at__week
-                , subq_5.paid_at__month
-                , subq_5.paid_at__quarter
-                , subq_5.paid_at__year
-                , subq_5.paid_at__extract_year
-                , subq_5.paid_at__extract_quarter
-                , subq_5.paid_at__extract_month
-                , subq_5.paid_at__extract_day
-                , subq_5.paid_at__extract_dow
-                , subq_5.paid_at__extract_doy
-                , subq_5.booking__ds__day
-                , subq_5.booking__ds__week
-                , subq_5.booking__ds__month
-                , subq_5.booking__ds__quarter
-                , subq_5.booking__ds__year
-                , subq_5.booking__ds__extract_year
-                , subq_5.booking__ds__extract_quarter
-                , subq_5.booking__ds__extract_month
-                , subq_5.booking__ds__extract_day
-                , subq_5.booking__ds__extract_dow
-                , subq_5.booking__ds__extract_doy
-                , subq_5.booking__ds_partitioned__day
-                , subq_5.booking__ds_partitioned__week
-                , subq_5.booking__ds_partitioned__month
-                , subq_5.booking__ds_partitioned__quarter
-                , subq_5.booking__ds_partitioned__year
-                , subq_5.booking__ds_partitioned__extract_year
-                , subq_5.booking__ds_partitioned__extract_quarter
-                , subq_5.booking__ds_partitioned__extract_month
-                , subq_5.booking__ds_partitioned__extract_day
-                , subq_5.booking__ds_partitioned__extract_dow
-                , subq_5.booking__ds_partitioned__extract_doy
-                , subq_5.booking__paid_at__day
-                , subq_5.booking__paid_at__week
-                , subq_5.booking__paid_at__month
-                , subq_5.booking__paid_at__quarter
-                , subq_5.booking__paid_at__year
-                , subq_5.booking__paid_at__extract_year
-                , subq_5.booking__paid_at__extract_quarter
-                , subq_5.booking__paid_at__extract_month
-                , subq_5.booking__paid_at__extract_day
-                , subq_5.booking__paid_at__extract_dow
-                , subq_5.booking__paid_at__extract_doy
-                , subq_5.ds__day AS metric_time__day
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.ds__extract_year AS metric_time__extract_year
-                , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_5.ds__extract_month AS metric_time__extract_month
-                , subq_5.ds__extract_day AS metric_time__extract_day
-                , subq_5.ds__extract_dow AS metric_time__extract_dow
-                , subq_5.ds__extract_doy AS metric_time__extract_doy
-                , subq_5.listing
-                , subq_5.guest
-                , subq_5.host
-                , subq_5.booking__listing
-                , subq_5.booking__guest
-                , subq_5.booking__host
-                , subq_5.is_instant
-                , subq_5.booking__is_instant
-                , subq_5.bookings
-                , subq_5.instant_bookings
-                , subq_5.booking_value
-                , subq_5.max_booking_value
-                , subq_5.min_booking_value
-                , subq_5.bookers
-                , subq_5.average_booking_value
-                , subq_5.referred_bookings
-                , subq_5.median_booking_value
-                , subq_5.booking_value_p99
-                , subq_5.discrete_booking_value_p99
-                , subq_5.approximate_continuous_booking_value_p99
-                , subq_5.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.ds__day AS metric_time__day
+                , subq_1.ds__week AS metric_time__week
+                , subq_1.ds__month AS metric_time__month
+                , subq_1.ds__quarter AS metric_time__quarter
+                , subq_1.ds__year AS metric_time__year
+                , subq_1.ds__extract_year AS metric_time__extract_year
+                , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_1.ds__extract_month AS metric_time__extract_month
+                , subq_1.ds__extract_day AS metric_time__extract_day
+                , subq_1.ds__extract_dow AS metric_time__extract_dow
+                , subq_1.ds__extract_doy AS metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -236,18 +236,18 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_5
-            ) subq_6
-          ) subq_7
+              ) subq_1
+            ) subq_2
+          ) subq_3
           GROUP BY
-            subq_7.listing
-        ) subq_8
-      ) subq_9
-    ) subq_10
+            subq_3.listing
+        ) subq_4
+      ) subq_5
+    ) subq_6
     ON
-      subq_4.listing = subq_10.listing
-  ) subq_11
+      subq_0.listing = subq_6.listing
+  ) subq_7
   WHERE listing__bookings > 2
-) subq_12
+) subq_8
 GROUP BY
-  subq_12.listing
+  subq_8.listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_23.listing__bookings AS listing__bookings
+    , subq_15.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+    ) subq_12
     GROUP BY
       listing
-  ) subq_23
+  ) subq_15
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_23.listing
-) subq_24
+    lux_listing_mapping_src_28000.listing_id = subq_15.listing
+) subq_16
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.guest__booking_value
-        , subq_14.bookers
+        subq_10.guest__booking_value
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'guest__booking_value']
         SELECT
-          subq_13.guest__booking_value
-          , subq_13.bookers
+          subq_9.guest__booking_value
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.guest AS guest
-            , subq_12.guest__booking_value AS guest__booking_value
-            , subq_6.bookers AS bookers
+            subq_2.guest AS guest
+            , subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']
             SELECT
-              subq_5.guest
-              , subq_5.bookers
+              subq_1.guest
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['guest', 'guest__booking_value']
             SELECT
-              subq_11.guest
-              , subq_11.guest__booking_value
+              subq_7.guest
+              , subq_7.guest__booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.guest
-                , subq_10.booking_value AS guest__booking_value
+                subq_6.guest
+                , subq_6.booking_value AS guest__booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.guest
-                  , SUM(subq_9.booking_value) AS booking_value
+                  subq_5.guest
+                  , SUM(subq_5.booking_value) AS booking_value
                 FROM (
                   -- Pass Only Elements: ['booking_value', 'guest']
                   SELECT
-                    subq_8.guest
-                    , subq_8.booking_value
+                    subq_4.guest
+                    , subq_4.booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.guest
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.guest
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.guest = subq_12.guest
-        ) subq_13
-      ) subq_14
+            subq_2.guest = subq_8.guest
+        ) subq_9
+      ) subq_10
       WHERE guest__booking_value > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_30.guest__booking_value AS guest__booking_value
-    , subq_24.bookers AS bookers
+    subq_22.guest__booking_value AS guest__booking_value
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.guest = subq_30.guest
-) subq_32
+    subq_16.guest = subq_22.guest
+) subq_24
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_39.listings
+  subq_24.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_38.listings) AS listings
+    SUM(subq_23.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_37.listings
+      subq_22.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_36.user__visit_buy_conversion_rate
-        , subq_36.listings
+        subq_21.user__visit_buy_conversion_rate
+        , subq_21.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
         SELECT
-          subq_35.user__visit_buy_conversion_rate
-          , subq_35.listings
+          subq_20.user__visit_buy_conversion_rate
+          , subq_20.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_17.user AS user
-            , subq_34.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
-            , subq_17.listings AS listings
+            subq_2.user AS user
+            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_16.user
-              , subq_16.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_15.ds__day
-                , subq_15.ds__week
-                , subq_15.ds__month
-                , subq_15.ds__quarter
-                , subq_15.ds__year
-                , subq_15.ds__extract_year
-                , subq_15.ds__extract_quarter
-                , subq_15.ds__extract_month
-                , subq_15.ds__extract_day
-                , subq_15.ds__extract_dow
-                , subq_15.ds__extract_doy
-                , subq_15.created_at__day
-                , subq_15.created_at__week
-                , subq_15.created_at__month
-                , subq_15.created_at__quarter
-                , subq_15.created_at__year
-                , subq_15.created_at__extract_year
-                , subq_15.created_at__extract_quarter
-                , subq_15.created_at__extract_month
-                , subq_15.created_at__extract_day
-                , subq_15.created_at__extract_dow
-                , subq_15.created_at__extract_doy
-                , subq_15.listing__ds__day
-                , subq_15.listing__ds__week
-                , subq_15.listing__ds__month
-                , subq_15.listing__ds__quarter
-                , subq_15.listing__ds__year
-                , subq_15.listing__ds__extract_year
-                , subq_15.listing__ds__extract_quarter
-                , subq_15.listing__ds__extract_month
-                , subq_15.listing__ds__extract_day
-                , subq_15.listing__ds__extract_dow
-                , subq_15.listing__ds__extract_doy
-                , subq_15.listing__created_at__day
-                , subq_15.listing__created_at__week
-                , subq_15.listing__created_at__month
-                , subq_15.listing__created_at__quarter
-                , subq_15.listing__created_at__year
-                , subq_15.listing__created_at__extract_year
-                , subq_15.listing__created_at__extract_quarter
-                , subq_15.listing__created_at__extract_month
-                , subq_15.listing__created_at__extract_day
-                , subq_15.listing__created_at__extract_dow
-                , subq_15.listing__created_at__extract_doy
-                , subq_15.ds__day AS metric_time__day
-                , subq_15.ds__week AS metric_time__week
-                , subq_15.ds__month AS metric_time__month
-                , subq_15.ds__quarter AS metric_time__quarter
-                , subq_15.ds__year AS metric_time__year
-                , subq_15.ds__extract_year AS metric_time__extract_year
-                , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_15.ds__extract_month AS metric_time__extract_month
-                , subq_15.ds__extract_day AS metric_time__extract_day
-                , subq_15.ds__extract_dow AS metric_time__extract_dow
-                , subq_15.ds__extract_doy AS metric_time__extract_doy
-                , subq_15.listing
-                , subq_15.user
-                , subq_15.listing__user
-                , subq_15.country_latest
-                , subq_15.is_lux_latest
-                , subq_15.capacity_latest
-                , subq_15.listing__country_latest
-                , subq_15.listing__is_lux_latest
-                , subq_15.listing__capacity_latest
-                , subq_15.listings
-                , subq_15.largest_listing
-                , subq_15.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,79 +160,79 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_15
-            ) subq_16
-          ) subq_17
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__visit_buy_conversion_rate']
             SELECT
-              subq_33.user
-              , subq_33.user__visit_buy_conversion_rate
+              subq_18.user
+              , subq_18.user__visit_buy_conversion_rate
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_32.user
-                , CAST(subq_32.buys AS DOUBLE) / CAST(NULLIF(subq_32.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+                subq_17.user
+                , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_21.user, subq_31.user) AS user
-                  , MAX(subq_21.visits) AS visits
-                  , MAX(subq_31.buys) AS buys
+                  COALESCE(subq_6.user, subq_16.user) AS user
+                  , MAX(subq_6.visits) AS visits
+                  , MAX(subq_16.buys) AS buys
                 FROM (
                   -- Aggregate Measures
                   SELECT
-                    subq_20.user
-                    , SUM(subq_20.visits) AS visits
+                    subq_5.user
+                    , SUM(subq_5.visits) AS visits
                   FROM (
                     -- Pass Only Elements: ['visits', 'user']
                     SELECT
-                      subq_19.user
-                      , subq_19.visits
+                      subq_4.user
+                      , subq_4.visits
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_18.ds__day
-                        , subq_18.ds__week
-                        , subq_18.ds__month
-                        , subq_18.ds__quarter
-                        , subq_18.ds__year
-                        , subq_18.ds__extract_year
-                        , subq_18.ds__extract_quarter
-                        , subq_18.ds__extract_month
-                        , subq_18.ds__extract_day
-                        , subq_18.ds__extract_dow
-                        , subq_18.ds__extract_doy
-                        , subq_18.visit__ds__day
-                        , subq_18.visit__ds__week
-                        , subq_18.visit__ds__month
-                        , subq_18.visit__ds__quarter
-                        , subq_18.visit__ds__year
-                        , subq_18.visit__ds__extract_year
-                        , subq_18.visit__ds__extract_quarter
-                        , subq_18.visit__ds__extract_month
-                        , subq_18.visit__ds__extract_day
-                        , subq_18.visit__ds__extract_dow
-                        , subq_18.visit__ds__extract_doy
-                        , subq_18.ds__day AS metric_time__day
-                        , subq_18.ds__week AS metric_time__week
-                        , subq_18.ds__month AS metric_time__month
-                        , subq_18.ds__quarter AS metric_time__quarter
-                        , subq_18.ds__year AS metric_time__year
-                        , subq_18.ds__extract_year AS metric_time__extract_year
-                        , subq_18.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_18.ds__extract_month AS metric_time__extract_month
-                        , subq_18.ds__extract_day AS metric_time__extract_day
-                        , subq_18.ds__extract_dow AS metric_time__extract_dow
-                        , subq_18.ds__extract_doy AS metric_time__extract_doy
-                        , subq_18.user
-                        , subq_18.session
-                        , subq_18.visit__user
-                        , subq_18.visit__session
-                        , subq_18.referrer_id
-                        , subq_18.visit__referrer_id
-                        , subq_18.visits
-                        , subq_18.visitors
+                        subq_3.ds__day
+                        , subq_3.ds__week
+                        , subq_3.ds__month
+                        , subq_3.ds__quarter
+                        , subq_3.ds__year
+                        , subq_3.ds__extract_year
+                        , subq_3.ds__extract_quarter
+                        , subq_3.ds__extract_month
+                        , subq_3.ds__extract_day
+                        , subq_3.ds__extract_dow
+                        , subq_3.ds__extract_doy
+                        , subq_3.visit__ds__day
+                        , subq_3.visit__ds__week
+                        , subq_3.visit__ds__month
+                        , subq_3.visit__ds__quarter
+                        , subq_3.visit__ds__year
+                        , subq_3.visit__ds__extract_year
+                        , subq_3.visit__ds__extract_quarter
+                        , subq_3.visit__ds__extract_month
+                        , subq_3.visit__ds__extract_day
+                        , subq_3.visit__ds__extract_dow
+                        , subq_3.visit__ds__extract_doy
+                        , subq_3.ds__day AS metric_time__day
+                        , subq_3.ds__week AS metric_time__week
+                        , subq_3.ds__month AS metric_time__month
+                        , subq_3.ds__quarter AS metric_time__quarter
+                        , subq_3.ds__year AS metric_time__year
+                        , subq_3.ds__extract_year AS metric_time__extract_year
+                        , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_3.ds__extract_month AS metric_time__extract_month
+                        , subq_3.ds__extract_day AS metric_time__extract_day
+                        , subq_3.ds__extract_dow AS metric_time__extract_dow
+                        , subq_3.ds__extract_doy AS metric_time__extract_doy
+                        , subq_3.user
+                        , subq_3.session
+                        , subq_3.visit__user
+                        , subq_3.visit__session
+                        , subq_3.referrer_id
+                        , subq_3.visit__referrer_id
+                        , subq_3.visits
+                        , subq_3.visitors
                       FROM (
                         -- Read Elements From Semantic Model 'visits_source'
                         SELECT
@@ -267,108 +267,108 @@ FROM (
                           , visits_source_src_28000.user_id AS visit__user
                           , visits_source_src_28000.session_id AS visit__session
                         FROM ***************************.fct_visits visits_source_src_28000
-                      ) subq_18
-                    ) subq_19
-                  ) subq_20
+                      ) subq_3
+                    ) subq_4
+                  ) subq_5
                   GROUP BY
-                    subq_20.user
-                ) subq_21
+                    subq_5.user
+                ) subq_6
                 FULL OUTER JOIN (
                   -- Aggregate Measures
                   SELECT
-                    subq_30.user
-                    , SUM(subq_30.buys) AS buys
+                    subq_15.user
+                    , SUM(subq_15.buys) AS buys
                   FROM (
                     -- Pass Only Elements: ['buys', 'user']
                     SELECT
-                      subq_29.user
-                      , subq_29.buys
+                      subq_14.user
+                      , subq_14.buys
                     FROM (
                       -- Find conversions for user within the range of INF
                       SELECT
-                        subq_28.ds__day
-                        , subq_28.user
-                        , subq_28.buys
-                        , subq_28.visits
+                        subq_13.ds__day
+                        , subq_13.user
+                        , subq_13.buys
+                        , subq_13.visits
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          FIRST_VALUE(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_9.visits) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , FIRST_VALUE(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_9.ds__day) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , FIRST_VALUE(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_9.user) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS user
-                          , subq_27.mf_internal_uuid AS mf_internal_uuid
-                          , subq_27.buys AS buys
+                          , subq_12.mf_internal_uuid AS mf_internal_uuid
+                          , subq_12.buys AS buys
                         FROM (
                           -- Pass Only Elements: ['visits', 'ds__day', 'user']
                           SELECT
-                            subq_23.ds__day
-                            , subq_23.user
-                            , subq_23.visits
+                            subq_8.ds__day
+                            , subq_8.user
+                            , subq_8.visits
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_22.ds__day
-                              , subq_22.ds__week
-                              , subq_22.ds__month
-                              , subq_22.ds__quarter
-                              , subq_22.ds__year
-                              , subq_22.ds__extract_year
-                              , subq_22.ds__extract_quarter
-                              , subq_22.ds__extract_month
-                              , subq_22.ds__extract_day
-                              , subq_22.ds__extract_dow
-                              , subq_22.ds__extract_doy
-                              , subq_22.visit__ds__day
-                              , subq_22.visit__ds__week
-                              , subq_22.visit__ds__month
-                              , subq_22.visit__ds__quarter
-                              , subq_22.visit__ds__year
-                              , subq_22.visit__ds__extract_year
-                              , subq_22.visit__ds__extract_quarter
-                              , subq_22.visit__ds__extract_month
-                              , subq_22.visit__ds__extract_day
-                              , subq_22.visit__ds__extract_dow
-                              , subq_22.visit__ds__extract_doy
-                              , subq_22.ds__day AS metric_time__day
-                              , subq_22.ds__week AS metric_time__week
-                              , subq_22.ds__month AS metric_time__month
-                              , subq_22.ds__quarter AS metric_time__quarter
-                              , subq_22.ds__year AS metric_time__year
-                              , subq_22.ds__extract_year AS metric_time__extract_year
-                              , subq_22.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_22.ds__extract_month AS metric_time__extract_month
-                              , subq_22.ds__extract_day AS metric_time__extract_day
-                              , subq_22.ds__extract_dow AS metric_time__extract_dow
-                              , subq_22.ds__extract_doy AS metric_time__extract_doy
-                              , subq_22.user
-                              , subq_22.session
-                              , subq_22.visit__user
-                              , subq_22.visit__session
-                              , subq_22.referrer_id
-                              , subq_22.visit__referrer_id
-                              , subq_22.visits
-                              , subq_22.visitors
+                              subq_7.ds__day
+                              , subq_7.ds__week
+                              , subq_7.ds__month
+                              , subq_7.ds__quarter
+                              , subq_7.ds__year
+                              , subq_7.ds__extract_year
+                              , subq_7.ds__extract_quarter
+                              , subq_7.ds__extract_month
+                              , subq_7.ds__extract_day
+                              , subq_7.ds__extract_dow
+                              , subq_7.ds__extract_doy
+                              , subq_7.visit__ds__day
+                              , subq_7.visit__ds__week
+                              , subq_7.visit__ds__month
+                              , subq_7.visit__ds__quarter
+                              , subq_7.visit__ds__year
+                              , subq_7.visit__ds__extract_year
+                              , subq_7.visit__ds__extract_quarter
+                              , subq_7.visit__ds__extract_month
+                              , subq_7.visit__ds__extract_day
+                              , subq_7.visit__ds__extract_dow
+                              , subq_7.visit__ds__extract_doy
+                              , subq_7.ds__day AS metric_time__day
+                              , subq_7.ds__week AS metric_time__week
+                              , subq_7.ds__month AS metric_time__month
+                              , subq_7.ds__quarter AS metric_time__quarter
+                              , subq_7.ds__year AS metric_time__year
+                              , subq_7.ds__extract_year AS metric_time__extract_year
+                              , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_7.ds__extract_month AS metric_time__extract_month
+                              , subq_7.ds__extract_day AS metric_time__extract_day
+                              , subq_7.ds__extract_dow AS metric_time__extract_dow
+                              , subq_7.ds__extract_doy AS metric_time__extract_doy
+                              , subq_7.user
+                              , subq_7.session
+                              , subq_7.visit__user
+                              , subq_7.visit__session
+                              , subq_7.referrer_id
+                              , subq_7.visit__referrer_id
+                              , subq_7.visits
+                              , subq_7.visitors
                             FROM (
                               -- Read Elements From Semantic Model 'visits_source'
                               SELECT
@@ -403,94 +403,94 @@ FROM (
                                 , visits_source_src_28000.user_id AS visit__user
                                 , visits_source_src_28000.session_id AS visit__session
                               FROM ***************************.fct_visits visits_source_src_28000
-                            ) subq_22
-                          ) subq_23
-                        ) subq_24
+                            ) subq_7
+                          ) subq_8
+                        ) subq_9
                         INNER JOIN (
                           -- Add column with generated UUID
                           SELECT
-                            subq_26.ds__day
-                            , subq_26.ds__week
-                            , subq_26.ds__month
-                            , subq_26.ds__quarter
-                            , subq_26.ds__year
-                            , subq_26.ds__extract_year
-                            , subq_26.ds__extract_quarter
-                            , subq_26.ds__extract_month
-                            , subq_26.ds__extract_day
-                            , subq_26.ds__extract_dow
-                            , subq_26.ds__extract_doy
-                            , subq_26.buy__ds__day
-                            , subq_26.buy__ds__week
-                            , subq_26.buy__ds__month
-                            , subq_26.buy__ds__quarter
-                            , subq_26.buy__ds__year
-                            , subq_26.buy__ds__extract_year
-                            , subq_26.buy__ds__extract_quarter
-                            , subq_26.buy__ds__extract_month
-                            , subq_26.buy__ds__extract_day
-                            , subq_26.buy__ds__extract_dow
-                            , subq_26.buy__ds__extract_doy
-                            , subq_26.metric_time__day
-                            , subq_26.metric_time__week
-                            , subq_26.metric_time__month
-                            , subq_26.metric_time__quarter
-                            , subq_26.metric_time__year
-                            , subq_26.metric_time__extract_year
-                            , subq_26.metric_time__extract_quarter
-                            , subq_26.metric_time__extract_month
-                            , subq_26.metric_time__extract_day
-                            , subq_26.metric_time__extract_dow
-                            , subq_26.metric_time__extract_doy
-                            , subq_26.user
-                            , subq_26.session_id
-                            , subq_26.buy__user
-                            , subq_26.buy__session_id
-                            , subq_26.buys
-                            , subq_26.buyers
+                            subq_11.ds__day
+                            , subq_11.ds__week
+                            , subq_11.ds__month
+                            , subq_11.ds__quarter
+                            , subq_11.ds__year
+                            , subq_11.ds__extract_year
+                            , subq_11.ds__extract_quarter
+                            , subq_11.ds__extract_month
+                            , subq_11.ds__extract_day
+                            , subq_11.ds__extract_dow
+                            , subq_11.ds__extract_doy
+                            , subq_11.buy__ds__day
+                            , subq_11.buy__ds__week
+                            , subq_11.buy__ds__month
+                            , subq_11.buy__ds__quarter
+                            , subq_11.buy__ds__year
+                            , subq_11.buy__ds__extract_year
+                            , subq_11.buy__ds__extract_quarter
+                            , subq_11.buy__ds__extract_month
+                            , subq_11.buy__ds__extract_day
+                            , subq_11.buy__ds__extract_dow
+                            , subq_11.buy__ds__extract_doy
+                            , subq_11.metric_time__day
+                            , subq_11.metric_time__week
+                            , subq_11.metric_time__month
+                            , subq_11.metric_time__quarter
+                            , subq_11.metric_time__year
+                            , subq_11.metric_time__extract_year
+                            , subq_11.metric_time__extract_quarter
+                            , subq_11.metric_time__extract_month
+                            , subq_11.metric_time__extract_day
+                            , subq_11.metric_time__extract_dow
+                            , subq_11.metric_time__extract_doy
+                            , subq_11.user
+                            , subq_11.session_id
+                            , subq_11.buy__user
+                            , subq_11.buy__session_id
+                            , subq_11.buys
+                            , subq_11.buyers
                             , UUID_STRING() AS mf_internal_uuid
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_25.ds__day
-                              , subq_25.ds__week
-                              , subq_25.ds__month
-                              , subq_25.ds__quarter
-                              , subq_25.ds__year
-                              , subq_25.ds__extract_year
-                              , subq_25.ds__extract_quarter
-                              , subq_25.ds__extract_month
-                              , subq_25.ds__extract_day
-                              , subq_25.ds__extract_dow
-                              , subq_25.ds__extract_doy
-                              , subq_25.buy__ds__day
-                              , subq_25.buy__ds__week
-                              , subq_25.buy__ds__month
-                              , subq_25.buy__ds__quarter
-                              , subq_25.buy__ds__year
-                              , subq_25.buy__ds__extract_year
-                              , subq_25.buy__ds__extract_quarter
-                              , subq_25.buy__ds__extract_month
-                              , subq_25.buy__ds__extract_day
-                              , subq_25.buy__ds__extract_dow
-                              , subq_25.buy__ds__extract_doy
-                              , subq_25.ds__day AS metric_time__day
-                              , subq_25.ds__week AS metric_time__week
-                              , subq_25.ds__month AS metric_time__month
-                              , subq_25.ds__quarter AS metric_time__quarter
-                              , subq_25.ds__year AS metric_time__year
-                              , subq_25.ds__extract_year AS metric_time__extract_year
-                              , subq_25.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_25.ds__extract_month AS metric_time__extract_month
-                              , subq_25.ds__extract_day AS metric_time__extract_day
-                              , subq_25.ds__extract_dow AS metric_time__extract_dow
-                              , subq_25.ds__extract_doy AS metric_time__extract_doy
-                              , subq_25.user
-                              , subq_25.session_id
-                              , subq_25.buy__user
-                              , subq_25.buy__session_id
-                              , subq_25.buys
-                              , subq_25.buyers
+                              subq_10.ds__day
+                              , subq_10.ds__week
+                              , subq_10.ds__month
+                              , subq_10.ds__quarter
+                              , subq_10.ds__year
+                              , subq_10.ds__extract_year
+                              , subq_10.ds__extract_quarter
+                              , subq_10.ds__extract_month
+                              , subq_10.ds__extract_day
+                              , subq_10.ds__extract_dow
+                              , subq_10.ds__extract_doy
+                              , subq_10.buy__ds__day
+                              , subq_10.buy__ds__week
+                              , subq_10.buy__ds__month
+                              , subq_10.buy__ds__quarter
+                              , subq_10.buy__ds__year
+                              , subq_10.buy__ds__extract_year
+                              , subq_10.buy__ds__extract_quarter
+                              , subq_10.buy__ds__extract_month
+                              , subq_10.buy__ds__extract_day
+                              , subq_10.buy__ds__extract_dow
+                              , subq_10.buy__ds__extract_doy
+                              , subq_10.ds__day AS metric_time__day
+                              , subq_10.ds__week AS metric_time__week
+                              , subq_10.ds__month AS metric_time__month
+                              , subq_10.ds__quarter AS metric_time__quarter
+                              , subq_10.ds__year AS metric_time__year
+                              , subq_10.ds__extract_year AS metric_time__extract_year
+                              , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_10.ds__extract_month AS metric_time__extract_month
+                              , subq_10.ds__extract_day AS metric_time__extract_day
+                              , subq_10.ds__extract_dow AS metric_time__extract_dow
+                              , subq_10.ds__extract_doy AS metric_time__extract_doy
+                              , subq_10.user
+                              , subq_10.session_id
+                              , subq_10.buy__user
+                              , subq_10.buy__session_id
+                              , subq_10.buys
+                              , subq_10.buyers
                             FROM (
                               -- Read Elements From Semantic Model 'buys_source'
                               SELECT
@@ -523,33 +523,33 @@ FROM (
                                 , buys_source_src_28000.user_id AS buy__user
                                 , buys_source_src_28000.session_id AS buy__session_id
                               FROM ***************************.fct_buys buys_source_src_28000
-                            ) subq_25
-                          ) subq_26
-                        ) subq_27
+                            ) subq_10
+                          ) subq_11
+                        ) subq_12
                         ON
                           (
-                            subq_24.user = subq_27.user
+                            subq_9.user = subq_12.user
                           ) AND (
-                            (subq_24.ds__day <= subq_27.ds__day)
+                            (subq_9.ds__day <= subq_12.ds__day)
                           )
-                      ) subq_28
-                    ) subq_29
-                  ) subq_30
+                      ) subq_13
+                    ) subq_14
+                  ) subq_15
                   GROUP BY
-                    subq_30.user
-                ) subq_31
+                    subq_15.user
+                ) subq_16
                 ON
-                  subq_21.user = subq_31.user
+                  subq_6.user = subq_16.user
                 GROUP BY
-                  COALESCE(subq_21.user, subq_31.user)
-              ) subq_32
-            ) subq_33
-          ) subq_34
+                  COALESCE(subq_6.user, subq_16.user)
+              ) subq_17
+            ) subq_18
+          ) subq_19
           ON
-            subq_17.user = subq_34.user
-        ) subq_35
-      ) subq_36
+            subq_2.user = subq_19.user
+        ) subq_20
+      ) subq_21
       WHERE user__visit_buy_conversion_rate > 2
-    ) subq_37
-  ) subq_38
-) subq_39
+    ) subq_22
+  ) subq_23
+) subq_24

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_72.buys AS DOUBLE) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
-    , subq_57.listings AS listings
+    CAST(subq_42.buys AS DOUBLE) / CAST(NULLIF(subq_42.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    , subq_27.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_57
+  ) subq_27
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_61.user, subq_71.user) AS user
-      , MAX(subq_61.visits) AS visits
-      , MAX(subq_71.buys) AS buys
+      COALESCE(subq_31.user, subq_41.user) AS user
+      , MAX(subq_31.visits) AS visits
+      , MAX(subq_41.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_60.user
+        subq_30.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_60
+      ) subq_30
       GROUP BY
-        subq_60.user
-    ) subq_61
+        subq_30.user
+    ) subq_31
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_68.user
+        subq_38.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_64.visits) OVER (
+          FIRST_VALUE(subq_34.visits) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_64.ds__day) OVER (
+          , FIRST_VALUE(subq_34.ds__day) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_64.user) OVER (
+          , FIRST_VALUE(subq_34.user) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_67.mf_internal_uuid AS mf_internal_uuid
-          , subq_67.buys AS buys
+          , subq_37.mf_internal_uuid AS mf_internal_uuid
+          , subq_37.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_64
+        ) subq_34
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , UUID_STRING() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_67
+        ) subq_37
         ON
           (
-            subq_64.user = subq_67.user
+            subq_34.user = subq_37.user
           ) AND (
-            (subq_64.ds__day <= subq_67.ds__day)
+            (subq_34.ds__day <= subq_37.ds__day)
           )
-      ) subq_68
+      ) subq_38
       GROUP BY
-        subq_68.user
-    ) subq_71
+        subq_38.user
+    ) subq_41
     ON
-      subq_61.user = subq_71.user
+      subq_31.user = subq_41.user
     GROUP BY
-      COALESCE(subq_61.user, subq_71.user)
-  ) subq_72
+      COALESCE(subq_31.user, subq_41.user)
+  ) subq_42
   ON
-    subq_57.user = subq_72.user
-) subq_76
+    subq_27.user = subq_42.user
+) subq_46
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0.sql
@@ -1,106 +1,106 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_18.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_17.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_16.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.user__listing__user__average_booking_value
-        , subq_24.listings
+        subq_15.user__listing__user__average_booking_value
+        , subq_15.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
         SELECT
-          subq_23.user__listing__user__average_booking_value
-          , subq_23.listings
+          subq_14.user__listing__user__average_booking_value
+          , subq_14.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.user AS user
-            , subq_22.listing__user AS user__listing__user
-            , subq_22.listing__user__average_booking_value AS user__listing__user__average_booking_value
-            , subq_11.listings AS listings
+            subq_2.user AS user
+            , subq_13.listing__user AS user__listing__user
+            , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_10.user
-              , subq_10.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds__day
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds__extract_year
-                , subq_9.ds__extract_quarter
-                , subq_9.ds__extract_month
-                , subq_9.ds__extract_day
-                , subq_9.ds__extract_dow
-                , subq_9.ds__extract_doy
-                , subq_9.created_at__day
-                , subq_9.created_at__week
-                , subq_9.created_at__month
-                , subq_9.created_at__quarter
-                , subq_9.created_at__year
-                , subq_9.created_at__extract_year
-                , subq_9.created_at__extract_quarter
-                , subq_9.created_at__extract_month
-                , subq_9.created_at__extract_day
-                , subq_9.created_at__extract_dow
-                , subq_9.created_at__extract_doy
-                , subq_9.listing__ds__day
-                , subq_9.listing__ds__week
-                , subq_9.listing__ds__month
-                , subq_9.listing__ds__quarter
-                , subq_9.listing__ds__year
-                , subq_9.listing__ds__extract_year
-                , subq_9.listing__ds__extract_quarter
-                , subq_9.listing__ds__extract_month
-                , subq_9.listing__ds__extract_day
-                , subq_9.listing__ds__extract_dow
-                , subq_9.listing__ds__extract_doy
-                , subq_9.listing__created_at__day
-                , subq_9.listing__created_at__week
-                , subq_9.listing__created_at__month
-                , subq_9.listing__created_at__quarter
-                , subq_9.listing__created_at__year
-                , subq_9.listing__created_at__extract_year
-                , subq_9.listing__created_at__extract_quarter
-                , subq_9.listing__created_at__extract_month
-                , subq_9.listing__created_at__extract_day
-                , subq_9.listing__created_at__extract_dow
-                , subq_9.listing__created_at__extract_doy
-                , subq_9.ds__day AS metric_time__day
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.ds__extract_year AS metric_time__extract_year
-                , subq_9.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.ds__extract_month AS metric_time__extract_month
-                , subq_9.ds__extract_day AS metric_time__extract_day
-                , subq_9.ds__extract_dow AS metric_time__extract_dow
-                , subq_9.ds__extract_doy AS metric_time__extract_doy
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.listing__user
-                , subq_9.country_latest
-                , subq_9.is_lux_latest
-                , subq_9.capacity_latest
-                , subq_9.listing__country_latest
-                , subq_9.listing__is_lux_latest
-                , subq_9.listing__capacity_latest
-                , subq_9.listings
-                , subq_9.largest_listing
-                , subq_9.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -161,141 +161,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
             SELECT
-              subq_21.listing__user
-              , subq_21.listing__user__average_booking_value
+              subq_12.listing__user
+              , subq_12.listing__user__average_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing__user
-                , subq_20.average_booking_value AS listing__user__average_booking_value
+                subq_11.listing__user
+                , subq_11.average_booking_value AS listing__user__average_booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing__user
-                  , AVG(subq_19.average_booking_value) AS average_booking_value
+                  subq_10.listing__user
+                  , AVG(subq_10.average_booking_value) AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'listing__user']
                   SELECT
-                    subq_18.listing__user
-                    , subq_18.average_booking_value
+                    subq_9.listing__user
+                    , subq_9.average_booking_value
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_14.listing AS listing
-                      , subq_17.user AS listing__user
-                      , subq_14.average_booking_value AS average_booking_value
+                      subq_5.listing AS listing
+                      , subq_8.user AS listing__user
+                      , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']
                       SELECT
-                        subq_13.listing
-                        , subq_13.average_booking_value
+                        subq_4.listing
+                        , subq_4.average_booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_12.ds__day
-                          , subq_12.ds__week
-                          , subq_12.ds__month
-                          , subq_12.ds__quarter
-                          , subq_12.ds__year
-                          , subq_12.ds__extract_year
-                          , subq_12.ds__extract_quarter
-                          , subq_12.ds__extract_month
-                          , subq_12.ds__extract_day
-                          , subq_12.ds__extract_dow
-                          , subq_12.ds__extract_doy
-                          , subq_12.ds_partitioned__day
-                          , subq_12.ds_partitioned__week
-                          , subq_12.ds_partitioned__month
-                          , subq_12.ds_partitioned__quarter
-                          , subq_12.ds_partitioned__year
-                          , subq_12.ds_partitioned__extract_year
-                          , subq_12.ds_partitioned__extract_quarter
-                          , subq_12.ds_partitioned__extract_month
-                          , subq_12.ds_partitioned__extract_day
-                          , subq_12.ds_partitioned__extract_dow
-                          , subq_12.ds_partitioned__extract_doy
-                          , subq_12.paid_at__day
-                          , subq_12.paid_at__week
-                          , subq_12.paid_at__month
-                          , subq_12.paid_at__quarter
-                          , subq_12.paid_at__year
-                          , subq_12.paid_at__extract_year
-                          , subq_12.paid_at__extract_quarter
-                          , subq_12.paid_at__extract_month
-                          , subq_12.paid_at__extract_day
-                          , subq_12.paid_at__extract_dow
-                          , subq_12.paid_at__extract_doy
-                          , subq_12.booking__ds__day
-                          , subq_12.booking__ds__week
-                          , subq_12.booking__ds__month
-                          , subq_12.booking__ds__quarter
-                          , subq_12.booking__ds__year
-                          , subq_12.booking__ds__extract_year
-                          , subq_12.booking__ds__extract_quarter
-                          , subq_12.booking__ds__extract_month
-                          , subq_12.booking__ds__extract_day
-                          , subq_12.booking__ds__extract_dow
-                          , subq_12.booking__ds__extract_doy
-                          , subq_12.booking__ds_partitioned__day
-                          , subq_12.booking__ds_partitioned__week
-                          , subq_12.booking__ds_partitioned__month
-                          , subq_12.booking__ds_partitioned__quarter
-                          , subq_12.booking__ds_partitioned__year
-                          , subq_12.booking__ds_partitioned__extract_year
-                          , subq_12.booking__ds_partitioned__extract_quarter
-                          , subq_12.booking__ds_partitioned__extract_month
-                          , subq_12.booking__ds_partitioned__extract_day
-                          , subq_12.booking__ds_partitioned__extract_dow
-                          , subq_12.booking__ds_partitioned__extract_doy
-                          , subq_12.booking__paid_at__day
-                          , subq_12.booking__paid_at__week
-                          , subq_12.booking__paid_at__month
-                          , subq_12.booking__paid_at__quarter
-                          , subq_12.booking__paid_at__year
-                          , subq_12.booking__paid_at__extract_year
-                          , subq_12.booking__paid_at__extract_quarter
-                          , subq_12.booking__paid_at__extract_month
-                          , subq_12.booking__paid_at__extract_day
-                          , subq_12.booking__paid_at__extract_dow
-                          , subq_12.booking__paid_at__extract_doy
-                          , subq_12.ds__day AS metric_time__day
-                          , subq_12.ds__week AS metric_time__week
-                          , subq_12.ds__month AS metric_time__month
-                          , subq_12.ds__quarter AS metric_time__quarter
-                          , subq_12.ds__year AS metric_time__year
-                          , subq_12.ds__extract_year AS metric_time__extract_year
-                          , subq_12.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_12.ds__extract_month AS metric_time__extract_month
-                          , subq_12.ds__extract_day AS metric_time__extract_day
-                          , subq_12.ds__extract_dow AS metric_time__extract_dow
-                          , subq_12.ds__extract_doy AS metric_time__extract_doy
-                          , subq_12.listing
-                          , subq_12.guest
-                          , subq_12.host
-                          , subq_12.booking__listing
-                          , subq_12.booking__guest
-                          , subq_12.booking__host
-                          , subq_12.is_instant
-                          , subq_12.booking__is_instant
-                          , subq_12.bookings
-                          , subq_12.instant_bookings
-                          , subq_12.booking_value
-                          , subq_12.max_booking_value
-                          , subq_12.min_booking_value
-                          , subq_12.bookers
-                          , subq_12.average_booking_value
-                          , subq_12.referred_bookings
-                          , subq_12.median_booking_value
-                          , subq_12.booking_value_p99
-                          , subq_12.discrete_booking_value_p99
-                          , subq_12.approximate_continuous_booking_value_p99
-                          , subq_12.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -388,84 +388,84 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_12
-                      ) subq_13
-                    ) subq_14
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['listing', 'user']
                       SELECT
-                        subq_16.listing
-                        , subq_16.user
+                        subq_7.listing
+                        , subq_7.user
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_15.ds__day
-                          , subq_15.ds__week
-                          , subq_15.ds__month
-                          , subq_15.ds__quarter
-                          , subq_15.ds__year
-                          , subq_15.ds__extract_year
-                          , subq_15.ds__extract_quarter
-                          , subq_15.ds__extract_month
-                          , subq_15.ds__extract_day
-                          , subq_15.ds__extract_dow
-                          , subq_15.ds__extract_doy
-                          , subq_15.created_at__day
-                          , subq_15.created_at__week
-                          , subq_15.created_at__month
-                          , subq_15.created_at__quarter
-                          , subq_15.created_at__year
-                          , subq_15.created_at__extract_year
-                          , subq_15.created_at__extract_quarter
-                          , subq_15.created_at__extract_month
-                          , subq_15.created_at__extract_day
-                          , subq_15.created_at__extract_dow
-                          , subq_15.created_at__extract_doy
-                          , subq_15.listing__ds__day
-                          , subq_15.listing__ds__week
-                          , subq_15.listing__ds__month
-                          , subq_15.listing__ds__quarter
-                          , subq_15.listing__ds__year
-                          , subq_15.listing__ds__extract_year
-                          , subq_15.listing__ds__extract_quarter
-                          , subq_15.listing__ds__extract_month
-                          , subq_15.listing__ds__extract_day
-                          , subq_15.listing__ds__extract_dow
-                          , subq_15.listing__ds__extract_doy
-                          , subq_15.listing__created_at__day
-                          , subq_15.listing__created_at__week
-                          , subq_15.listing__created_at__month
-                          , subq_15.listing__created_at__quarter
-                          , subq_15.listing__created_at__year
-                          , subq_15.listing__created_at__extract_year
-                          , subq_15.listing__created_at__extract_quarter
-                          , subq_15.listing__created_at__extract_month
-                          , subq_15.listing__created_at__extract_day
-                          , subq_15.listing__created_at__extract_dow
-                          , subq_15.listing__created_at__extract_doy
-                          , subq_15.ds__day AS metric_time__day
-                          , subq_15.ds__week AS metric_time__week
-                          , subq_15.ds__month AS metric_time__month
-                          , subq_15.ds__quarter AS metric_time__quarter
-                          , subq_15.ds__year AS metric_time__year
-                          , subq_15.ds__extract_year AS metric_time__extract_year
-                          , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_15.ds__extract_month AS metric_time__extract_month
-                          , subq_15.ds__extract_day AS metric_time__extract_day
-                          , subq_15.ds__extract_dow AS metric_time__extract_dow
-                          , subq_15.ds__extract_doy AS metric_time__extract_doy
-                          , subq_15.listing
-                          , subq_15.user
-                          , subq_15.listing__user
-                          , subq_15.country_latest
-                          , subq_15.is_lux_latest
-                          , subq_15.capacity_latest
-                          , subq_15.listing__country_latest
-                          , subq_15.listing__is_lux_latest
-                          , subq_15.listing__capacity_latest
-                          , subq_15.listings
-                          , subq_15.largest_listing
-                          , subq_15.smallest_listing
+                          subq_6.ds__day
+                          , subq_6.ds__week
+                          , subq_6.ds__month
+                          , subq_6.ds__quarter
+                          , subq_6.ds__year
+                          , subq_6.ds__extract_year
+                          , subq_6.ds__extract_quarter
+                          , subq_6.ds__extract_month
+                          , subq_6.ds__extract_day
+                          , subq_6.ds__extract_dow
+                          , subq_6.ds__extract_doy
+                          , subq_6.created_at__day
+                          , subq_6.created_at__week
+                          , subq_6.created_at__month
+                          , subq_6.created_at__quarter
+                          , subq_6.created_at__year
+                          , subq_6.created_at__extract_year
+                          , subq_6.created_at__extract_quarter
+                          , subq_6.created_at__extract_month
+                          , subq_6.created_at__extract_day
+                          , subq_6.created_at__extract_dow
+                          , subq_6.created_at__extract_doy
+                          , subq_6.listing__ds__day
+                          , subq_6.listing__ds__week
+                          , subq_6.listing__ds__month
+                          , subq_6.listing__ds__quarter
+                          , subq_6.listing__ds__year
+                          , subq_6.listing__ds__extract_year
+                          , subq_6.listing__ds__extract_quarter
+                          , subq_6.listing__ds__extract_month
+                          , subq_6.listing__ds__extract_day
+                          , subq_6.listing__ds__extract_dow
+                          , subq_6.listing__ds__extract_doy
+                          , subq_6.listing__created_at__day
+                          , subq_6.listing__created_at__week
+                          , subq_6.listing__created_at__month
+                          , subq_6.listing__created_at__quarter
+                          , subq_6.listing__created_at__year
+                          , subq_6.listing__created_at__extract_year
+                          , subq_6.listing__created_at__extract_quarter
+                          , subq_6.listing__created_at__extract_month
+                          , subq_6.listing__created_at__extract_day
+                          , subq_6.listing__created_at__extract_dow
+                          , subq_6.listing__created_at__extract_doy
+                          , subq_6.ds__day AS metric_time__day
+                          , subq_6.ds__week AS metric_time__week
+                          , subq_6.ds__month AS metric_time__month
+                          , subq_6.ds__quarter AS metric_time__quarter
+                          , subq_6.ds__year AS metric_time__year
+                          , subq_6.ds__extract_year AS metric_time__extract_year
+                          , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_6.ds__extract_month AS metric_time__extract_month
+                          , subq_6.ds__extract_day AS metric_time__extract_day
+                          , subq_6.ds__extract_dow AS metric_time__extract_dow
+                          , subq_6.ds__extract_doy AS metric_time__extract_doy
+                          , subq_6.listing
+                          , subq_6.user
+                          , subq_6.listing__user
+                          , subq_6.country_latest
+                          , subq_6.is_lux_latest
+                          , subq_6.capacity_latest
+                          , subq_6.listing__country_latest
+                          , subq_6.listing__is_lux_latest
+                          , subq_6.listing__capacity_latest
+                          , subq_6.listings
+                          , subq_6.largest_listing
+                          , subq_6.smallest_listing
                         FROM (
                           -- Read Elements From Semantic Model 'listings_latest'
                           SELECT
@@ -526,23 +526,23 @@ FROM (
                             , listings_latest_src_28000.user_id AS user
                             , listings_latest_src_28000.user_id AS listing__user
                           FROM ***************************.dim_listings_latest listings_latest_src_28000
-                        ) subq_15
-                      ) subq_16
-                    ) subq_17
+                        ) subq_6
+                      ) subq_7
+                    ) subq_8
                     ON
-                      subq_14.listing = subq_17.listing
-                  ) subq_18
-                ) subq_19
+                      subq_5.listing = subq_8.listing
+                  ) subq_9
+                ) subq_10
                 GROUP BY
-                  subq_19.listing__user
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_10.listing__user
+              ) subq_11
+            ) subq_12
+          ) subq_13
           ON
-            subq_11.user = subq_22.listing__user
-        ) subq_23
-      ) subq_24
+            subq_2.user = subq_13.listing__user
+        ) subq_14
+      ) subq_15
       WHERE user__listing__user__average_booking_value > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_16
+  ) subq_17
+) subq_18

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_39.listings AS listings
+    subq_32.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_21.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_39
+  ) subq_21
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_50
+  ) subq_32
   ON
-    subq_39.user = subq_50.listing__user
-) subq_52
+    subq_21.user = subq_32.listing__user
+) subq_34
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_multi_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_40.third_hop_count
+  subq_22.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_39.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_21.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_38.third_hop_count
+      subq_20.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_37.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-        , subq_37.third_hop_count
+        subq_19.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+        , subq_19.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
         SELECT
-          subq_36.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-          , subq_36.third_hop_count
+          subq_18.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+          , subq_18.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_20.customer_third_hop_id AS customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-            , subq_20.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_19.customer_third_hop_id
-              , subq_19.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_18.third_hop_ds__day
-                , subq_18.third_hop_ds__week
-                , subq_18.third_hop_ds__month
-                , subq_18.third_hop_ds__quarter
-                , subq_18.third_hop_ds__year
-                , subq_18.third_hop_ds__extract_year
-                , subq_18.third_hop_ds__extract_quarter
-                , subq_18.third_hop_ds__extract_month
-                , subq_18.third_hop_ds__extract_day
-                , subq_18.third_hop_ds__extract_dow
-                , subq_18.third_hop_ds__extract_doy
-                , subq_18.customer_third_hop_id__third_hop_ds__day
-                , subq_18.customer_third_hop_id__third_hop_ds__week
-                , subq_18.customer_third_hop_id__third_hop_ds__month
-                , subq_18.customer_third_hop_id__third_hop_ds__quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_18.third_hop_ds__day AS metric_time__day
-                , subq_18.third_hop_ds__week AS metric_time__week
-                , subq_18.third_hop_ds__month AS metric_time__month
-                , subq_18.third_hop_ds__quarter AS metric_time__quarter
-                , subq_18.third_hop_ds__year AS metric_time__year
-                , subq_18.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_18.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_18.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_18.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_18.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_18.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_18.customer_third_hop_id
-                , subq_18.value
-                , subq_18.customer_third_hop_id__value
-                , subq_18.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,105 +101,105 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_18
-            ) subq_19
-          ) subq_20
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
             SELECT
-              subq_34.account_id__customer_id__customer_third_hop_id
-              , subq_34.account_id__customer_id__customer_third_hop_id__txn_count
+              subq_16.account_id__customer_id__customer_third_hop_id
+              , subq_16.account_id__customer_id__customer_third_hop_id__txn_count
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_33.account_id__customer_id__customer_third_hop_id
-                , subq_33.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
+                subq_15.account_id__customer_id__customer_third_hop_id
+                , subq_15.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_32.account_id__customer_id__customer_third_hop_id
-                  , SUM(subq_32.txn_count) AS txn_count
+                  subq_14.account_id__customer_id__customer_third_hop_id
+                  , SUM(subq_14.txn_count) AS txn_count
                 FROM (
                   -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_third_hop_id']
                   SELECT
-                    subq_31.account_id__customer_id__customer_third_hop_id
-                    , subq_31.txn_count
+                    subq_13.account_id__customer_id__customer_third_hop_id
+                    , subq_13.txn_count
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_23.ds_partitioned__day AS ds_partitioned__day
-                      , subq_30.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_23.account_id AS account_id
-                      , subq_30.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
-                      , subq_23.txn_count AS txn_count
+                      subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
+                      , subq_5.account_id AS account_id
+                      , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
                       SELECT
-                        subq_22.ds_partitioned__day
-                        , subq_22.account_id
-                        , subq_22.txn_count
+                        subq_4.ds_partitioned__day
+                        , subq_4.account_id
+                        , subq_4.txn_count
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_21.ds_partitioned__day
-                          , subq_21.ds_partitioned__week
-                          , subq_21.ds_partitioned__month
-                          , subq_21.ds_partitioned__quarter
-                          , subq_21.ds_partitioned__year
-                          , subq_21.ds_partitioned__extract_year
-                          , subq_21.ds_partitioned__extract_quarter
-                          , subq_21.ds_partitioned__extract_month
-                          , subq_21.ds_partitioned__extract_day
-                          , subq_21.ds_partitioned__extract_dow
-                          , subq_21.ds_partitioned__extract_doy
-                          , subq_21.ds__day
-                          , subq_21.ds__week
-                          , subq_21.ds__month
-                          , subq_21.ds__quarter
-                          , subq_21.ds__year
-                          , subq_21.ds__extract_year
-                          , subq_21.ds__extract_quarter
-                          , subq_21.ds__extract_month
-                          , subq_21.ds__extract_day
-                          , subq_21.ds__extract_dow
-                          , subq_21.ds__extract_doy
-                          , subq_21.account_id__ds_partitioned__day
-                          , subq_21.account_id__ds_partitioned__week
-                          , subq_21.account_id__ds_partitioned__month
-                          , subq_21.account_id__ds_partitioned__quarter
-                          , subq_21.account_id__ds_partitioned__year
-                          , subq_21.account_id__ds_partitioned__extract_year
-                          , subq_21.account_id__ds_partitioned__extract_quarter
-                          , subq_21.account_id__ds_partitioned__extract_month
-                          , subq_21.account_id__ds_partitioned__extract_day
-                          , subq_21.account_id__ds_partitioned__extract_dow
-                          , subq_21.account_id__ds_partitioned__extract_doy
-                          , subq_21.account_id__ds__day
-                          , subq_21.account_id__ds__week
-                          , subq_21.account_id__ds__month
-                          , subq_21.account_id__ds__quarter
-                          , subq_21.account_id__ds__year
-                          , subq_21.account_id__ds__extract_year
-                          , subq_21.account_id__ds__extract_quarter
-                          , subq_21.account_id__ds__extract_month
-                          , subq_21.account_id__ds__extract_day
-                          , subq_21.account_id__ds__extract_dow
-                          , subq_21.account_id__ds__extract_doy
-                          , subq_21.ds__day AS metric_time__day
-                          , subq_21.ds__week AS metric_time__week
-                          , subq_21.ds__month AS metric_time__month
-                          , subq_21.ds__quarter AS metric_time__quarter
-                          , subq_21.ds__year AS metric_time__year
-                          , subq_21.ds__extract_year AS metric_time__extract_year
-                          , subq_21.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_21.ds__extract_month AS metric_time__extract_month
-                          , subq_21.ds__extract_day AS metric_time__extract_day
-                          , subq_21.ds__extract_dow AS metric_time__extract_dow
-                          , subq_21.ds__extract_doy AS metric_time__extract_doy
-                          , subq_21.account_id
-                          , subq_21.account_month
-                          , subq_21.account_id__account_month
-                          , subq_21.txn_count
+                          subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.account_id__ds_partitioned__day
+                          , subq_3.account_id__ds_partitioned__week
+                          , subq_3.account_id__ds_partitioned__month
+                          , subq_3.account_id__ds_partitioned__quarter
+                          , subq_3.account_id__ds_partitioned__year
+                          , subq_3.account_id__ds_partitioned__extract_year
+                          , subq_3.account_id__ds_partitioned__extract_quarter
+                          , subq_3.account_id__ds_partitioned__extract_month
+                          , subq_3.account_id__ds_partitioned__extract_day
+                          , subq_3.account_id__ds_partitioned__extract_dow
+                          , subq_3.account_id__ds_partitioned__extract_doy
+                          , subq_3.account_id__ds__day
+                          , subq_3.account_id__ds__week
+                          , subq_3.account_id__ds__month
+                          , subq_3.account_id__ds__quarter
+                          , subq_3.account_id__ds__year
+                          , subq_3.account_id__ds__extract_year
+                          , subq_3.account_id__ds__extract_quarter
+                          , subq_3.account_id__ds__extract_month
+                          , subq_3.account_id__ds__extract_day
+                          , subq_3.account_id__ds__extract_dow
+                          , subq_3.account_id__ds__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.account_id
+                          , subq_3.account_month
+                          , subq_3.account_id__account_month
+                          , subq_3.txn_count
                         FROM (
                           -- Read Elements From Semantic Model 'account_month_txns'
                           SELECT
@@ -252,164 +252,164 @@ FROM (
                             , account_month_txns_src_22000.account_month AS account_id__account_month
                             , account_month_txns_src_22000.account_id
                           FROM ***************************.account_month_txns account_month_txns_src_22000
-                        ) subq_21
-                      ) subq_22
-                    ) subq_23
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['ds_partitioned__day', 'account_id', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_29.ds_partitioned__day
-                        , subq_29.account_id
-                        , subq_29.customer_id__customer_third_hop_id
+                        subq_11.ds_partitioned__day
+                        , subq_11.account_id
+                        , subq_11.customer_id__customer_third_hop_id
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_25.ds_partitioned__day AS ds_partitioned__day
-                          , subq_25.ds_partitioned__week AS ds_partitioned__week
-                          , subq_25.ds_partitioned__month AS ds_partitioned__month
-                          , subq_25.ds_partitioned__quarter AS ds_partitioned__quarter
-                          , subq_25.ds_partitioned__year AS ds_partitioned__year
-                          , subq_25.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                          , subq_25.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                          , subq_25.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                          , subq_25.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                          , subq_25.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                          , subq_25.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                          , subq_25.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-                          , subq_25.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-                          , subq_25.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-                          , subq_25.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-                          , subq_25.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-                          , subq_25.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-                          , subq_25.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-                          , subq_25.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-                          , subq_25.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-                          , subq_25.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-                          , subq_25.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-                          , subq_25.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-                          , subq_25.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-                          , subq_25.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-                          , subq_25.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-                          , subq_25.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-                          , subq_25.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-                          , subq_25.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-                          , subq_25.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-                          , subq_25.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-                          , subq_25.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-                          , subq_25.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-                          , subq_25.metric_time__day AS metric_time__day
-                          , subq_25.metric_time__week AS metric_time__week
-                          , subq_25.metric_time__month AS metric_time__month
-                          , subq_25.metric_time__quarter AS metric_time__quarter
-                          , subq_25.metric_time__year AS metric_time__year
-                          , subq_25.metric_time__extract_year AS metric_time__extract_year
-                          , subq_25.metric_time__extract_quarter AS metric_time__extract_quarter
-                          , subq_25.metric_time__extract_month AS metric_time__extract_month
-                          , subq_25.metric_time__extract_day AS metric_time__extract_day
-                          , subq_25.metric_time__extract_dow AS metric_time__extract_dow
-                          , subq_25.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_28.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_28.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_28.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_28.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_28.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_28.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_28.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_28.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_28.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_28.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_28.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_28.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_28.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_28.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_28.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_28.metric_time__day AS customer_id__metric_time__day
-                          , subq_28.metric_time__week AS customer_id__metric_time__week
-                          , subq_28.metric_time__month AS customer_id__metric_time__month
-                          , subq_28.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_28.metric_time__year AS customer_id__metric_time__year
-                          , subq_28.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_28.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_28.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_28.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_28.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_28.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-                          , subq_25.account_id AS account_id
-                          , subq_25.customer_id AS customer_id
-                          , subq_25.account_id__customer_id AS account_id__customer_id
-                          , subq_25.bridge_account__account_id AS bridge_account__account_id
-                          , subq_25.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_28.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_28.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
-                          , subq_25.extra_dim AS extra_dim
-                          , subq_25.account_id__extra_dim AS account_id__extra_dim
-                          , subq_25.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_28.country AS customer_id__country
-                          , subq_28.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
-                          , subq_25.account_customer_combos AS account_customer_combos
+                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          , subq_7.ds_partitioned__week AS ds_partitioned__week
+                          , subq_7.ds_partitioned__month AS ds_partitioned__month
+                          , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+                          , subq_7.ds_partitioned__year AS ds_partitioned__year
+                          , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                          , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                          , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                          , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                          , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                          , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                          , subq_7.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+                          , subq_7.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+                          , subq_7.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+                          , subq_7.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+                          , subq_7.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+                          , subq_7.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+                          , subq_7.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+                          , subq_7.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+                          , subq_7.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+                          , subq_7.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+                          , subq_7.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+                          , subq_7.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+                          , subq_7.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+                          , subq_7.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+                          , subq_7.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+                          , subq_7.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+                          , subq_7.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+                          , subq_7.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+                          , subq_7.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+                          , subq_7.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+                          , subq_7.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+                          , subq_7.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+                          , subq_7.metric_time__day AS metric_time__day
+                          , subq_7.metric_time__week AS metric_time__week
+                          , subq_7.metric_time__month AS metric_time__month
+                          , subq_7.metric_time__quarter AS metric_time__quarter
+                          , subq_7.metric_time__year AS metric_time__year
+                          , subq_7.metric_time__extract_year AS metric_time__extract_year
+                          , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+                          , subq_7.metric_time__extract_month AS metric_time__extract_month
+                          , subq_7.metric_time__extract_day AS metric_time__extract_day
+                          , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+                          , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_7.account_id AS account_id
+                          , subq_7.customer_id AS customer_id
+                          , subq_7.account_id__customer_id AS account_id__customer_id
+                          , subq_7.bridge_account__account_id AS bridge_account__account_id
+                          , subq_7.bridge_account__customer_id AS bridge_account__customer_id
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.extra_dim AS extra_dim
+                          , subq_7.account_id__extra_dim AS account_id__extra_dim
+                          , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
+                          , subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'
                           SELECT
-                            subq_24.ds_partitioned__day
-                            , subq_24.ds_partitioned__week
-                            , subq_24.ds_partitioned__month
-                            , subq_24.ds_partitioned__quarter
-                            , subq_24.ds_partitioned__year
-                            , subq_24.ds_partitioned__extract_year
-                            , subq_24.ds_partitioned__extract_quarter
-                            , subq_24.ds_partitioned__extract_month
-                            , subq_24.ds_partitioned__extract_day
-                            , subq_24.ds_partitioned__extract_dow
-                            , subq_24.ds_partitioned__extract_doy
-                            , subq_24.account_id__ds_partitioned__day
-                            , subq_24.account_id__ds_partitioned__week
-                            , subq_24.account_id__ds_partitioned__month
-                            , subq_24.account_id__ds_partitioned__quarter
-                            , subq_24.account_id__ds_partitioned__year
-                            , subq_24.account_id__ds_partitioned__extract_year
-                            , subq_24.account_id__ds_partitioned__extract_quarter
-                            , subq_24.account_id__ds_partitioned__extract_month
-                            , subq_24.account_id__ds_partitioned__extract_day
-                            , subq_24.account_id__ds_partitioned__extract_dow
-                            , subq_24.account_id__ds_partitioned__extract_doy
-                            , subq_24.bridge_account__ds_partitioned__day
-                            , subq_24.bridge_account__ds_partitioned__week
-                            , subq_24.bridge_account__ds_partitioned__month
-                            , subq_24.bridge_account__ds_partitioned__quarter
-                            , subq_24.bridge_account__ds_partitioned__year
-                            , subq_24.bridge_account__ds_partitioned__extract_year
-                            , subq_24.bridge_account__ds_partitioned__extract_quarter
-                            , subq_24.bridge_account__ds_partitioned__extract_month
-                            , subq_24.bridge_account__ds_partitioned__extract_day
-                            , subq_24.bridge_account__ds_partitioned__extract_dow
-                            , subq_24.bridge_account__ds_partitioned__extract_doy
-                            , subq_24.ds_partitioned__day AS metric_time__day
-                            , subq_24.ds_partitioned__week AS metric_time__week
-                            , subq_24.ds_partitioned__month AS metric_time__month
-                            , subq_24.ds_partitioned__quarter AS metric_time__quarter
-                            , subq_24.ds_partitioned__year AS metric_time__year
-                            , subq_24.ds_partitioned__extract_year AS metric_time__extract_year
-                            , subq_24.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                            , subq_24.ds_partitioned__extract_month AS metric_time__extract_month
-                            , subq_24.ds_partitioned__extract_day AS metric_time__extract_day
-                            , subq_24.ds_partitioned__extract_dow AS metric_time__extract_dow
-                            , subq_24.ds_partitioned__extract_doy AS metric_time__extract_doy
-                            , subq_24.account_id
-                            , subq_24.customer_id
-                            , subq_24.account_id__customer_id
-                            , subq_24.bridge_account__account_id
-                            , subq_24.bridge_account__customer_id
-                            , subq_24.extra_dim
-                            , subq_24.account_id__extra_dim
-                            , subq_24.bridge_account__extra_dim
-                            , subq_24.account_customer_combos
+                            subq_6.ds_partitioned__day
+                            , subq_6.ds_partitioned__week
+                            , subq_6.ds_partitioned__month
+                            , subq_6.ds_partitioned__quarter
+                            , subq_6.ds_partitioned__year
+                            , subq_6.ds_partitioned__extract_year
+                            , subq_6.ds_partitioned__extract_quarter
+                            , subq_6.ds_partitioned__extract_month
+                            , subq_6.ds_partitioned__extract_day
+                            , subq_6.ds_partitioned__extract_dow
+                            , subq_6.ds_partitioned__extract_doy
+                            , subq_6.account_id__ds_partitioned__day
+                            , subq_6.account_id__ds_partitioned__week
+                            , subq_6.account_id__ds_partitioned__month
+                            , subq_6.account_id__ds_partitioned__quarter
+                            , subq_6.account_id__ds_partitioned__year
+                            , subq_6.account_id__ds_partitioned__extract_year
+                            , subq_6.account_id__ds_partitioned__extract_quarter
+                            , subq_6.account_id__ds_partitioned__extract_month
+                            , subq_6.account_id__ds_partitioned__extract_day
+                            , subq_6.account_id__ds_partitioned__extract_dow
+                            , subq_6.account_id__ds_partitioned__extract_doy
+                            , subq_6.bridge_account__ds_partitioned__day
+                            , subq_6.bridge_account__ds_partitioned__week
+                            , subq_6.bridge_account__ds_partitioned__month
+                            , subq_6.bridge_account__ds_partitioned__quarter
+                            , subq_6.bridge_account__ds_partitioned__year
+                            , subq_6.bridge_account__ds_partitioned__extract_year
+                            , subq_6.bridge_account__ds_partitioned__extract_quarter
+                            , subq_6.bridge_account__ds_partitioned__extract_month
+                            , subq_6.bridge_account__ds_partitioned__extract_day
+                            , subq_6.bridge_account__ds_partitioned__extract_dow
+                            , subq_6.bridge_account__ds_partitioned__extract_doy
+                            , subq_6.ds_partitioned__day AS metric_time__day
+                            , subq_6.ds_partitioned__week AS metric_time__week
+                            , subq_6.ds_partitioned__month AS metric_time__month
+                            , subq_6.ds_partitioned__quarter AS metric_time__quarter
+                            , subq_6.ds_partitioned__year AS metric_time__year
+                            , subq_6.ds_partitioned__extract_year AS metric_time__extract_year
+                            , subq_6.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                            , subq_6.ds_partitioned__extract_month AS metric_time__extract_month
+                            , subq_6.ds_partitioned__extract_day AS metric_time__extract_day
+                            , subq_6.ds_partitioned__extract_dow AS metric_time__extract_dow
+                            , subq_6.ds_partitioned__extract_doy AS metric_time__extract_doy
+                            , subq_6.account_id
+                            , subq_6.customer_id
+                            , subq_6.account_id__customer_id
+                            , subq_6.bridge_account__account_id
+                            , subq_6.bridge_account__customer_id
+                            , subq_6.extra_dim
+                            , subq_6.account_id__extra_dim
+                            , subq_6.bridge_account__extra_dim
+                            , subq_6.account_customer_combos
                           FROM (
                             -- Read Elements From Semantic Model 'bridge_table'
                             SELECT
@@ -456,8 +456,8 @@ FROM (
                               , bridge_table_src_22000.account_id AS bridge_account__account_id
                               , bridge_table_src_22000.customer_id AS bridge_account__customer_id
                             FROM ***************************.bridge_table bridge_table_src_22000
-                          ) subq_24
-                        ) subq_25
+                          ) subq_6
+                        ) subq_7
                         LEFT OUTER JOIN (
                           -- Pass Only Elements: [
                           --   'country',
@@ -513,112 +513,112 @@ FROM (
                           --   'customer_third_hop_id__customer_id',
                           -- ]
                           SELECT
-                            subq_27.acquired_ds__day
-                            , subq_27.acquired_ds__week
-                            , subq_27.acquired_ds__month
-                            , subq_27.acquired_ds__quarter
-                            , subq_27.acquired_ds__year
-                            , subq_27.acquired_ds__extract_year
-                            , subq_27.acquired_ds__extract_quarter
-                            , subq_27.acquired_ds__extract_month
-                            , subq_27.acquired_ds__extract_day
-                            , subq_27.acquired_ds__extract_dow
-                            , subq_27.acquired_ds__extract_doy
-                            , subq_27.customer_id__acquired_ds__day
-                            , subq_27.customer_id__acquired_ds__week
-                            , subq_27.customer_id__acquired_ds__month
-                            , subq_27.customer_id__acquired_ds__quarter
-                            , subq_27.customer_id__acquired_ds__year
-                            , subq_27.customer_id__acquired_ds__extract_year
-                            , subq_27.customer_id__acquired_ds__extract_quarter
-                            , subq_27.customer_id__acquired_ds__extract_month
-                            , subq_27.customer_id__acquired_ds__extract_day
-                            , subq_27.customer_id__acquired_ds__extract_dow
-                            , subq_27.customer_id__acquired_ds__extract_doy
-                            , subq_27.customer_third_hop_id__acquired_ds__day
-                            , subq_27.customer_third_hop_id__acquired_ds__week
-                            , subq_27.customer_third_hop_id__acquired_ds__month
-                            , subq_27.customer_third_hop_id__acquired_ds__quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_27.metric_time__day
-                            , subq_27.metric_time__week
-                            , subq_27.metric_time__month
-                            , subq_27.metric_time__quarter
-                            , subq_27.metric_time__year
-                            , subq_27.metric_time__extract_year
-                            , subq_27.metric_time__extract_quarter
-                            , subq_27.metric_time__extract_month
-                            , subq_27.metric_time__extract_day
-                            , subq_27.metric_time__extract_dow
-                            , subq_27.metric_time__extract_doy
-                            , subq_27.customer_id
-                            , subq_27.customer_third_hop_id
-                            , subq_27.customer_id__customer_third_hop_id
-                            , subq_27.customer_third_hop_id__customer_id
-                            , subq_27.country
-                            , subq_27.customer_id__country
-                            , subq_27.customer_third_hop_id__country
+                            subq_9.acquired_ds__day
+                            , subq_9.acquired_ds__week
+                            , subq_9.acquired_ds__month
+                            , subq_9.acquired_ds__quarter
+                            , subq_9.acquired_ds__year
+                            , subq_9.acquired_ds__extract_year
+                            , subq_9.acquired_ds__extract_quarter
+                            , subq_9.acquired_ds__extract_month
+                            , subq_9.acquired_ds__extract_day
+                            , subq_9.acquired_ds__extract_dow
+                            , subq_9.acquired_ds__extract_doy
+                            , subq_9.customer_id__acquired_ds__day
+                            , subq_9.customer_id__acquired_ds__week
+                            , subq_9.customer_id__acquired_ds__month
+                            , subq_9.customer_id__acquired_ds__quarter
+                            , subq_9.customer_id__acquired_ds__year
+                            , subq_9.customer_id__acquired_ds__extract_year
+                            , subq_9.customer_id__acquired_ds__extract_quarter
+                            , subq_9.customer_id__acquired_ds__extract_month
+                            , subq_9.customer_id__acquired_ds__extract_day
+                            , subq_9.customer_id__acquired_ds__extract_dow
+                            , subq_9.customer_id__acquired_ds__extract_doy
+                            , subq_9.customer_third_hop_id__acquired_ds__day
+                            , subq_9.customer_third_hop_id__acquired_ds__week
+                            , subq_9.customer_third_hop_id__acquired_ds__month
+                            , subq_9.customer_third_hop_id__acquired_ds__quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_9.metric_time__day
+                            , subq_9.metric_time__week
+                            , subq_9.metric_time__month
+                            , subq_9.metric_time__quarter
+                            , subq_9.metric_time__year
+                            , subq_9.metric_time__extract_year
+                            , subq_9.metric_time__extract_quarter
+                            , subq_9.metric_time__extract_month
+                            , subq_9.metric_time__extract_day
+                            , subq_9.metric_time__extract_dow
+                            , subq_9.metric_time__extract_doy
+                            , subq_9.customer_id
+                            , subq_9.customer_third_hop_id
+                            , subq_9.customer_id__customer_third_hop_id
+                            , subq_9.customer_third_hop_id__customer_id
+                            , subq_9.country
+                            , subq_9.customer_id__country
+                            , subq_9.customer_third_hop_id__country
                           FROM (
                             -- Metric Time Dimension 'acquired_ds'
                             SELECT
-                              subq_26.acquired_ds__day
-                              , subq_26.acquired_ds__week
-                              , subq_26.acquired_ds__month
-                              , subq_26.acquired_ds__quarter
-                              , subq_26.acquired_ds__year
-                              , subq_26.acquired_ds__extract_year
-                              , subq_26.acquired_ds__extract_quarter
-                              , subq_26.acquired_ds__extract_month
-                              , subq_26.acquired_ds__extract_day
-                              , subq_26.acquired_ds__extract_dow
-                              , subq_26.acquired_ds__extract_doy
-                              , subq_26.customer_id__acquired_ds__day
-                              , subq_26.customer_id__acquired_ds__week
-                              , subq_26.customer_id__acquired_ds__month
-                              , subq_26.customer_id__acquired_ds__quarter
-                              , subq_26.customer_id__acquired_ds__year
-                              , subq_26.customer_id__acquired_ds__extract_year
-                              , subq_26.customer_id__acquired_ds__extract_quarter
-                              , subq_26.customer_id__acquired_ds__extract_month
-                              , subq_26.customer_id__acquired_ds__extract_day
-                              , subq_26.customer_id__acquired_ds__extract_dow
-                              , subq_26.customer_id__acquired_ds__extract_doy
-                              , subq_26.customer_third_hop_id__acquired_ds__day
-                              , subq_26.customer_third_hop_id__acquired_ds__week
-                              , subq_26.customer_third_hop_id__acquired_ds__month
-                              , subq_26.customer_third_hop_id__acquired_ds__quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_month
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_day
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_dow
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_doy
-                              , subq_26.acquired_ds__day AS metric_time__day
-                              , subq_26.acquired_ds__week AS metric_time__week
-                              , subq_26.acquired_ds__month AS metric_time__month
-                              , subq_26.acquired_ds__quarter AS metric_time__quarter
-                              , subq_26.acquired_ds__year AS metric_time__year
-                              , subq_26.acquired_ds__extract_year AS metric_time__extract_year
-                              , subq_26.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_26.acquired_ds__extract_month AS metric_time__extract_month
-                              , subq_26.acquired_ds__extract_day AS metric_time__extract_day
-                              , subq_26.acquired_ds__extract_dow AS metric_time__extract_dow
-                              , subq_26.acquired_ds__extract_doy AS metric_time__extract_doy
-                              , subq_26.customer_id
-                              , subq_26.customer_third_hop_id
-                              , subq_26.customer_id__customer_third_hop_id
-                              , subq_26.customer_third_hop_id__customer_id
-                              , subq_26.country
-                              , subq_26.customer_id__country
-                              , subq_26.customer_third_hop_id__country
-                              , subq_26.customers_with_other_data
+                              subq_8.acquired_ds__day
+                              , subq_8.acquired_ds__week
+                              , subq_8.acquired_ds__month
+                              , subq_8.acquired_ds__quarter
+                              , subq_8.acquired_ds__year
+                              , subq_8.acquired_ds__extract_year
+                              , subq_8.acquired_ds__extract_quarter
+                              , subq_8.acquired_ds__extract_month
+                              , subq_8.acquired_ds__extract_day
+                              , subq_8.acquired_ds__extract_dow
+                              , subq_8.acquired_ds__extract_doy
+                              , subq_8.customer_id__acquired_ds__day
+                              , subq_8.customer_id__acquired_ds__week
+                              , subq_8.customer_id__acquired_ds__month
+                              , subq_8.customer_id__acquired_ds__quarter
+                              , subq_8.customer_id__acquired_ds__year
+                              , subq_8.customer_id__acquired_ds__extract_year
+                              , subq_8.customer_id__acquired_ds__extract_quarter
+                              , subq_8.customer_id__acquired_ds__extract_month
+                              , subq_8.customer_id__acquired_ds__extract_day
+                              , subq_8.customer_id__acquired_ds__extract_dow
+                              , subq_8.customer_id__acquired_ds__extract_doy
+                              , subq_8.customer_third_hop_id__acquired_ds__day
+                              , subq_8.customer_third_hop_id__acquired_ds__week
+                              , subq_8.customer_third_hop_id__acquired_ds__month
+                              , subq_8.customer_third_hop_id__acquired_ds__quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_month
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_day
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_dow
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_doy
+                              , subq_8.acquired_ds__day AS metric_time__day
+                              , subq_8.acquired_ds__week AS metric_time__week
+                              , subq_8.acquired_ds__month AS metric_time__month
+                              , subq_8.acquired_ds__quarter AS metric_time__quarter
+                              , subq_8.acquired_ds__year AS metric_time__year
+                              , subq_8.acquired_ds__extract_year AS metric_time__extract_year
+                              , subq_8.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_8.acquired_ds__extract_month AS metric_time__extract_month
+                              , subq_8.acquired_ds__extract_day AS metric_time__extract_day
+                              , subq_8.acquired_ds__extract_dow AS metric_time__extract_dow
+                              , subq_8.acquired_ds__extract_doy AS metric_time__extract_doy
+                              , subq_8.customer_id
+                              , subq_8.customer_third_hop_id
+                              , subq_8.customer_id__customer_third_hop_id
+                              , subq_8.customer_third_hop_id__customer_id
+                              , subq_8.country
+                              , subq_8.customer_id__country
+                              , subq_8.customer_third_hop_id__country
+                              , subq_8.customers_with_other_data
                             FROM (
                               -- Read Elements From Semantic Model 'customer_other_data'
                               SELECT
@@ -664,31 +664,31 @@ FROM (
                                 , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                                 , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                               FROM ***************************.customer_other_data customer_other_data_src_22000
-                            ) subq_26
-                          ) subq_27
-                        ) subq_28
+                            ) subq_8
+                          ) subq_9
+                        ) subq_10
                         ON
-                          subq_25.customer_id = subq_28.customer_id
-                      ) subq_29
-                    ) subq_30
+                          subq_7.customer_id = subq_10.customer_id
+                      ) subq_11
+                    ) subq_12
                     ON
                       (
-                        subq_23.account_id = subq_30.account_id
+                        subq_5.account_id = subq_12.account_id
                       ) AND (
-                        subq_23.ds_partitioned__day = subq_30.ds_partitioned__day
+                        subq_5.ds_partitioned__day = subq_12.ds_partitioned__day
                       )
-                  ) subq_31
-                ) subq_32
+                  ) subq_13
+                ) subq_14
                 GROUP BY
-                  subq_32.account_id__customer_id__customer_third_hop_id
-              ) subq_33
-            ) subq_34
-          ) subq_35
+                  subq_14.account_id__customer_id__customer_third_hop_id
+              ) subq_15
+            ) subq_16
+          ) subq_17
           ON
-            subq_20.customer_third_hop_id = subq_35.account_id__customer_id__customer_third_hop_id
-        ) subq_36
-      ) subq_37
+            subq_2.customer_third_hop_id = subq_17.account_id__customer_id__customer_third_hop_id
+        ) subq_18
+      ) subq_19
       WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2
-    ) subq_38
-  ) subq_39
-) subq_40
+    ) subq_20
+  ) subq_21
+) subq_22

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_40.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_35.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_71
+    ) subq_35
     ON
       (
-        account_month_txns_src_22000.account_id = subq_71.account_id
+        account_month_txns_src_22000.account_id = subq_35.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_35.ds_partitioned__day
       )
     GROUP BY
-      subq_71.customer_id__customer_third_hop_id
-  ) subq_76
+      subq_35.customer_id__customer_third_hop_id
+  ) subq_40
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
-) subq_78
+    third_hop_table_src_22000.customer_third_hop_id = subq_40.account_id__customer_id__customer_third_hop_id
+) subq_42
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_25.third_hop_count
+  subq_16.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_24.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_23.third_hop_count
+      subq_14.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_22.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_22.third_hop_count
+        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_13.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_21.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_21.third_hop_count
+          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_12.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.customer_third_hop_id AS customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-            , subq_11.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_10.customer_third_hop_id
-              , subq_10.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_9.third_hop_ds__day
-                , subq_9.third_hop_ds__week
-                , subq_9.third_hop_ds__month
-                , subq_9.third_hop_ds__quarter
-                , subq_9.third_hop_ds__year
-                , subq_9.third_hop_ds__extract_year
-                , subq_9.third_hop_ds__extract_quarter
-                , subq_9.third_hop_ds__extract_month
-                , subq_9.third_hop_ds__extract_day
-                , subq_9.third_hop_ds__extract_dow
-                , subq_9.third_hop_ds__extract_doy
-                , subq_9.customer_third_hop_id__third_hop_ds__day
-                , subq_9.customer_third_hop_id__third_hop_ds__week
-                , subq_9.customer_third_hop_id__third_hop_ds__month
-                , subq_9.customer_third_hop_id__third_hop_ds__quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_9.third_hop_ds__day AS metric_time__day
-                , subq_9.third_hop_ds__week AS metric_time__week
-                , subq_9.third_hop_ds__month AS metric_time__month
-                , subq_9.third_hop_ds__quarter AS metric_time__quarter
-                , subq_9.third_hop_ds__year AS metric_time__year
-                , subq_9.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_9.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_9.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_9.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_9.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_9.customer_third_hop_id
-                , subq_9.value
-                , subq_9.customer_third_hop_id__value
-                , subq_9.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,151 +101,151 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_19.customer_id__customer_third_hop_id
-              , subq_19.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_10.customer_id__customer_third_hop_id
+              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_18.customer_id__customer_third_hop_id
-                , subq_18.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_9.customer_id__customer_third_hop_id
+                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_17.customer_id__customer_third_hop_id
-                  , SUM(subq_17.customers_with_other_data) AS customers_with_other_data
+                  subq_8.customer_id__customer_third_hop_id
+                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_16.customer_id__customer_third_hop_id
-                    , subq_16.customers_with_other_data
+                    subq_7.customer_id__customer_third_hop_id
+                    , subq_7.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_15.customer_id__customer_third_hop_id
-                      , subq_15.customer_id__country
-                      , subq_15.customers_with_other_data
+                      subq_6.customer_id__customer_third_hop_id
+                      , subq_6.customer_id__country
+                      , subq_6.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_14.customer_id__customer_third_hop_id
-                        , subq_14.customer_id__country
-                        , subq_14.customers_with_other_data
+                        subq_5.customer_id__customer_third_hop_id
+                        , subq_5.customer_id__country
+                        , subq_5.customers_with_other_data
                       FROM (
                         -- Constrain Output with WHERE
                         SELECT
-                          subq_13.acquired_ds__day
-                          , subq_13.acquired_ds__week
-                          , subq_13.acquired_ds__month
-                          , subq_13.acquired_ds__quarter
-                          , subq_13.acquired_ds__year
-                          , subq_13.acquired_ds__extract_year
-                          , subq_13.acquired_ds__extract_quarter
-                          , subq_13.acquired_ds__extract_month
-                          , subq_13.acquired_ds__extract_day
-                          , subq_13.acquired_ds__extract_dow
-                          , subq_13.acquired_ds__extract_doy
-                          , subq_13.customer_id__acquired_ds__day
-                          , subq_13.customer_id__acquired_ds__week
-                          , subq_13.customer_id__acquired_ds__month
-                          , subq_13.customer_id__acquired_ds__quarter
-                          , subq_13.customer_id__acquired_ds__year
-                          , subq_13.customer_id__acquired_ds__extract_year
-                          , subq_13.customer_id__acquired_ds__extract_quarter
-                          , subq_13.customer_id__acquired_ds__extract_month
-                          , subq_13.customer_id__acquired_ds__extract_day
-                          , subq_13.customer_id__acquired_ds__extract_dow
-                          , subq_13.customer_id__acquired_ds__extract_doy
-                          , subq_13.customer_third_hop_id__acquired_ds__day
-                          , subq_13.customer_third_hop_id__acquired_ds__week
-                          , subq_13.customer_third_hop_id__acquired_ds__month
-                          , subq_13.customer_third_hop_id__acquired_ds__quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_13.metric_time__day
-                          , subq_13.metric_time__week
-                          , subq_13.metric_time__month
-                          , subq_13.metric_time__quarter
-                          , subq_13.metric_time__year
-                          , subq_13.metric_time__extract_year
-                          , subq_13.metric_time__extract_quarter
-                          , subq_13.metric_time__extract_month
-                          , subq_13.metric_time__extract_day
-                          , subq_13.metric_time__extract_dow
-                          , subq_13.metric_time__extract_doy
-                          , subq_13.customer_id
-                          , subq_13.customer_third_hop_id
-                          , subq_13.customer_id__customer_third_hop_id
-                          , subq_13.customer_third_hop_id__customer_id
-                          , subq_13.country
-                          , subq_13.customer_id__country
-                          , subq_13.customer_third_hop_id__country
-                          , subq_13.customers_with_other_data
+                          subq_4.acquired_ds__day
+                          , subq_4.acquired_ds__week
+                          , subq_4.acquired_ds__month
+                          , subq_4.acquired_ds__quarter
+                          , subq_4.acquired_ds__year
+                          , subq_4.acquired_ds__extract_year
+                          , subq_4.acquired_ds__extract_quarter
+                          , subq_4.acquired_ds__extract_month
+                          , subq_4.acquired_ds__extract_day
+                          , subq_4.acquired_ds__extract_dow
+                          , subq_4.acquired_ds__extract_doy
+                          , subq_4.customer_id__acquired_ds__day
+                          , subq_4.customer_id__acquired_ds__week
+                          , subq_4.customer_id__acquired_ds__month
+                          , subq_4.customer_id__acquired_ds__quarter
+                          , subq_4.customer_id__acquired_ds__year
+                          , subq_4.customer_id__acquired_ds__extract_year
+                          , subq_4.customer_id__acquired_ds__extract_quarter
+                          , subq_4.customer_id__acquired_ds__extract_month
+                          , subq_4.customer_id__acquired_ds__extract_day
+                          , subq_4.customer_id__acquired_ds__extract_dow
+                          , subq_4.customer_id__acquired_ds__extract_doy
+                          , subq_4.customer_third_hop_id__acquired_ds__day
+                          , subq_4.customer_third_hop_id__acquired_ds__week
+                          , subq_4.customer_third_hop_id__acquired_ds__month
+                          , subq_4.customer_third_hop_id__acquired_ds__quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_4.metric_time__day
+                          , subq_4.metric_time__week
+                          , subq_4.metric_time__month
+                          , subq_4.metric_time__quarter
+                          , subq_4.metric_time__year
+                          , subq_4.metric_time__extract_year
+                          , subq_4.metric_time__extract_quarter
+                          , subq_4.metric_time__extract_month
+                          , subq_4.metric_time__extract_day
+                          , subq_4.metric_time__extract_dow
+                          , subq_4.metric_time__extract_doy
+                          , subq_4.customer_id
+                          , subq_4.customer_third_hop_id
+                          , subq_4.customer_id__customer_third_hop_id
+                          , subq_4.customer_third_hop_id__customer_id
+                          , subq_4.country
+                          , subq_4.customer_id__country
+                          , subq_4.customer_third_hop_id__country
+                          , subq_4.customers_with_other_data
                         FROM (
                           -- Metric Time Dimension 'acquired_ds'
                           SELECT
-                            subq_12.acquired_ds__day
-                            , subq_12.acquired_ds__week
-                            , subq_12.acquired_ds__month
-                            , subq_12.acquired_ds__quarter
-                            , subq_12.acquired_ds__year
-                            , subq_12.acquired_ds__extract_year
-                            , subq_12.acquired_ds__extract_quarter
-                            , subq_12.acquired_ds__extract_month
-                            , subq_12.acquired_ds__extract_day
-                            , subq_12.acquired_ds__extract_dow
-                            , subq_12.acquired_ds__extract_doy
-                            , subq_12.customer_id__acquired_ds__day
-                            , subq_12.customer_id__acquired_ds__week
-                            , subq_12.customer_id__acquired_ds__month
-                            , subq_12.customer_id__acquired_ds__quarter
-                            , subq_12.customer_id__acquired_ds__year
-                            , subq_12.customer_id__acquired_ds__extract_year
-                            , subq_12.customer_id__acquired_ds__extract_quarter
-                            , subq_12.customer_id__acquired_ds__extract_month
-                            , subq_12.customer_id__acquired_ds__extract_day
-                            , subq_12.customer_id__acquired_ds__extract_dow
-                            , subq_12.customer_id__acquired_ds__extract_doy
-                            , subq_12.customer_third_hop_id__acquired_ds__day
-                            , subq_12.customer_third_hop_id__acquired_ds__week
-                            , subq_12.customer_third_hop_id__acquired_ds__month
-                            , subq_12.customer_third_hop_id__acquired_ds__quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_12.acquired_ds__day AS metric_time__day
-                            , subq_12.acquired_ds__week AS metric_time__week
-                            , subq_12.acquired_ds__month AS metric_time__month
-                            , subq_12.acquired_ds__quarter AS metric_time__quarter
-                            , subq_12.acquired_ds__year AS metric_time__year
-                            , subq_12.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_12.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_12.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_12.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_12.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_12.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_12.customer_id
-                            , subq_12.customer_third_hop_id
-                            , subq_12.customer_id__customer_third_hop_id
-                            , subq_12.customer_third_hop_id__customer_id
-                            , subq_12.country
-                            , subq_12.customer_id__country
-                            , subq_12.customer_third_hop_id__country
-                            , subq_12.customers_with_other_data
+                            subq_3.acquired_ds__day
+                            , subq_3.acquired_ds__week
+                            , subq_3.acquired_ds__month
+                            , subq_3.acquired_ds__quarter
+                            , subq_3.acquired_ds__year
+                            , subq_3.acquired_ds__extract_year
+                            , subq_3.acquired_ds__extract_quarter
+                            , subq_3.acquired_ds__extract_month
+                            , subq_3.acquired_ds__extract_day
+                            , subq_3.acquired_ds__extract_dow
+                            , subq_3.acquired_ds__extract_doy
+                            , subq_3.customer_id__acquired_ds__day
+                            , subq_3.customer_id__acquired_ds__week
+                            , subq_3.customer_id__acquired_ds__month
+                            , subq_3.customer_id__acquired_ds__quarter
+                            , subq_3.customer_id__acquired_ds__year
+                            , subq_3.customer_id__acquired_ds__extract_year
+                            , subq_3.customer_id__acquired_ds__extract_quarter
+                            , subq_3.customer_id__acquired_ds__extract_month
+                            , subq_3.customer_id__acquired_ds__extract_day
+                            , subq_3.customer_id__acquired_ds__extract_dow
+                            , subq_3.customer_id__acquired_ds__extract_doy
+                            , subq_3.customer_third_hop_id__acquired_ds__day
+                            , subq_3.customer_third_hop_id__acquired_ds__week
+                            , subq_3.customer_third_hop_id__acquired_ds__month
+                            , subq_3.customer_third_hop_id__acquired_ds__quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_3.acquired_ds__day AS metric_time__day
+                            , subq_3.acquired_ds__week AS metric_time__week
+                            , subq_3.acquired_ds__month AS metric_time__month
+                            , subq_3.acquired_ds__quarter AS metric_time__quarter
+                            , subq_3.acquired_ds__year AS metric_time__year
+                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                            , subq_3.customer_id
+                            , subq_3.customer_third_hop_id
+                            , subq_3.customer_id__customer_third_hop_id
+                            , subq_3.customer_third_hop_id__customer_id
+                            , subq_3.country
+                            , subq_3.customer_id__country
+                            , subq_3.customer_third_hop_id__country
+                            , subq_3.customers_with_other_data
                           FROM (
                             -- Read Elements From Semantic Model 'customer_other_data'
                             SELECT
@@ -291,24 +291,24 @@ FROM (
                               , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                               , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                             FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_12
-                        ) subq_13
+                          ) subq_3
+                        ) subq_4
                         WHERE customer_id__country = 'paraguay'
-                      ) subq_14
-                    ) subq_15
+                      ) subq_5
+                    ) subq_6
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_16
-                ) subq_17
+                  ) subq_7
+                ) subq_8
                 GROUP BY
-                  subq_17.customer_id__customer_third_hop_id
-              ) subq_18
-            ) subq_19
-          ) subq_20
+                  subq_8.customer_id__customer_third_hop_id
+              ) subq_9
+            ) subq_10
+          ) subq_11
           ON
-            subq_11.customer_third_hop_id = subq_20.customer_id__customer_third_hop_id
-        ) subq_21
-      ) subq_22
+            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
+        ) subq_12
+      ) subq_13
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_23
-  ) subq_24
-) subq_25
+    ) subq_14
+  ) subq_15
+) subq_16

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_39
+      ) subq_21
       WHERE customer_id__country = 'paraguay'
-    ) subq_41
+    ) subq_23
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_46
+  ) subq_28
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
-) subq_48
+    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
+) subq_30
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookers
-        , subq_14.bookers
+        subq_10.listing__bookers
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'listing__bookers']
         SELECT
-          subq_13.listing__bookers
-          , subq_13.bookers
+          subq_9.listing__bookers
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookers AS listing__bookers
-            , subq_6.bookers AS bookers
+            subq_2.listing AS listing
+            , subq_8.listing__bookers AS listing__bookers
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.bookers
+              subq_1.listing
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookers
+              subq_7.listing
+              , subq_7.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookers AS listing__bookers
+                subq_6.listing
+                , subq_6.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , COUNT(DISTINCT subq_9.bookers) AS bookers
+                  subq_5.listing
+                  , COUNT(DISTINCT subq_5.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookers
+                    subq_4.listing
+                    , subq_4.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookers > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_30.listing__bookers AS listing__bookers
-    , subq_24.bookers AS bookers
+    subq_22.listing__bookers AS listing__bookers
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_with_metric_in_where_filter__plan0.sql
@@ -1,112 +1,112 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time__day
-  , subq_17.listings AS active_listings
+  subq_13.metric_time__day
+  , subq_13.listings AS active_listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.metric_time__day
-    , SUM(subq_16.listings) AS listings
+    subq_12.metric_time__day
+    , SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'metric_time__day']
     SELECT
-      subq_15.metric_time__day
-      , subq_15.listings
+      subq_11.metric_time__day
+      , subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.metric_time__day
-        , subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.metric_time__day
+        , subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
         SELECT
-          subq_13.metric_time__day
-          , subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.metric_time__day
+          , subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.metric_time__day AS metric_time__day
-            , subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']
             SELECT
-              subq_5.metric_time__day
-              , subq_5.listing
-              , subq_5.listings
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -167,130 +167,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -383,21 +383,21 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
+    ) subq_11
+  ) subq_12
   GROUP BY
-    subq_16.metric_time__day
-) subq_17
+    subq_12.metric_time__day
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_24.metric_time__day AS metric_time__day
-    , subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_16.metric_time__day AS metric_time__day
+    , subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.user__revenue_all_time
-        , subq_14.listings
+        subq_10.user__revenue_all_time
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__revenue_all_time']
         SELECT
-          subq_13.user__revenue_all_time
-          , subq_13.listings
+          subq_9.user__revenue_all_time
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.user AS user
-            , subq_12.user__revenue_all_time AS user__revenue_all_time
-            , subq_6.listings AS listings
+            subq_2.user AS user
+            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_5.user
-              , subq_5.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,68 +160,68 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__revenue_all_time']
             SELECT
-              subq_11.user
-              , subq_11.user__revenue_all_time
+              subq_7.user
+              , subq_7.user__revenue_all_time
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.user
-                , subq_10.txn_revenue AS user__revenue_all_time
+                subq_6.user
+                , subq_6.txn_revenue AS user__revenue_all_time
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.user
-                  , SUM(subq_9.txn_revenue) AS txn_revenue
+                  subq_5.user
+                  , SUM(subq_5.txn_revenue) AS txn_revenue
                 FROM (
                   -- Pass Only Elements: ['txn_revenue', 'user']
                   SELECT
-                    subq_8.user
-                    , subq_8.txn_revenue
+                    subq_4.user
+                    , subq_4.txn_revenue
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.revenue_instance__ds__day
-                      , subq_7.revenue_instance__ds__week
-                      , subq_7.revenue_instance__ds__month
-                      , subq_7.revenue_instance__ds__quarter
-                      , subq_7.revenue_instance__ds__year
-                      , subq_7.revenue_instance__ds__extract_year
-                      , subq_7.revenue_instance__ds__extract_quarter
-                      , subq_7.revenue_instance__ds__extract_month
-                      , subq_7.revenue_instance__ds__extract_day
-                      , subq_7.revenue_instance__ds__extract_dow
-                      , subq_7.revenue_instance__ds__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.user
-                      , subq_7.revenue_instance__user
-                      , subq_7.txn_revenue
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.revenue_instance__ds__day
+                      , subq_3.revenue_instance__ds__week
+                      , subq_3.revenue_instance__ds__month
+                      , subq_3.revenue_instance__ds__quarter
+                      , subq_3.revenue_instance__ds__year
+                      , subq_3.revenue_instance__ds__extract_year
+                      , subq_3.revenue_instance__ds__extract_quarter
+                      , subq_3.revenue_instance__ds__extract_month
+                      , subq_3.revenue_instance__ds__extract_day
+                      , subq_3.revenue_instance__ds__extract_dow
+                      , subq_3.revenue_instance__ds__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.user
+                      , subq_3.revenue_instance__user
+                      , subq_3.txn_revenue
                     FROM (
                       -- Read Elements From Semantic Model 'revenue'
                       SELECT
@@ -251,19 +251,19 @@ FROM (
                         , revenue_src_28000.user_id AS user
                         , revenue_src_28000.user_id AS revenue_instance__user
                       FROM ***************************.fct_revenue revenue_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.user
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.user
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.user = subq_12.user
-        ) subq_13
-      ) subq_14
+            subq_2.user = subq_8.user
+        ) subq_9
+      ) subq_10
       WHERE user__revenue_all_time > 1
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_30.user__revenue_all_time AS user__revenue_all_time
-    , subq_24.listings AS listings
+    subq_22.user__revenue_all_time AS user__revenue_all_time
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.user = subq_30.user
-) subq_32
+    subq_16.user = subq_22.user
+) subq_24
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__views_times_booking_value
-        , subq_28.listings
+        subq_17.listing__views_times_booking_value
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
         SELECT
-          subq_27.listing__views_times_booking_value
-          , subq_27.listings
+          subq_16.listing__views_times_booking_value
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__views_times_booking_value AS listing__views_times_booking_value
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
             SELECT
-              subq_25.listing
-              , subq_25.listing__views_times_booking_value
+              subq_14.listing
+              , subq_14.listing__views_times_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
+                subq_13.listing
                 , booking_value * views AS listing__views_times_booking_value
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.booking_value) AS booking_value
-                  , MAX(subq_23.views) AS views
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.booking_value) AS booking_value
+                  , MAX(subq_12.views) AS views
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.booking_value
+                    subq_6.listing
+                    , subq_6.booking_value
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.booking_value) AS booking_value
+                      subq_5.listing
+                      , SUM(subq_5.booking_value) AS booking_value
                     FROM (
                       -- Pass Only Elements: ['booking_value', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.booking_value
+                        subq_4.listing
+                        , subq_4.booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,91 +387,91 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.views
+                    subq_11.listing
+                    , subq_11.views
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , SUM(subq_21.views) AS views
+                      subq_10.listing
+                      , SUM(subq_10.views) AS views
                     FROM (
                       -- Pass Only Elements: ['views', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.views
+                        subq_9.listing
+                        , subq_9.views
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.view__ds__day
-                          , subq_19.view__ds__week
-                          , subq_19.view__ds__month
-                          , subq_19.view__ds__quarter
-                          , subq_19.view__ds__year
-                          , subq_19.view__ds__extract_year
-                          , subq_19.view__ds__extract_quarter
-                          , subq_19.view__ds__extract_month
-                          , subq_19.view__ds__extract_day
-                          , subq_19.view__ds__extract_dow
-                          , subq_19.view__ds__extract_doy
-                          , subq_19.view__ds_partitioned__day
-                          , subq_19.view__ds_partitioned__week
-                          , subq_19.view__ds_partitioned__month
-                          , subq_19.view__ds_partitioned__quarter
-                          , subq_19.view__ds_partitioned__year
-                          , subq_19.view__ds_partitioned__extract_year
-                          , subq_19.view__ds_partitioned__extract_quarter
-                          , subq_19.view__ds_partitioned__extract_month
-                          , subq_19.view__ds_partitioned__extract_day
-                          , subq_19.view__ds_partitioned__extract_dow
-                          , subq_19.view__ds_partitioned__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.user
-                          , subq_19.view__listing
-                          , subq_19.view__user
-                          , subq_19.views
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.view__ds__day
+                          , subq_8.view__ds__week
+                          , subq_8.view__ds__month
+                          , subq_8.view__ds__quarter
+                          , subq_8.view__ds__year
+                          , subq_8.view__ds__extract_year
+                          , subq_8.view__ds__extract_quarter
+                          , subq_8.view__ds__extract_month
+                          , subq_8.view__ds__extract_day
+                          , subq_8.view__ds__extract_dow
+                          , subq_8.view__ds__extract_doy
+                          , subq_8.view__ds_partitioned__day
+                          , subq_8.view__ds_partitioned__week
+                          , subq_8.view__ds_partitioned__month
+                          , subq_8.view__ds_partitioned__quarter
+                          , subq_8.view__ds_partitioned__year
+                          , subq_8.view__ds_partitioned__extract_year
+                          , subq_8.view__ds_partitioned__extract_quarter
+                          , subq_8.view__ds_partitioned__extract_month
+                          , subq_8.view__ds_partitioned__extract_day
+                          , subq_8.view__ds_partitioned__extract_dow
+                          , subq_8.view__ds_partitioned__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.user
+                          , subq_8.view__listing
+                          , subq_8.view__user
+                          , subq_8.views
                         FROM (
                           -- Read Elements From Semantic Model 'views_source'
                           SELECT
@@ -525,25 +525,25 @@ FROM (
                             , views_source_src_28000.listing_id AS view__listing
                             , views_source_src_28000.user_id AS view__user
                           FROM ***************************.fct_views views_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__views_times_booking_value > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_45.listings AS listings
+    subq_36.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_50.listing, subq_55.listing) AS listing
-        , MAX(subq_50.booking_value) AS booking_value
-        , MAX(subq_55.views) AS views
+        COALESCE(subq_28.listing, subq_33.listing) AS listing
+        , MAX(subq_28.booking_value) AS booking_value
+        , MAX(subq_33.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_50
+      ) subq_28
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_53
+        ) subq_31
         GROUP BY
           listing
-      ) subq_55
+      ) subq_33
       ON
-        subq_50.listing = subq_55.listing
+        subq_28.listing = subq_33.listing
       GROUP BY
-        COALESCE(subq_50.listing, subq_55.listing)
-    ) subq_56
-  ) subq_58
+        COALESCE(subq_28.listing, subq_33.listing)
+    ) subq_34
+  ) subq_36
   ON
-    subq_45.listing = subq_58.listing
-) subq_60
+    subq_23.listing = subq_36.listing
+) subq_38
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -1,108 +1,108 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_19.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_18.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_17.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.listing__bookings
-        , subq_24.listing__bookers
-        , subq_24.listings
+        subq_16.listing__bookings
+        , subq_16.listing__bookers
+        , subq_16.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
         SELECT
-          subq_23.listing__bookings
-          , subq_23.listing__bookers
-          , subq_23.listings
+          subq_15.listing__bookings
+          , subq_15.listing__bookers
+          , subq_15.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_10.listing AS listing
-            , subq_16.listing__bookings AS listing__bookings
-            , subq_22.listing__bookers AS listing__bookers
-            , subq_10.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']
             SELECT
-              subq_9.listing
-              , subq_9.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_8.ds__day
-                , subq_8.ds__week
-                , subq_8.ds__month
-                , subq_8.ds__quarter
-                , subq_8.ds__year
-                , subq_8.ds__extract_year
-                , subq_8.ds__extract_quarter
-                , subq_8.ds__extract_month
-                , subq_8.ds__extract_day
-                , subq_8.ds__extract_dow
-                , subq_8.ds__extract_doy
-                , subq_8.created_at__day
-                , subq_8.created_at__week
-                , subq_8.created_at__month
-                , subq_8.created_at__quarter
-                , subq_8.created_at__year
-                , subq_8.created_at__extract_year
-                , subq_8.created_at__extract_quarter
-                , subq_8.created_at__extract_month
-                , subq_8.created_at__extract_day
-                , subq_8.created_at__extract_dow
-                , subq_8.created_at__extract_doy
-                , subq_8.listing__ds__day
-                , subq_8.listing__ds__week
-                , subq_8.listing__ds__month
-                , subq_8.listing__ds__quarter
-                , subq_8.listing__ds__year
-                , subq_8.listing__ds__extract_year
-                , subq_8.listing__ds__extract_quarter
-                , subq_8.listing__ds__extract_month
-                , subq_8.listing__ds__extract_day
-                , subq_8.listing__ds__extract_dow
-                , subq_8.listing__ds__extract_doy
-                , subq_8.listing__created_at__day
-                , subq_8.listing__created_at__week
-                , subq_8.listing__created_at__month
-                , subq_8.listing__created_at__quarter
-                , subq_8.listing__created_at__year
-                , subq_8.listing__created_at__extract_year
-                , subq_8.listing__created_at__extract_quarter
-                , subq_8.listing__created_at__extract_month
-                , subq_8.listing__created_at__extract_day
-                , subq_8.listing__created_at__extract_dow
-                , subq_8.listing__created_at__extract_doy
-                , subq_8.ds__day AS metric_time__day
-                , subq_8.ds__week AS metric_time__week
-                , subq_8.ds__month AS metric_time__month
-                , subq_8.ds__quarter AS metric_time__quarter
-                , subq_8.ds__year AS metric_time__year
-                , subq_8.ds__extract_year AS metric_time__extract_year
-                , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_8.ds__extract_month AS metric_time__extract_month
-                , subq_8.ds__extract_day AS metric_time__extract_day
-                , subq_8.ds__extract_dow AS metric_time__extract_dow
-                , subq_8.ds__extract_doy AS metric_time__extract_doy
-                , subq_8.listing
-                , subq_8.user
-                , subq_8.listing__user
-                , subq_8.country_latest
-                , subq_8.is_lux_latest
-                , subq_8.capacity_latest
-                , subq_8.listing__country_latest
-                , subq_8.listing__is_lux_latest
-                , subq_8.listing__capacity_latest
-                , subq_8.listings
-                , subq_8.largest_listing
-                , subq_8.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -163,130 +163,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_8
-            ) subq_9
-          ) subq_10
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_15.listing
-              , subq_15.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_14.listing
-                , subq_14.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_13.listing
-                  , SUM(subq_13.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_12.listing
-                    , subq_12.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_11.ds__day
-                      , subq_11.ds__week
-                      , subq_11.ds__month
-                      , subq_11.ds__quarter
-                      , subq_11.ds__year
-                      , subq_11.ds__extract_year
-                      , subq_11.ds__extract_quarter
-                      , subq_11.ds__extract_month
-                      , subq_11.ds__extract_day
-                      , subq_11.ds__extract_dow
-                      , subq_11.ds__extract_doy
-                      , subq_11.ds_partitioned__day
-                      , subq_11.ds_partitioned__week
-                      , subq_11.ds_partitioned__month
-                      , subq_11.ds_partitioned__quarter
-                      , subq_11.ds_partitioned__year
-                      , subq_11.ds_partitioned__extract_year
-                      , subq_11.ds_partitioned__extract_quarter
-                      , subq_11.ds_partitioned__extract_month
-                      , subq_11.ds_partitioned__extract_day
-                      , subq_11.ds_partitioned__extract_dow
-                      , subq_11.ds_partitioned__extract_doy
-                      , subq_11.paid_at__day
-                      , subq_11.paid_at__week
-                      , subq_11.paid_at__month
-                      , subq_11.paid_at__quarter
-                      , subq_11.paid_at__year
-                      , subq_11.paid_at__extract_year
-                      , subq_11.paid_at__extract_quarter
-                      , subq_11.paid_at__extract_month
-                      , subq_11.paid_at__extract_day
-                      , subq_11.paid_at__extract_dow
-                      , subq_11.paid_at__extract_doy
-                      , subq_11.booking__ds__day
-                      , subq_11.booking__ds__week
-                      , subq_11.booking__ds__month
-                      , subq_11.booking__ds__quarter
-                      , subq_11.booking__ds__year
-                      , subq_11.booking__ds__extract_year
-                      , subq_11.booking__ds__extract_quarter
-                      , subq_11.booking__ds__extract_month
-                      , subq_11.booking__ds__extract_day
-                      , subq_11.booking__ds__extract_dow
-                      , subq_11.booking__ds__extract_doy
-                      , subq_11.booking__ds_partitioned__day
-                      , subq_11.booking__ds_partitioned__week
-                      , subq_11.booking__ds_partitioned__month
-                      , subq_11.booking__ds_partitioned__quarter
-                      , subq_11.booking__ds_partitioned__year
-                      , subq_11.booking__ds_partitioned__extract_year
-                      , subq_11.booking__ds_partitioned__extract_quarter
-                      , subq_11.booking__ds_partitioned__extract_month
-                      , subq_11.booking__ds_partitioned__extract_day
-                      , subq_11.booking__ds_partitioned__extract_dow
-                      , subq_11.booking__ds_partitioned__extract_doy
-                      , subq_11.booking__paid_at__day
-                      , subq_11.booking__paid_at__week
-                      , subq_11.booking__paid_at__month
-                      , subq_11.booking__paid_at__quarter
-                      , subq_11.booking__paid_at__year
-                      , subq_11.booking__paid_at__extract_year
-                      , subq_11.booking__paid_at__extract_quarter
-                      , subq_11.booking__paid_at__extract_month
-                      , subq_11.booking__paid_at__extract_day
-                      , subq_11.booking__paid_at__extract_dow
-                      , subq_11.booking__paid_at__extract_doy
-                      , subq_11.ds__day AS metric_time__day
-                      , subq_11.ds__week AS metric_time__week
-                      , subq_11.ds__month AS metric_time__month
-                      , subq_11.ds__quarter AS metric_time__quarter
-                      , subq_11.ds__year AS metric_time__year
-                      , subq_11.ds__extract_year AS metric_time__extract_year
-                      , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_11.ds__extract_month AS metric_time__extract_month
-                      , subq_11.ds__extract_day AS metric_time__extract_day
-                      , subq_11.ds__extract_dow AS metric_time__extract_dow
-                      , subq_11.ds__extract_doy AS metric_time__extract_doy
-                      , subq_11.listing
-                      , subq_11.guest
-                      , subq_11.host
-                      , subq_11.booking__listing
-                      , subq_11.booking__guest
-                      , subq_11.booking__host
-                      , subq_11.is_instant
-                      , subq_11.booking__is_instant
-                      , subq_11.bookings
-                      , subq_11.instant_bookings
-                      , subq_11.booking_value
-                      , subq_11.max_booking_value
-                      , subq_11.min_booking_value
-                      , subq_11.bookers
-                      , subq_11.average_booking_value
-                      , subq_11.referred_bookings
-                      , subq_11.median_booking_value
-                      , subq_11.booking_value_p99
-                      , subq_11.discrete_booking_value_p99
-                      , subq_11.approximate_continuous_booking_value_p99
-                      , subq_11.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -379,137 +379,137 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_11
-                  ) subq_12
-                ) subq_13
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_13.listing
-              ) subq_14
-            ) subq_15
-          ) subq_16
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_10.listing = subq_16.listing
+            subq_2.listing = subq_8.listing
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_21.listing
-              , subq_21.listing__bookers
+              subq_13.listing
+              , subq_13.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing
-                , subq_20.bookers AS listing__bookers
+                subq_12.listing
+                , subq_12.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing
-                  , COUNT(DISTINCT subq_19.bookers) AS bookers
+                  subq_11.listing
+                  , COUNT(DISTINCT subq_11.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_18.listing
-                    , subq_18.bookers
+                    subq_10.listing
+                    , subq_10.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.ds_partitioned__day
-                      , subq_17.ds_partitioned__week
-                      , subq_17.ds_partitioned__month
-                      , subq_17.ds_partitioned__quarter
-                      , subq_17.ds_partitioned__year
-                      , subq_17.ds_partitioned__extract_year
-                      , subq_17.ds_partitioned__extract_quarter
-                      , subq_17.ds_partitioned__extract_month
-                      , subq_17.ds_partitioned__extract_day
-                      , subq_17.ds_partitioned__extract_dow
-                      , subq_17.ds_partitioned__extract_doy
-                      , subq_17.paid_at__day
-                      , subq_17.paid_at__week
-                      , subq_17.paid_at__month
-                      , subq_17.paid_at__quarter
-                      , subq_17.paid_at__year
-                      , subq_17.paid_at__extract_year
-                      , subq_17.paid_at__extract_quarter
-                      , subq_17.paid_at__extract_month
-                      , subq_17.paid_at__extract_day
-                      , subq_17.paid_at__extract_dow
-                      , subq_17.paid_at__extract_doy
-                      , subq_17.booking__ds__day
-                      , subq_17.booking__ds__week
-                      , subq_17.booking__ds__month
-                      , subq_17.booking__ds__quarter
-                      , subq_17.booking__ds__year
-                      , subq_17.booking__ds__extract_year
-                      , subq_17.booking__ds__extract_quarter
-                      , subq_17.booking__ds__extract_month
-                      , subq_17.booking__ds__extract_day
-                      , subq_17.booking__ds__extract_dow
-                      , subq_17.booking__ds__extract_doy
-                      , subq_17.booking__ds_partitioned__day
-                      , subq_17.booking__ds_partitioned__week
-                      , subq_17.booking__ds_partitioned__month
-                      , subq_17.booking__ds_partitioned__quarter
-                      , subq_17.booking__ds_partitioned__year
-                      , subq_17.booking__ds_partitioned__extract_year
-                      , subq_17.booking__ds_partitioned__extract_quarter
-                      , subq_17.booking__ds_partitioned__extract_month
-                      , subq_17.booking__ds_partitioned__extract_day
-                      , subq_17.booking__ds_partitioned__extract_dow
-                      , subq_17.booking__ds_partitioned__extract_doy
-                      , subq_17.booking__paid_at__day
-                      , subq_17.booking__paid_at__week
-                      , subq_17.booking__paid_at__month
-                      , subq_17.booking__paid_at__quarter
-                      , subq_17.booking__paid_at__year
-                      , subq_17.booking__paid_at__extract_year
-                      , subq_17.booking__paid_at__extract_quarter
-                      , subq_17.booking__paid_at__extract_month
-                      , subq_17.booking__paid_at__extract_day
-                      , subq_17.booking__paid_at__extract_dow
-                      , subq_17.booking__paid_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.guest
-                      , subq_17.host
-                      , subq_17.booking__listing
-                      , subq_17.booking__guest
-                      , subq_17.booking__host
-                      , subq_17.is_instant
-                      , subq_17.booking__is_instant
-                      , subq_17.bookings
-                      , subq_17.instant_bookings
-                      , subq_17.booking_value
-                      , subq_17.max_booking_value
-                      , subq_17.min_booking_value
-                      , subq_17.bookers
-                      , subq_17.average_booking_value
-                      , subq_17.referred_bookings
-                      , subq_17.median_booking_value
-                      , subq_17.booking_value_p99
-                      , subq_17.discrete_booking_value_p99
-                      , subq_17.approximate_continuous_booking_value_p99
-                      , subq_17.approximate_discrete_booking_value_p99
+                      subq_9.ds__day
+                      , subq_9.ds__week
+                      , subq_9.ds__month
+                      , subq_9.ds__quarter
+                      , subq_9.ds__year
+                      , subq_9.ds__extract_year
+                      , subq_9.ds__extract_quarter
+                      , subq_9.ds__extract_month
+                      , subq_9.ds__extract_day
+                      , subq_9.ds__extract_dow
+                      , subq_9.ds__extract_doy
+                      , subq_9.ds_partitioned__day
+                      , subq_9.ds_partitioned__week
+                      , subq_9.ds_partitioned__month
+                      , subq_9.ds_partitioned__quarter
+                      , subq_9.ds_partitioned__year
+                      , subq_9.ds_partitioned__extract_year
+                      , subq_9.ds_partitioned__extract_quarter
+                      , subq_9.ds_partitioned__extract_month
+                      , subq_9.ds_partitioned__extract_day
+                      , subq_9.ds_partitioned__extract_dow
+                      , subq_9.ds_partitioned__extract_doy
+                      , subq_9.paid_at__day
+                      , subq_9.paid_at__week
+                      , subq_9.paid_at__month
+                      , subq_9.paid_at__quarter
+                      , subq_9.paid_at__year
+                      , subq_9.paid_at__extract_year
+                      , subq_9.paid_at__extract_quarter
+                      , subq_9.paid_at__extract_month
+                      , subq_9.paid_at__extract_day
+                      , subq_9.paid_at__extract_dow
+                      , subq_9.paid_at__extract_doy
+                      , subq_9.booking__ds__day
+                      , subq_9.booking__ds__week
+                      , subq_9.booking__ds__month
+                      , subq_9.booking__ds__quarter
+                      , subq_9.booking__ds__year
+                      , subq_9.booking__ds__extract_year
+                      , subq_9.booking__ds__extract_quarter
+                      , subq_9.booking__ds__extract_month
+                      , subq_9.booking__ds__extract_day
+                      , subq_9.booking__ds__extract_dow
+                      , subq_9.booking__ds__extract_doy
+                      , subq_9.booking__ds_partitioned__day
+                      , subq_9.booking__ds_partitioned__week
+                      , subq_9.booking__ds_partitioned__month
+                      , subq_9.booking__ds_partitioned__quarter
+                      , subq_9.booking__ds_partitioned__year
+                      , subq_9.booking__ds_partitioned__extract_year
+                      , subq_9.booking__ds_partitioned__extract_quarter
+                      , subq_9.booking__ds_partitioned__extract_month
+                      , subq_9.booking__ds_partitioned__extract_day
+                      , subq_9.booking__ds_partitioned__extract_dow
+                      , subq_9.booking__ds_partitioned__extract_doy
+                      , subq_9.booking__paid_at__day
+                      , subq_9.booking__paid_at__week
+                      , subq_9.booking__paid_at__month
+                      , subq_9.booking__paid_at__quarter
+                      , subq_9.booking__paid_at__year
+                      , subq_9.booking__paid_at__extract_year
+                      , subq_9.booking__paid_at__extract_quarter
+                      , subq_9.booking__paid_at__extract_month
+                      , subq_9.booking__paid_at__extract_day
+                      , subq_9.booking__paid_at__extract_dow
+                      , subq_9.booking__paid_at__extract_doy
+                      , subq_9.ds__day AS metric_time__day
+                      , subq_9.ds__week AS metric_time__week
+                      , subq_9.ds__month AS metric_time__month
+                      , subq_9.ds__quarter AS metric_time__quarter
+                      , subq_9.ds__year AS metric_time__year
+                      , subq_9.ds__extract_year AS metric_time__extract_year
+                      , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_9.ds__extract_month AS metric_time__extract_month
+                      , subq_9.ds__extract_day AS metric_time__extract_day
+                      , subq_9.ds__extract_dow AS metric_time__extract_dow
+                      , subq_9.ds__extract_doy AS metric_time__extract_doy
+                      , subq_9.listing
+                      , subq_9.guest
+                      , subq_9.host
+                      , subq_9.booking__listing
+                      , subq_9.booking__guest
+                      , subq_9.booking__host
+                      , subq_9.is_instant
+                      , subq_9.booking__is_instant
+                      , subq_9.bookings
+                      , subq_9.instant_bookings
+                      , subq_9.booking_value
+                      , subq_9.max_booking_value
+                      , subq_9.min_booking_value
+                      , subq_9.bookers
+                      , subq_9.average_booking_value
+                      , subq_9.referred_bookings
+                      , subq_9.median_booking_value
+                      , subq_9.booking_value_p99
+                      , subq_9.discrete_booking_value_p99
+                      , subq_9.approximate_continuous_booking_value_p99
+                      , subq_9.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -602,19 +602,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_9
+                  ) subq_10
+                ) subq_11
                 GROUP BY
-                  subq_19.listing
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_11.listing
+              ) subq_12
+            ) subq_13
+          ) subq_14
           ON
-            subq_10.listing = subq_22.listing
-        ) subq_23
-      ) subq_24
+            subq_2.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       WHERE listing__bookings > 2 AND listing__bookers > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_17
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_44.listing__bookings AS listing__bookings
-    , subq_50.listing__bookers AS listing__bookers
-    , subq_38.listings AS listings
+    subq_28.listing__bookings AS listing__bookings
+    , subq_34.listing__bookers AS listing__bookers
+    , subq_22.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_38
+  ) subq_22
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_41
+    ) subq_25
     GROUP BY
       listing
-  ) subq_44
+  ) subq_28
   ON
-    subq_38.listing = subq_44.listing
+    subq_22.listing = subq_28.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_50
+  ) subq_34
   ON
-    subq_38.listing = subq_50.listing
-) subq_52
+    subq_22.listing = subq_34.listing
+) subq_36
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__bookings_per_booker
-        , subq_28.listings
+        subq_17.listing__bookings_per_booker
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
         SELECT
-          subq_27.listing__bookings_per_booker
-          , subq_27.listings
+          subq_16.listing__bookings_per_booker
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__bookings_per_booker AS listing__bookings_per_booker
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings_per_booker']
             SELECT
-              subq_25.listing
-              , subq_25.listing__bookings_per_booker
+              subq_14.listing
+              , subq_14.listing__bookings_per_booker
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
-                , CAST(subq_24.bookings AS DOUBLE) / CAST(NULLIF(subq_24.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+                subq_13.listing
+                , CAST(subq_13.bookings AS DOUBLE) / CAST(NULLIF(subq_13.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.bookings) AS bookings
-                  , MAX(subq_23.bookers) AS bookers
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.bookings) AS bookings
+                  , MAX(subq_12.bookers) AS bookers
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.bookings
+                    subq_6.listing
+                    , subq_6.bookings
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.bookings) AS bookings
+                      subq_5.listing
+                      , SUM(subq_5.bookings) AS bookings
                     FROM (
                       -- Pass Only Elements: ['bookings', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.bookings
+                        subq_4.listing
+                        , subq_4.bookings
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,129 +387,129 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.bookers
+                    subq_11.listing
+                    , subq_11.bookers
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , COUNT(DISTINCT subq_21.bookers) AS bookers
+                      subq_10.listing
+                      , COUNT(DISTINCT subq_10.bookers) AS bookers
                     FROM (
                       -- Pass Only Elements: ['bookers', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.bookers
+                        subq_9.listing
+                        , subq_9.bookers
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.paid_at__day
-                          , subq_19.paid_at__week
-                          , subq_19.paid_at__month
-                          , subq_19.paid_at__quarter
-                          , subq_19.paid_at__year
-                          , subq_19.paid_at__extract_year
-                          , subq_19.paid_at__extract_quarter
-                          , subq_19.paid_at__extract_month
-                          , subq_19.paid_at__extract_day
-                          , subq_19.paid_at__extract_dow
-                          , subq_19.paid_at__extract_doy
-                          , subq_19.booking__ds__day
-                          , subq_19.booking__ds__week
-                          , subq_19.booking__ds__month
-                          , subq_19.booking__ds__quarter
-                          , subq_19.booking__ds__year
-                          , subq_19.booking__ds__extract_year
-                          , subq_19.booking__ds__extract_quarter
-                          , subq_19.booking__ds__extract_month
-                          , subq_19.booking__ds__extract_day
-                          , subq_19.booking__ds__extract_dow
-                          , subq_19.booking__ds__extract_doy
-                          , subq_19.booking__ds_partitioned__day
-                          , subq_19.booking__ds_partitioned__week
-                          , subq_19.booking__ds_partitioned__month
-                          , subq_19.booking__ds_partitioned__quarter
-                          , subq_19.booking__ds_partitioned__year
-                          , subq_19.booking__ds_partitioned__extract_year
-                          , subq_19.booking__ds_partitioned__extract_quarter
-                          , subq_19.booking__ds_partitioned__extract_month
-                          , subq_19.booking__ds_partitioned__extract_day
-                          , subq_19.booking__ds_partitioned__extract_dow
-                          , subq_19.booking__ds_partitioned__extract_doy
-                          , subq_19.booking__paid_at__day
-                          , subq_19.booking__paid_at__week
-                          , subq_19.booking__paid_at__month
-                          , subq_19.booking__paid_at__quarter
-                          , subq_19.booking__paid_at__year
-                          , subq_19.booking__paid_at__extract_year
-                          , subq_19.booking__paid_at__extract_quarter
-                          , subq_19.booking__paid_at__extract_month
-                          , subq_19.booking__paid_at__extract_day
-                          , subq_19.booking__paid_at__extract_dow
-                          , subq_19.booking__paid_at__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.guest
-                          , subq_19.host
-                          , subq_19.booking__listing
-                          , subq_19.booking__guest
-                          , subq_19.booking__host
-                          , subq_19.is_instant
-                          , subq_19.booking__is_instant
-                          , subq_19.bookings
-                          , subq_19.instant_bookings
-                          , subq_19.booking_value
-                          , subq_19.max_booking_value
-                          , subq_19.min_booking_value
-                          , subq_19.bookers
-                          , subq_19.average_booking_value
-                          , subq_19.referred_bookings
-                          , subq_19.median_booking_value
-                          , subq_19.booking_value_p99
-                          , subq_19.discrete_booking_value_p99
-                          , subq_19.approximate_continuous_booking_value_p99
-                          , subq_19.approximate_discrete_booking_value_p99
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.paid_at__day
+                          , subq_8.paid_at__week
+                          , subq_8.paid_at__month
+                          , subq_8.paid_at__quarter
+                          , subq_8.paid_at__year
+                          , subq_8.paid_at__extract_year
+                          , subq_8.paid_at__extract_quarter
+                          , subq_8.paid_at__extract_month
+                          , subq_8.paid_at__extract_day
+                          , subq_8.paid_at__extract_dow
+                          , subq_8.paid_at__extract_doy
+                          , subq_8.booking__ds__day
+                          , subq_8.booking__ds__week
+                          , subq_8.booking__ds__month
+                          , subq_8.booking__ds__quarter
+                          , subq_8.booking__ds__year
+                          , subq_8.booking__ds__extract_year
+                          , subq_8.booking__ds__extract_quarter
+                          , subq_8.booking__ds__extract_month
+                          , subq_8.booking__ds__extract_day
+                          , subq_8.booking__ds__extract_dow
+                          , subq_8.booking__ds__extract_doy
+                          , subq_8.booking__ds_partitioned__day
+                          , subq_8.booking__ds_partitioned__week
+                          , subq_8.booking__ds_partitioned__month
+                          , subq_8.booking__ds_partitioned__quarter
+                          , subq_8.booking__ds_partitioned__year
+                          , subq_8.booking__ds_partitioned__extract_year
+                          , subq_8.booking__ds_partitioned__extract_quarter
+                          , subq_8.booking__ds_partitioned__extract_month
+                          , subq_8.booking__ds_partitioned__extract_day
+                          , subq_8.booking__ds_partitioned__extract_dow
+                          , subq_8.booking__ds_partitioned__extract_doy
+                          , subq_8.booking__paid_at__day
+                          , subq_8.booking__paid_at__week
+                          , subq_8.booking__paid_at__month
+                          , subq_8.booking__paid_at__quarter
+                          , subq_8.booking__paid_at__year
+                          , subq_8.booking__paid_at__extract_year
+                          , subq_8.booking__paid_at__extract_quarter
+                          , subq_8.booking__paid_at__extract_month
+                          , subq_8.booking__paid_at__extract_day
+                          , subq_8.booking__paid_at__extract_dow
+                          , subq_8.booking__paid_at__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.guest
+                          , subq_8.host
+                          , subq_8.booking__listing
+                          , subq_8.booking__guest
+                          , subq_8.booking__host
+                          , subq_8.is_instant
+                          , subq_8.booking__is_instant
+                          , subq_8.bookings
+                          , subq_8.instant_bookings
+                          , subq_8.booking_value
+                          , subq_8.max_booking_value
+                          , subq_8.min_booking_value
+                          , subq_8.bookers
+                          , subq_8.average_booking_value
+                          , subq_8.referred_bookings
+                          , subq_8.median_booking_value
+                          , subq_8.booking_value_p99
+                          , subq_8.discrete_booking_value_p99
+                          , subq_8.approximate_continuous_booking_value_p99
+                          , subq_8.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -602,25 +602,25 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__bookings_per_booker > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_56.bookings AS DOUBLE) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
-    , subq_45.listings AS listings
+    CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_50.listing, subq_55.listing) AS listing
-      , MAX(subq_50.bookings) AS bookings
-      , MAX(subq_55.bookers) AS bookers
+      COALESCE(subq_28.listing, subq_33.listing) AS listing
+      , MAX(subq_28.bookings) AS bookings
+      , MAX(subq_33.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_48
+      ) subq_26
       GROUP BY
         listing
-    ) subq_50
+    ) subq_28
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_55
+    ) subq_33
     ON
-      subq_50.listing = subq_55.listing
+      subq_28.listing = subq_33.listing
     GROUP BY
-      COALESCE(subq_50.listing, subq_55.listing)
-  ) subq_56
+      COALESCE(subq_28.listing, subq_33.listing)
+  ) subq_34
   ON
-    subq_45.listing = subq_56.listing
-) subq_60
+    subq_23.listing = subq_34.listing
+) subq_38
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings']
         SELECT
-          subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,130 +160,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -376,19 +376,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -1,20 +1,20 @@
 -- Pass Only Elements: ['listing',]
 SELECT
-  subq_12.listing
+  subq_8.listing
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_11.listing
-    , subq_11.lux_listing
-    , subq_11.listing__lux_listing
-    , subq_11.listing__bookings
+    subq_7.listing
+    , subq_7.lux_listing
+    , subq_7.listing__lux_listing
+    , subq_7.listing__bookings
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_4.listing AS listing
-      , subq_4.lux_listing AS lux_listing
-      , subq_4.listing__lux_listing AS listing__lux_listing
-      , subq_10.listing__bookings AS listing__bookings
+      subq_0.listing AS listing
+      , subq_0.lux_listing AS lux_listing
+      , subq_0.listing__lux_listing AS listing__lux_listing
+      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT
@@ -22,128 +22,128 @@ FROM (
         , lux_listing_mapping_src_28000.lux_listing_id AS lux_listing
         , lux_listing_mapping_src_28000.lux_listing_id AS listing__lux_listing
       FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
-    ) subq_4
+    ) subq_0
     FULL OUTER JOIN (
       -- Pass Only Elements: ['listing', 'listing__bookings']
       SELECT
-        subq_9.listing
-        , subq_9.listing__bookings
+        subq_5.listing
+        , subq_5.listing__bookings
       FROM (
         -- Compute Metrics via Expressions
         SELECT
-          subq_8.listing
-          , subq_8.bookings AS listing__bookings
+          subq_4.listing
+          , subq_4.bookings AS listing__bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_7.listing
-            , SUM(subq_7.bookings) AS bookings
+            subq_3.listing
+            , SUM(subq_3.bookings) AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'listing']
             SELECT
-              subq_6.listing
-              , subq_6.bookings
+              subq_2.listing
+              , subq_2.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds__day
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.ds__extract_year
-                , subq_5.ds__extract_quarter
-                , subq_5.ds__extract_month
-                , subq_5.ds__extract_day
-                , subq_5.ds__extract_dow
-                , subq_5.ds__extract_doy
-                , subq_5.ds_partitioned__day
-                , subq_5.ds_partitioned__week
-                , subq_5.ds_partitioned__month
-                , subq_5.ds_partitioned__quarter
-                , subq_5.ds_partitioned__year
-                , subq_5.ds_partitioned__extract_year
-                , subq_5.ds_partitioned__extract_quarter
-                , subq_5.ds_partitioned__extract_month
-                , subq_5.ds_partitioned__extract_day
-                , subq_5.ds_partitioned__extract_dow
-                , subq_5.ds_partitioned__extract_doy
-                , subq_5.paid_at__day
-                , subq_5.paid_at__week
-                , subq_5.paid_at__month
-                , subq_5.paid_at__quarter
-                , subq_5.paid_at__year
-                , subq_5.paid_at__extract_year
-                , subq_5.paid_at__extract_quarter
-                , subq_5.paid_at__extract_month
-                , subq_5.paid_at__extract_day
-                , subq_5.paid_at__extract_dow
-                , subq_5.paid_at__extract_doy
-                , subq_5.booking__ds__day
-                , subq_5.booking__ds__week
-                , subq_5.booking__ds__month
-                , subq_5.booking__ds__quarter
-                , subq_5.booking__ds__year
-                , subq_5.booking__ds__extract_year
-                , subq_5.booking__ds__extract_quarter
-                , subq_5.booking__ds__extract_month
-                , subq_5.booking__ds__extract_day
-                , subq_5.booking__ds__extract_dow
-                , subq_5.booking__ds__extract_doy
-                , subq_5.booking__ds_partitioned__day
-                , subq_5.booking__ds_partitioned__week
-                , subq_5.booking__ds_partitioned__month
-                , subq_5.booking__ds_partitioned__quarter
-                , subq_5.booking__ds_partitioned__year
-                , subq_5.booking__ds_partitioned__extract_year
-                , subq_5.booking__ds_partitioned__extract_quarter
-                , subq_5.booking__ds_partitioned__extract_month
-                , subq_5.booking__ds_partitioned__extract_day
-                , subq_5.booking__ds_partitioned__extract_dow
-                , subq_5.booking__ds_partitioned__extract_doy
-                , subq_5.booking__paid_at__day
-                , subq_5.booking__paid_at__week
-                , subq_5.booking__paid_at__month
-                , subq_5.booking__paid_at__quarter
-                , subq_5.booking__paid_at__year
-                , subq_5.booking__paid_at__extract_year
-                , subq_5.booking__paid_at__extract_quarter
-                , subq_5.booking__paid_at__extract_month
-                , subq_5.booking__paid_at__extract_day
-                , subq_5.booking__paid_at__extract_dow
-                , subq_5.booking__paid_at__extract_doy
-                , subq_5.ds__day AS metric_time__day
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.ds__extract_year AS metric_time__extract_year
-                , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_5.ds__extract_month AS metric_time__extract_month
-                , subq_5.ds__extract_day AS metric_time__extract_day
-                , subq_5.ds__extract_dow AS metric_time__extract_dow
-                , subq_5.ds__extract_doy AS metric_time__extract_doy
-                , subq_5.listing
-                , subq_5.guest
-                , subq_5.host
-                , subq_5.booking__listing
-                , subq_5.booking__guest
-                , subq_5.booking__host
-                , subq_5.is_instant
-                , subq_5.booking__is_instant
-                , subq_5.bookings
-                , subq_5.instant_bookings
-                , subq_5.booking_value
-                , subq_5.max_booking_value
-                , subq_5.min_booking_value
-                , subq_5.bookers
-                , subq_5.average_booking_value
-                , subq_5.referred_bookings
-                , subq_5.median_booking_value
-                , subq_5.booking_value_p99
-                , subq_5.discrete_booking_value_p99
-                , subq_5.approximate_continuous_booking_value_p99
-                , subq_5.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.ds__day AS metric_time__day
+                , subq_1.ds__week AS metric_time__week
+                , subq_1.ds__month AS metric_time__month
+                , subq_1.ds__quarter AS metric_time__quarter
+                , subq_1.ds__year AS metric_time__year
+                , subq_1.ds__extract_year AS metric_time__extract_year
+                , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_1.ds__extract_month AS metric_time__extract_month
+                , subq_1.ds__extract_day AS metric_time__extract_day
+                , subq_1.ds__extract_dow AS metric_time__extract_dow
+                , subq_1.ds__extract_doy AS metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -236,18 +236,18 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_5
-            ) subq_6
-          ) subq_7
+              ) subq_1
+            ) subq_2
+          ) subq_3
           GROUP BY
-            subq_7.listing
-        ) subq_8
-      ) subq_9
-    ) subq_10
+            subq_3.listing
+        ) subq_4
+      ) subq_5
+    ) subq_6
     ON
-      subq_4.listing = subq_10.listing
-  ) subq_11
+      subq_0.listing = subq_6.listing
+  ) subq_7
   WHERE listing__bookings > 2
-) subq_12
+) subq_8
 GROUP BY
-  subq_12.listing
+  subq_8.listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_23.listing__bookings AS listing__bookings
+    , subq_15.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+    ) subq_12
     GROUP BY
       listing
-  ) subq_23
+  ) subq_15
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_23.listing
-) subq_24
+    lux_listing_mapping_src_28000.listing_id = subq_15.listing
+) subq_16
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.guest__booking_value
-        , subq_14.bookers
+        subq_10.guest__booking_value
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'guest__booking_value']
         SELECT
-          subq_13.guest__booking_value
-          , subq_13.bookers
+          subq_9.guest__booking_value
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.guest AS guest
-            , subq_12.guest__booking_value AS guest__booking_value
-            , subq_6.bookers AS bookers
+            subq_2.guest AS guest
+            , subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']
             SELECT
-              subq_5.guest
-              , subq_5.bookers
+              subq_1.guest
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['guest', 'guest__booking_value']
             SELECT
-              subq_11.guest
-              , subq_11.guest__booking_value
+              subq_7.guest
+              , subq_7.guest__booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.guest
-                , subq_10.booking_value AS guest__booking_value
+                subq_6.guest
+                , subq_6.booking_value AS guest__booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.guest
-                  , SUM(subq_9.booking_value) AS booking_value
+                  subq_5.guest
+                  , SUM(subq_5.booking_value) AS booking_value
                 FROM (
                   -- Pass Only Elements: ['booking_value', 'guest']
                   SELECT
-                    subq_8.guest
-                    , subq_8.booking_value
+                    subq_4.guest
+                    , subq_4.booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.guest
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.guest
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.guest = subq_12.guest
-        ) subq_13
-      ) subq_14
+            subq_2.guest = subq_8.guest
+        ) subq_9
+      ) subq_10
       WHERE guest__booking_value > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_30.guest__booking_value AS guest__booking_value
-    , subq_24.bookers AS bookers
+    subq_22.guest__booking_value AS guest__booking_value
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.guest = subq_30.guest
-) subq_32
+    subq_16.guest = subq_22.guest
+) subq_24
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_39.listings
+  subq_24.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_38.listings) AS listings
+    SUM(subq_23.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_37.listings
+      subq_22.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_36.user__visit_buy_conversion_rate
-        , subq_36.listings
+        subq_21.user__visit_buy_conversion_rate
+        , subq_21.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
         SELECT
-          subq_35.user__visit_buy_conversion_rate
-          , subq_35.listings
+          subq_20.user__visit_buy_conversion_rate
+          , subq_20.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_17.user AS user
-            , subq_34.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
-            , subq_17.listings AS listings
+            subq_2.user AS user
+            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_16.user
-              , subq_16.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_15.ds__day
-                , subq_15.ds__week
-                , subq_15.ds__month
-                , subq_15.ds__quarter
-                , subq_15.ds__year
-                , subq_15.ds__extract_year
-                , subq_15.ds__extract_quarter
-                , subq_15.ds__extract_month
-                , subq_15.ds__extract_day
-                , subq_15.ds__extract_dow
-                , subq_15.ds__extract_doy
-                , subq_15.created_at__day
-                , subq_15.created_at__week
-                , subq_15.created_at__month
-                , subq_15.created_at__quarter
-                , subq_15.created_at__year
-                , subq_15.created_at__extract_year
-                , subq_15.created_at__extract_quarter
-                , subq_15.created_at__extract_month
-                , subq_15.created_at__extract_day
-                , subq_15.created_at__extract_dow
-                , subq_15.created_at__extract_doy
-                , subq_15.listing__ds__day
-                , subq_15.listing__ds__week
-                , subq_15.listing__ds__month
-                , subq_15.listing__ds__quarter
-                , subq_15.listing__ds__year
-                , subq_15.listing__ds__extract_year
-                , subq_15.listing__ds__extract_quarter
-                , subq_15.listing__ds__extract_month
-                , subq_15.listing__ds__extract_day
-                , subq_15.listing__ds__extract_dow
-                , subq_15.listing__ds__extract_doy
-                , subq_15.listing__created_at__day
-                , subq_15.listing__created_at__week
-                , subq_15.listing__created_at__month
-                , subq_15.listing__created_at__quarter
-                , subq_15.listing__created_at__year
-                , subq_15.listing__created_at__extract_year
-                , subq_15.listing__created_at__extract_quarter
-                , subq_15.listing__created_at__extract_month
-                , subq_15.listing__created_at__extract_day
-                , subq_15.listing__created_at__extract_dow
-                , subq_15.listing__created_at__extract_doy
-                , subq_15.ds__day AS metric_time__day
-                , subq_15.ds__week AS metric_time__week
-                , subq_15.ds__month AS metric_time__month
-                , subq_15.ds__quarter AS metric_time__quarter
-                , subq_15.ds__year AS metric_time__year
-                , subq_15.ds__extract_year AS metric_time__extract_year
-                , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_15.ds__extract_month AS metric_time__extract_month
-                , subq_15.ds__extract_day AS metric_time__extract_day
-                , subq_15.ds__extract_dow AS metric_time__extract_dow
-                , subq_15.ds__extract_doy AS metric_time__extract_doy
-                , subq_15.listing
-                , subq_15.user
-                , subq_15.listing__user
-                , subq_15.country_latest
-                , subq_15.is_lux_latest
-                , subq_15.capacity_latest
-                , subq_15.listing__country_latest
-                , subq_15.listing__is_lux_latest
-                , subq_15.listing__capacity_latest
-                , subq_15.listings
-                , subq_15.largest_listing
-                , subq_15.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,79 +160,79 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_15
-            ) subq_16
-          ) subq_17
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__visit_buy_conversion_rate']
             SELECT
-              subq_33.user
-              , subq_33.user__visit_buy_conversion_rate
+              subq_18.user
+              , subq_18.user__visit_buy_conversion_rate
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_32.user
-                , CAST(subq_32.buys AS DOUBLE) / CAST(NULLIF(subq_32.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+                subq_17.user
+                , CAST(subq_17.buys AS DOUBLE) / CAST(NULLIF(subq_17.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_21.user, subq_31.user) AS user
-                  , MAX(subq_21.visits) AS visits
-                  , MAX(subq_31.buys) AS buys
+                  COALESCE(subq_6.user, subq_16.user) AS user
+                  , MAX(subq_6.visits) AS visits
+                  , MAX(subq_16.buys) AS buys
                 FROM (
                   -- Aggregate Measures
                   SELECT
-                    subq_20.user
-                    , SUM(subq_20.visits) AS visits
+                    subq_5.user
+                    , SUM(subq_5.visits) AS visits
                   FROM (
                     -- Pass Only Elements: ['visits', 'user']
                     SELECT
-                      subq_19.user
-                      , subq_19.visits
+                      subq_4.user
+                      , subq_4.visits
                     FROM (
                       -- Metric Time Dimension 'ds'
                       SELECT
-                        subq_18.ds__day
-                        , subq_18.ds__week
-                        , subq_18.ds__month
-                        , subq_18.ds__quarter
-                        , subq_18.ds__year
-                        , subq_18.ds__extract_year
-                        , subq_18.ds__extract_quarter
-                        , subq_18.ds__extract_month
-                        , subq_18.ds__extract_day
-                        , subq_18.ds__extract_dow
-                        , subq_18.ds__extract_doy
-                        , subq_18.visit__ds__day
-                        , subq_18.visit__ds__week
-                        , subq_18.visit__ds__month
-                        , subq_18.visit__ds__quarter
-                        , subq_18.visit__ds__year
-                        , subq_18.visit__ds__extract_year
-                        , subq_18.visit__ds__extract_quarter
-                        , subq_18.visit__ds__extract_month
-                        , subq_18.visit__ds__extract_day
-                        , subq_18.visit__ds__extract_dow
-                        , subq_18.visit__ds__extract_doy
-                        , subq_18.ds__day AS metric_time__day
-                        , subq_18.ds__week AS metric_time__week
-                        , subq_18.ds__month AS metric_time__month
-                        , subq_18.ds__quarter AS metric_time__quarter
-                        , subq_18.ds__year AS metric_time__year
-                        , subq_18.ds__extract_year AS metric_time__extract_year
-                        , subq_18.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_18.ds__extract_month AS metric_time__extract_month
-                        , subq_18.ds__extract_day AS metric_time__extract_day
-                        , subq_18.ds__extract_dow AS metric_time__extract_dow
-                        , subq_18.ds__extract_doy AS metric_time__extract_doy
-                        , subq_18.user
-                        , subq_18.session
-                        , subq_18.visit__user
-                        , subq_18.visit__session
-                        , subq_18.referrer_id
-                        , subq_18.visit__referrer_id
-                        , subq_18.visits
-                        , subq_18.visitors
+                        subq_3.ds__day
+                        , subq_3.ds__week
+                        , subq_3.ds__month
+                        , subq_3.ds__quarter
+                        , subq_3.ds__year
+                        , subq_3.ds__extract_year
+                        , subq_3.ds__extract_quarter
+                        , subq_3.ds__extract_month
+                        , subq_3.ds__extract_day
+                        , subq_3.ds__extract_dow
+                        , subq_3.ds__extract_doy
+                        , subq_3.visit__ds__day
+                        , subq_3.visit__ds__week
+                        , subq_3.visit__ds__month
+                        , subq_3.visit__ds__quarter
+                        , subq_3.visit__ds__year
+                        , subq_3.visit__ds__extract_year
+                        , subq_3.visit__ds__extract_quarter
+                        , subq_3.visit__ds__extract_month
+                        , subq_3.visit__ds__extract_day
+                        , subq_3.visit__ds__extract_dow
+                        , subq_3.visit__ds__extract_doy
+                        , subq_3.ds__day AS metric_time__day
+                        , subq_3.ds__week AS metric_time__week
+                        , subq_3.ds__month AS metric_time__month
+                        , subq_3.ds__quarter AS metric_time__quarter
+                        , subq_3.ds__year AS metric_time__year
+                        , subq_3.ds__extract_year AS metric_time__extract_year
+                        , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_3.ds__extract_month AS metric_time__extract_month
+                        , subq_3.ds__extract_day AS metric_time__extract_day
+                        , subq_3.ds__extract_dow AS metric_time__extract_dow
+                        , subq_3.ds__extract_doy AS metric_time__extract_doy
+                        , subq_3.user
+                        , subq_3.session
+                        , subq_3.visit__user
+                        , subq_3.visit__session
+                        , subq_3.referrer_id
+                        , subq_3.visit__referrer_id
+                        , subq_3.visits
+                        , subq_3.visitors
                       FROM (
                         -- Read Elements From Semantic Model 'visits_source'
                         SELECT
@@ -267,108 +267,108 @@ FROM (
                           , visits_source_src_28000.user_id AS visit__user
                           , visits_source_src_28000.session_id AS visit__session
                         FROM ***************************.fct_visits visits_source_src_28000
-                      ) subq_18
-                    ) subq_19
-                  ) subq_20
+                      ) subq_3
+                    ) subq_4
+                  ) subq_5
                   GROUP BY
-                    subq_20.user
-                ) subq_21
+                    subq_5.user
+                ) subq_6
                 FULL OUTER JOIN (
                   -- Aggregate Measures
                   SELECT
-                    subq_30.user
-                    , SUM(subq_30.buys) AS buys
+                    subq_15.user
+                    , SUM(subq_15.buys) AS buys
                   FROM (
                     -- Pass Only Elements: ['buys', 'user']
                     SELECT
-                      subq_29.user
-                      , subq_29.buys
+                      subq_14.user
+                      , subq_14.buys
                     FROM (
                       -- Find conversions for user within the range of INF
                       SELECT
-                        subq_28.ds__day
-                        , subq_28.user
-                        , subq_28.buys
-                        , subq_28.visits
+                        subq_13.ds__day
+                        , subq_13.user
+                        , subq_13.buys
+                        , subq_13.visits
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          FIRST_VALUE(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_9.visits) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , FIRST_VALUE(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_9.ds__day) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , FIRST_VALUE(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_9.user) OVER (
                             PARTITION BY
-                              subq_27.user
-                              , subq_27.ds__day
-                              , subq_27.mf_internal_uuid
-                            ORDER BY subq_24.ds__day DESC
+                              subq_12.user
+                              , subq_12.ds__day
+                              , subq_12.mf_internal_uuid
+                            ORDER BY subq_9.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS user
-                          , subq_27.mf_internal_uuid AS mf_internal_uuid
-                          , subq_27.buys AS buys
+                          , subq_12.mf_internal_uuid AS mf_internal_uuid
+                          , subq_12.buys AS buys
                         FROM (
                           -- Pass Only Elements: ['visits', 'ds__day', 'user']
                           SELECT
-                            subq_23.ds__day
-                            , subq_23.user
-                            , subq_23.visits
+                            subq_8.ds__day
+                            , subq_8.user
+                            , subq_8.visits
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_22.ds__day
-                              , subq_22.ds__week
-                              , subq_22.ds__month
-                              , subq_22.ds__quarter
-                              , subq_22.ds__year
-                              , subq_22.ds__extract_year
-                              , subq_22.ds__extract_quarter
-                              , subq_22.ds__extract_month
-                              , subq_22.ds__extract_day
-                              , subq_22.ds__extract_dow
-                              , subq_22.ds__extract_doy
-                              , subq_22.visit__ds__day
-                              , subq_22.visit__ds__week
-                              , subq_22.visit__ds__month
-                              , subq_22.visit__ds__quarter
-                              , subq_22.visit__ds__year
-                              , subq_22.visit__ds__extract_year
-                              , subq_22.visit__ds__extract_quarter
-                              , subq_22.visit__ds__extract_month
-                              , subq_22.visit__ds__extract_day
-                              , subq_22.visit__ds__extract_dow
-                              , subq_22.visit__ds__extract_doy
-                              , subq_22.ds__day AS metric_time__day
-                              , subq_22.ds__week AS metric_time__week
-                              , subq_22.ds__month AS metric_time__month
-                              , subq_22.ds__quarter AS metric_time__quarter
-                              , subq_22.ds__year AS metric_time__year
-                              , subq_22.ds__extract_year AS metric_time__extract_year
-                              , subq_22.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_22.ds__extract_month AS metric_time__extract_month
-                              , subq_22.ds__extract_day AS metric_time__extract_day
-                              , subq_22.ds__extract_dow AS metric_time__extract_dow
-                              , subq_22.ds__extract_doy AS metric_time__extract_doy
-                              , subq_22.user
-                              , subq_22.session
-                              , subq_22.visit__user
-                              , subq_22.visit__session
-                              , subq_22.referrer_id
-                              , subq_22.visit__referrer_id
-                              , subq_22.visits
-                              , subq_22.visitors
+                              subq_7.ds__day
+                              , subq_7.ds__week
+                              , subq_7.ds__month
+                              , subq_7.ds__quarter
+                              , subq_7.ds__year
+                              , subq_7.ds__extract_year
+                              , subq_7.ds__extract_quarter
+                              , subq_7.ds__extract_month
+                              , subq_7.ds__extract_day
+                              , subq_7.ds__extract_dow
+                              , subq_7.ds__extract_doy
+                              , subq_7.visit__ds__day
+                              , subq_7.visit__ds__week
+                              , subq_7.visit__ds__month
+                              , subq_7.visit__ds__quarter
+                              , subq_7.visit__ds__year
+                              , subq_7.visit__ds__extract_year
+                              , subq_7.visit__ds__extract_quarter
+                              , subq_7.visit__ds__extract_month
+                              , subq_7.visit__ds__extract_day
+                              , subq_7.visit__ds__extract_dow
+                              , subq_7.visit__ds__extract_doy
+                              , subq_7.ds__day AS metric_time__day
+                              , subq_7.ds__week AS metric_time__week
+                              , subq_7.ds__month AS metric_time__month
+                              , subq_7.ds__quarter AS metric_time__quarter
+                              , subq_7.ds__year AS metric_time__year
+                              , subq_7.ds__extract_year AS metric_time__extract_year
+                              , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_7.ds__extract_month AS metric_time__extract_month
+                              , subq_7.ds__extract_day AS metric_time__extract_day
+                              , subq_7.ds__extract_dow AS metric_time__extract_dow
+                              , subq_7.ds__extract_doy AS metric_time__extract_doy
+                              , subq_7.user
+                              , subq_7.session
+                              , subq_7.visit__user
+                              , subq_7.visit__session
+                              , subq_7.referrer_id
+                              , subq_7.visit__referrer_id
+                              , subq_7.visits
+                              , subq_7.visitors
                             FROM (
                               -- Read Elements From Semantic Model 'visits_source'
                               SELECT
@@ -403,94 +403,94 @@ FROM (
                                 , visits_source_src_28000.user_id AS visit__user
                                 , visits_source_src_28000.session_id AS visit__session
                               FROM ***************************.fct_visits visits_source_src_28000
-                            ) subq_22
-                          ) subq_23
-                        ) subq_24
+                            ) subq_7
+                          ) subq_8
+                        ) subq_9
                         INNER JOIN (
                           -- Add column with generated UUID
                           SELECT
-                            subq_26.ds__day
-                            , subq_26.ds__week
-                            , subq_26.ds__month
-                            , subq_26.ds__quarter
-                            , subq_26.ds__year
-                            , subq_26.ds__extract_year
-                            , subq_26.ds__extract_quarter
-                            , subq_26.ds__extract_month
-                            , subq_26.ds__extract_day
-                            , subq_26.ds__extract_dow
-                            , subq_26.ds__extract_doy
-                            , subq_26.buy__ds__day
-                            , subq_26.buy__ds__week
-                            , subq_26.buy__ds__month
-                            , subq_26.buy__ds__quarter
-                            , subq_26.buy__ds__year
-                            , subq_26.buy__ds__extract_year
-                            , subq_26.buy__ds__extract_quarter
-                            , subq_26.buy__ds__extract_month
-                            , subq_26.buy__ds__extract_day
-                            , subq_26.buy__ds__extract_dow
-                            , subq_26.buy__ds__extract_doy
-                            , subq_26.metric_time__day
-                            , subq_26.metric_time__week
-                            , subq_26.metric_time__month
-                            , subq_26.metric_time__quarter
-                            , subq_26.metric_time__year
-                            , subq_26.metric_time__extract_year
-                            , subq_26.metric_time__extract_quarter
-                            , subq_26.metric_time__extract_month
-                            , subq_26.metric_time__extract_day
-                            , subq_26.metric_time__extract_dow
-                            , subq_26.metric_time__extract_doy
-                            , subq_26.user
-                            , subq_26.session_id
-                            , subq_26.buy__user
-                            , subq_26.buy__session_id
-                            , subq_26.buys
-                            , subq_26.buyers
+                            subq_11.ds__day
+                            , subq_11.ds__week
+                            , subq_11.ds__month
+                            , subq_11.ds__quarter
+                            , subq_11.ds__year
+                            , subq_11.ds__extract_year
+                            , subq_11.ds__extract_quarter
+                            , subq_11.ds__extract_month
+                            , subq_11.ds__extract_day
+                            , subq_11.ds__extract_dow
+                            , subq_11.ds__extract_doy
+                            , subq_11.buy__ds__day
+                            , subq_11.buy__ds__week
+                            , subq_11.buy__ds__month
+                            , subq_11.buy__ds__quarter
+                            , subq_11.buy__ds__year
+                            , subq_11.buy__ds__extract_year
+                            , subq_11.buy__ds__extract_quarter
+                            , subq_11.buy__ds__extract_month
+                            , subq_11.buy__ds__extract_day
+                            , subq_11.buy__ds__extract_dow
+                            , subq_11.buy__ds__extract_doy
+                            , subq_11.metric_time__day
+                            , subq_11.metric_time__week
+                            , subq_11.metric_time__month
+                            , subq_11.metric_time__quarter
+                            , subq_11.metric_time__year
+                            , subq_11.metric_time__extract_year
+                            , subq_11.metric_time__extract_quarter
+                            , subq_11.metric_time__extract_month
+                            , subq_11.metric_time__extract_day
+                            , subq_11.metric_time__extract_dow
+                            , subq_11.metric_time__extract_doy
+                            , subq_11.user
+                            , subq_11.session_id
+                            , subq_11.buy__user
+                            , subq_11.buy__session_id
+                            , subq_11.buys
+                            , subq_11.buyers
                             , uuid() AS mf_internal_uuid
                           FROM (
                             -- Metric Time Dimension 'ds'
                             SELECT
-                              subq_25.ds__day
-                              , subq_25.ds__week
-                              , subq_25.ds__month
-                              , subq_25.ds__quarter
-                              , subq_25.ds__year
-                              , subq_25.ds__extract_year
-                              , subq_25.ds__extract_quarter
-                              , subq_25.ds__extract_month
-                              , subq_25.ds__extract_day
-                              , subq_25.ds__extract_dow
-                              , subq_25.ds__extract_doy
-                              , subq_25.buy__ds__day
-                              , subq_25.buy__ds__week
-                              , subq_25.buy__ds__month
-                              , subq_25.buy__ds__quarter
-                              , subq_25.buy__ds__year
-                              , subq_25.buy__ds__extract_year
-                              , subq_25.buy__ds__extract_quarter
-                              , subq_25.buy__ds__extract_month
-                              , subq_25.buy__ds__extract_day
-                              , subq_25.buy__ds__extract_dow
-                              , subq_25.buy__ds__extract_doy
-                              , subq_25.ds__day AS metric_time__day
-                              , subq_25.ds__week AS metric_time__week
-                              , subq_25.ds__month AS metric_time__month
-                              , subq_25.ds__quarter AS metric_time__quarter
-                              , subq_25.ds__year AS metric_time__year
-                              , subq_25.ds__extract_year AS metric_time__extract_year
-                              , subq_25.ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_25.ds__extract_month AS metric_time__extract_month
-                              , subq_25.ds__extract_day AS metric_time__extract_day
-                              , subq_25.ds__extract_dow AS metric_time__extract_dow
-                              , subq_25.ds__extract_doy AS metric_time__extract_doy
-                              , subq_25.user
-                              , subq_25.session_id
-                              , subq_25.buy__user
-                              , subq_25.buy__session_id
-                              , subq_25.buys
-                              , subq_25.buyers
+                              subq_10.ds__day
+                              , subq_10.ds__week
+                              , subq_10.ds__month
+                              , subq_10.ds__quarter
+                              , subq_10.ds__year
+                              , subq_10.ds__extract_year
+                              , subq_10.ds__extract_quarter
+                              , subq_10.ds__extract_month
+                              , subq_10.ds__extract_day
+                              , subq_10.ds__extract_dow
+                              , subq_10.ds__extract_doy
+                              , subq_10.buy__ds__day
+                              , subq_10.buy__ds__week
+                              , subq_10.buy__ds__month
+                              , subq_10.buy__ds__quarter
+                              , subq_10.buy__ds__year
+                              , subq_10.buy__ds__extract_year
+                              , subq_10.buy__ds__extract_quarter
+                              , subq_10.buy__ds__extract_month
+                              , subq_10.buy__ds__extract_day
+                              , subq_10.buy__ds__extract_dow
+                              , subq_10.buy__ds__extract_doy
+                              , subq_10.ds__day AS metric_time__day
+                              , subq_10.ds__week AS metric_time__week
+                              , subq_10.ds__month AS metric_time__month
+                              , subq_10.ds__quarter AS metric_time__quarter
+                              , subq_10.ds__year AS metric_time__year
+                              , subq_10.ds__extract_year AS metric_time__extract_year
+                              , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_10.ds__extract_month AS metric_time__extract_month
+                              , subq_10.ds__extract_day AS metric_time__extract_day
+                              , subq_10.ds__extract_dow AS metric_time__extract_dow
+                              , subq_10.ds__extract_doy AS metric_time__extract_doy
+                              , subq_10.user
+                              , subq_10.session_id
+                              , subq_10.buy__user
+                              , subq_10.buy__session_id
+                              , subq_10.buys
+                              , subq_10.buyers
                             FROM (
                               -- Read Elements From Semantic Model 'buys_source'
                               SELECT
@@ -523,33 +523,33 @@ FROM (
                                 , buys_source_src_28000.user_id AS buy__user
                                 , buys_source_src_28000.session_id AS buy__session_id
                               FROM ***************************.fct_buys buys_source_src_28000
-                            ) subq_25
-                          ) subq_26
-                        ) subq_27
+                            ) subq_10
+                          ) subq_11
+                        ) subq_12
                         ON
                           (
-                            subq_24.user = subq_27.user
+                            subq_9.user = subq_12.user
                           ) AND (
-                            (subq_24.ds__day <= subq_27.ds__day)
+                            (subq_9.ds__day <= subq_12.ds__day)
                           )
-                      ) subq_28
-                    ) subq_29
-                  ) subq_30
+                      ) subq_13
+                    ) subq_14
+                  ) subq_15
                   GROUP BY
-                    subq_30.user
-                ) subq_31
+                    subq_15.user
+                ) subq_16
                 ON
-                  subq_21.user = subq_31.user
+                  subq_6.user = subq_16.user
                 GROUP BY
-                  COALESCE(subq_21.user, subq_31.user)
-              ) subq_32
-            ) subq_33
-          ) subq_34
+                  COALESCE(subq_6.user, subq_16.user)
+              ) subq_17
+            ) subq_18
+          ) subq_19
           ON
-            subq_17.user = subq_34.user
-        ) subq_35
-      ) subq_36
+            subq_2.user = subq_19.user
+        ) subq_20
+      ) subq_21
       WHERE user__visit_buy_conversion_rate > 2
-    ) subq_37
-  ) subq_38
-) subq_39
+    ) subq_22
+  ) subq_23
+) subq_24

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_72.buys AS DOUBLE) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
-    , subq_57.listings AS listings
+    CAST(subq_42.buys AS DOUBLE) / CAST(NULLIF(subq_42.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    , subq_27.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_57
+  ) subq_27
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_61.user, subq_71.user) AS user
-      , MAX(subq_61.visits) AS visits
-      , MAX(subq_71.buys) AS buys
+      COALESCE(subq_31.user, subq_41.user) AS user
+      , MAX(subq_31.visits) AS visits
+      , MAX(subq_41.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_60.user
+        subq_30.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_60
+      ) subq_30
       GROUP BY
-        subq_60.user
-    ) subq_61
+        subq_30.user
+    ) subq_31
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_68.user
+        subq_38.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_64.visits) OVER (
+          FIRST_VALUE(subq_34.visits) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_64.ds__day) OVER (
+          , FIRST_VALUE(subq_34.ds__day) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_64.user) OVER (
+          , FIRST_VALUE(subq_34.user) OVER (
             PARTITION BY
-              subq_67.user
-              , subq_67.ds__day
-              , subq_67.mf_internal_uuid
-            ORDER BY subq_64.ds__day DESC
+              subq_37.user
+              , subq_37.ds__day
+              , subq_37.mf_internal_uuid
+            ORDER BY subq_34.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_67.mf_internal_uuid AS mf_internal_uuid
-          , subq_67.buys AS buys
+          , subq_37.mf_internal_uuid AS mf_internal_uuid
+          , subq_37.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_64
+        ) subq_34
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , uuid() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_67
+        ) subq_37
         ON
           (
-            subq_64.user = subq_67.user
+            subq_34.user = subq_37.user
           ) AND (
-            (subq_64.ds__day <= subq_67.ds__day)
+            (subq_34.ds__day <= subq_37.ds__day)
           )
-      ) subq_68
+      ) subq_38
       GROUP BY
-        subq_68.user
-    ) subq_71
+        subq_38.user
+    ) subq_41
     ON
-      subq_61.user = subq_71.user
+      subq_31.user = subq_41.user
     GROUP BY
-      COALESCE(subq_61.user, subq_71.user)
-  ) subq_72
+      COALESCE(subq_31.user, subq_41.user)
+  ) subq_42
   ON
-    subq_57.user = subq_72.user
-) subq_76
+    subq_27.user = subq_42.user
+) subq_46
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0.sql
@@ -1,106 +1,106 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_18.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_17.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_16.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.user__listing__user__average_booking_value
-        , subq_24.listings
+        subq_15.user__listing__user__average_booking_value
+        , subq_15.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
         SELECT
-          subq_23.user__listing__user__average_booking_value
-          , subq_23.listings
+          subq_14.user__listing__user__average_booking_value
+          , subq_14.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.user AS user
-            , subq_22.listing__user AS user__listing__user
-            , subq_22.listing__user__average_booking_value AS user__listing__user__average_booking_value
-            , subq_11.listings AS listings
+            subq_2.user AS user
+            , subq_13.listing__user AS user__listing__user
+            , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_10.user
-              , subq_10.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds__day
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds__extract_year
-                , subq_9.ds__extract_quarter
-                , subq_9.ds__extract_month
-                , subq_9.ds__extract_day
-                , subq_9.ds__extract_dow
-                , subq_9.ds__extract_doy
-                , subq_9.created_at__day
-                , subq_9.created_at__week
-                , subq_9.created_at__month
-                , subq_9.created_at__quarter
-                , subq_9.created_at__year
-                , subq_9.created_at__extract_year
-                , subq_9.created_at__extract_quarter
-                , subq_9.created_at__extract_month
-                , subq_9.created_at__extract_day
-                , subq_9.created_at__extract_dow
-                , subq_9.created_at__extract_doy
-                , subq_9.listing__ds__day
-                , subq_9.listing__ds__week
-                , subq_9.listing__ds__month
-                , subq_9.listing__ds__quarter
-                , subq_9.listing__ds__year
-                , subq_9.listing__ds__extract_year
-                , subq_9.listing__ds__extract_quarter
-                , subq_9.listing__ds__extract_month
-                , subq_9.listing__ds__extract_day
-                , subq_9.listing__ds__extract_dow
-                , subq_9.listing__ds__extract_doy
-                , subq_9.listing__created_at__day
-                , subq_9.listing__created_at__week
-                , subq_9.listing__created_at__month
-                , subq_9.listing__created_at__quarter
-                , subq_9.listing__created_at__year
-                , subq_9.listing__created_at__extract_year
-                , subq_9.listing__created_at__extract_quarter
-                , subq_9.listing__created_at__extract_month
-                , subq_9.listing__created_at__extract_day
-                , subq_9.listing__created_at__extract_dow
-                , subq_9.listing__created_at__extract_doy
-                , subq_9.ds__day AS metric_time__day
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.ds__extract_year AS metric_time__extract_year
-                , subq_9.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.ds__extract_month AS metric_time__extract_month
-                , subq_9.ds__extract_day AS metric_time__extract_day
-                , subq_9.ds__extract_dow AS metric_time__extract_dow
-                , subq_9.ds__extract_doy AS metric_time__extract_doy
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.listing__user
-                , subq_9.country_latest
-                , subq_9.is_lux_latest
-                , subq_9.capacity_latest
-                , subq_9.listing__country_latest
-                , subq_9.listing__is_lux_latest
-                , subq_9.listing__capacity_latest
-                , subq_9.listings
-                , subq_9.largest_listing
-                , subq_9.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -161,141 +161,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
             SELECT
-              subq_21.listing__user
-              , subq_21.listing__user__average_booking_value
+              subq_12.listing__user
+              , subq_12.listing__user__average_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing__user
-                , subq_20.average_booking_value AS listing__user__average_booking_value
+                subq_11.listing__user
+                , subq_11.average_booking_value AS listing__user__average_booking_value
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing__user
-                  , AVG(subq_19.average_booking_value) AS average_booking_value
+                  subq_10.listing__user
+                  , AVG(subq_10.average_booking_value) AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'listing__user']
                   SELECT
-                    subq_18.listing__user
-                    , subq_18.average_booking_value
+                    subq_9.listing__user
+                    , subq_9.average_booking_value
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_14.listing AS listing
-                      , subq_17.user AS listing__user
-                      , subq_14.average_booking_value AS average_booking_value
+                      subq_5.listing AS listing
+                      , subq_8.user AS listing__user
+                      , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']
                       SELECT
-                        subq_13.listing
-                        , subq_13.average_booking_value
+                        subq_4.listing
+                        , subq_4.average_booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_12.ds__day
-                          , subq_12.ds__week
-                          , subq_12.ds__month
-                          , subq_12.ds__quarter
-                          , subq_12.ds__year
-                          , subq_12.ds__extract_year
-                          , subq_12.ds__extract_quarter
-                          , subq_12.ds__extract_month
-                          , subq_12.ds__extract_day
-                          , subq_12.ds__extract_dow
-                          , subq_12.ds__extract_doy
-                          , subq_12.ds_partitioned__day
-                          , subq_12.ds_partitioned__week
-                          , subq_12.ds_partitioned__month
-                          , subq_12.ds_partitioned__quarter
-                          , subq_12.ds_partitioned__year
-                          , subq_12.ds_partitioned__extract_year
-                          , subq_12.ds_partitioned__extract_quarter
-                          , subq_12.ds_partitioned__extract_month
-                          , subq_12.ds_partitioned__extract_day
-                          , subq_12.ds_partitioned__extract_dow
-                          , subq_12.ds_partitioned__extract_doy
-                          , subq_12.paid_at__day
-                          , subq_12.paid_at__week
-                          , subq_12.paid_at__month
-                          , subq_12.paid_at__quarter
-                          , subq_12.paid_at__year
-                          , subq_12.paid_at__extract_year
-                          , subq_12.paid_at__extract_quarter
-                          , subq_12.paid_at__extract_month
-                          , subq_12.paid_at__extract_day
-                          , subq_12.paid_at__extract_dow
-                          , subq_12.paid_at__extract_doy
-                          , subq_12.booking__ds__day
-                          , subq_12.booking__ds__week
-                          , subq_12.booking__ds__month
-                          , subq_12.booking__ds__quarter
-                          , subq_12.booking__ds__year
-                          , subq_12.booking__ds__extract_year
-                          , subq_12.booking__ds__extract_quarter
-                          , subq_12.booking__ds__extract_month
-                          , subq_12.booking__ds__extract_day
-                          , subq_12.booking__ds__extract_dow
-                          , subq_12.booking__ds__extract_doy
-                          , subq_12.booking__ds_partitioned__day
-                          , subq_12.booking__ds_partitioned__week
-                          , subq_12.booking__ds_partitioned__month
-                          , subq_12.booking__ds_partitioned__quarter
-                          , subq_12.booking__ds_partitioned__year
-                          , subq_12.booking__ds_partitioned__extract_year
-                          , subq_12.booking__ds_partitioned__extract_quarter
-                          , subq_12.booking__ds_partitioned__extract_month
-                          , subq_12.booking__ds_partitioned__extract_day
-                          , subq_12.booking__ds_partitioned__extract_dow
-                          , subq_12.booking__ds_partitioned__extract_doy
-                          , subq_12.booking__paid_at__day
-                          , subq_12.booking__paid_at__week
-                          , subq_12.booking__paid_at__month
-                          , subq_12.booking__paid_at__quarter
-                          , subq_12.booking__paid_at__year
-                          , subq_12.booking__paid_at__extract_year
-                          , subq_12.booking__paid_at__extract_quarter
-                          , subq_12.booking__paid_at__extract_month
-                          , subq_12.booking__paid_at__extract_day
-                          , subq_12.booking__paid_at__extract_dow
-                          , subq_12.booking__paid_at__extract_doy
-                          , subq_12.ds__day AS metric_time__day
-                          , subq_12.ds__week AS metric_time__week
-                          , subq_12.ds__month AS metric_time__month
-                          , subq_12.ds__quarter AS metric_time__quarter
-                          , subq_12.ds__year AS metric_time__year
-                          , subq_12.ds__extract_year AS metric_time__extract_year
-                          , subq_12.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_12.ds__extract_month AS metric_time__extract_month
-                          , subq_12.ds__extract_day AS metric_time__extract_day
-                          , subq_12.ds__extract_dow AS metric_time__extract_dow
-                          , subq_12.ds__extract_doy AS metric_time__extract_doy
-                          , subq_12.listing
-                          , subq_12.guest
-                          , subq_12.host
-                          , subq_12.booking__listing
-                          , subq_12.booking__guest
-                          , subq_12.booking__host
-                          , subq_12.is_instant
-                          , subq_12.booking__is_instant
-                          , subq_12.bookings
-                          , subq_12.instant_bookings
-                          , subq_12.booking_value
-                          , subq_12.max_booking_value
-                          , subq_12.min_booking_value
-                          , subq_12.bookers
-                          , subq_12.average_booking_value
-                          , subq_12.referred_bookings
-                          , subq_12.median_booking_value
-                          , subq_12.booking_value_p99
-                          , subq_12.discrete_booking_value_p99
-                          , subq_12.approximate_continuous_booking_value_p99
-                          , subq_12.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -388,84 +388,84 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_12
-                      ) subq_13
-                    ) subq_14
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['listing', 'user']
                       SELECT
-                        subq_16.listing
-                        , subq_16.user
+                        subq_7.listing
+                        , subq_7.user
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_15.ds__day
-                          , subq_15.ds__week
-                          , subq_15.ds__month
-                          , subq_15.ds__quarter
-                          , subq_15.ds__year
-                          , subq_15.ds__extract_year
-                          , subq_15.ds__extract_quarter
-                          , subq_15.ds__extract_month
-                          , subq_15.ds__extract_day
-                          , subq_15.ds__extract_dow
-                          , subq_15.ds__extract_doy
-                          , subq_15.created_at__day
-                          , subq_15.created_at__week
-                          , subq_15.created_at__month
-                          , subq_15.created_at__quarter
-                          , subq_15.created_at__year
-                          , subq_15.created_at__extract_year
-                          , subq_15.created_at__extract_quarter
-                          , subq_15.created_at__extract_month
-                          , subq_15.created_at__extract_day
-                          , subq_15.created_at__extract_dow
-                          , subq_15.created_at__extract_doy
-                          , subq_15.listing__ds__day
-                          , subq_15.listing__ds__week
-                          , subq_15.listing__ds__month
-                          , subq_15.listing__ds__quarter
-                          , subq_15.listing__ds__year
-                          , subq_15.listing__ds__extract_year
-                          , subq_15.listing__ds__extract_quarter
-                          , subq_15.listing__ds__extract_month
-                          , subq_15.listing__ds__extract_day
-                          , subq_15.listing__ds__extract_dow
-                          , subq_15.listing__ds__extract_doy
-                          , subq_15.listing__created_at__day
-                          , subq_15.listing__created_at__week
-                          , subq_15.listing__created_at__month
-                          , subq_15.listing__created_at__quarter
-                          , subq_15.listing__created_at__year
-                          , subq_15.listing__created_at__extract_year
-                          , subq_15.listing__created_at__extract_quarter
-                          , subq_15.listing__created_at__extract_month
-                          , subq_15.listing__created_at__extract_day
-                          , subq_15.listing__created_at__extract_dow
-                          , subq_15.listing__created_at__extract_doy
-                          , subq_15.ds__day AS metric_time__day
-                          , subq_15.ds__week AS metric_time__week
-                          , subq_15.ds__month AS metric_time__month
-                          , subq_15.ds__quarter AS metric_time__quarter
-                          , subq_15.ds__year AS metric_time__year
-                          , subq_15.ds__extract_year AS metric_time__extract_year
-                          , subq_15.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_15.ds__extract_month AS metric_time__extract_month
-                          , subq_15.ds__extract_day AS metric_time__extract_day
-                          , subq_15.ds__extract_dow AS metric_time__extract_dow
-                          , subq_15.ds__extract_doy AS metric_time__extract_doy
-                          , subq_15.listing
-                          , subq_15.user
-                          , subq_15.listing__user
-                          , subq_15.country_latest
-                          , subq_15.is_lux_latest
-                          , subq_15.capacity_latest
-                          , subq_15.listing__country_latest
-                          , subq_15.listing__is_lux_latest
-                          , subq_15.listing__capacity_latest
-                          , subq_15.listings
-                          , subq_15.largest_listing
-                          , subq_15.smallest_listing
+                          subq_6.ds__day
+                          , subq_6.ds__week
+                          , subq_6.ds__month
+                          , subq_6.ds__quarter
+                          , subq_6.ds__year
+                          , subq_6.ds__extract_year
+                          , subq_6.ds__extract_quarter
+                          , subq_6.ds__extract_month
+                          , subq_6.ds__extract_day
+                          , subq_6.ds__extract_dow
+                          , subq_6.ds__extract_doy
+                          , subq_6.created_at__day
+                          , subq_6.created_at__week
+                          , subq_6.created_at__month
+                          , subq_6.created_at__quarter
+                          , subq_6.created_at__year
+                          , subq_6.created_at__extract_year
+                          , subq_6.created_at__extract_quarter
+                          , subq_6.created_at__extract_month
+                          , subq_6.created_at__extract_day
+                          , subq_6.created_at__extract_dow
+                          , subq_6.created_at__extract_doy
+                          , subq_6.listing__ds__day
+                          , subq_6.listing__ds__week
+                          , subq_6.listing__ds__month
+                          , subq_6.listing__ds__quarter
+                          , subq_6.listing__ds__year
+                          , subq_6.listing__ds__extract_year
+                          , subq_6.listing__ds__extract_quarter
+                          , subq_6.listing__ds__extract_month
+                          , subq_6.listing__ds__extract_day
+                          , subq_6.listing__ds__extract_dow
+                          , subq_6.listing__ds__extract_doy
+                          , subq_6.listing__created_at__day
+                          , subq_6.listing__created_at__week
+                          , subq_6.listing__created_at__month
+                          , subq_6.listing__created_at__quarter
+                          , subq_6.listing__created_at__year
+                          , subq_6.listing__created_at__extract_year
+                          , subq_6.listing__created_at__extract_quarter
+                          , subq_6.listing__created_at__extract_month
+                          , subq_6.listing__created_at__extract_day
+                          , subq_6.listing__created_at__extract_dow
+                          , subq_6.listing__created_at__extract_doy
+                          , subq_6.ds__day AS metric_time__day
+                          , subq_6.ds__week AS metric_time__week
+                          , subq_6.ds__month AS metric_time__month
+                          , subq_6.ds__quarter AS metric_time__quarter
+                          , subq_6.ds__year AS metric_time__year
+                          , subq_6.ds__extract_year AS metric_time__extract_year
+                          , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_6.ds__extract_month AS metric_time__extract_month
+                          , subq_6.ds__extract_day AS metric_time__extract_day
+                          , subq_6.ds__extract_dow AS metric_time__extract_dow
+                          , subq_6.ds__extract_doy AS metric_time__extract_doy
+                          , subq_6.listing
+                          , subq_6.user
+                          , subq_6.listing__user
+                          , subq_6.country_latest
+                          , subq_6.is_lux_latest
+                          , subq_6.capacity_latest
+                          , subq_6.listing__country_latest
+                          , subq_6.listing__is_lux_latest
+                          , subq_6.listing__capacity_latest
+                          , subq_6.listings
+                          , subq_6.largest_listing
+                          , subq_6.smallest_listing
                         FROM (
                           -- Read Elements From Semantic Model 'listings_latest'
                           SELECT
@@ -526,23 +526,23 @@ FROM (
                             , listings_latest_src_28000.user_id AS user
                             , listings_latest_src_28000.user_id AS listing__user
                           FROM ***************************.dim_listings_latest listings_latest_src_28000
-                        ) subq_15
-                      ) subq_16
-                    ) subq_17
+                        ) subq_6
+                      ) subq_7
+                    ) subq_8
                     ON
-                      subq_14.listing = subq_17.listing
-                  ) subq_18
-                ) subq_19
+                      subq_5.listing = subq_8.listing
+                  ) subq_9
+                ) subq_10
                 GROUP BY
-                  subq_19.listing__user
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_10.listing__user
+              ) subq_11
+            ) subq_12
+          ) subq_13
           ON
-            subq_11.user = subq_22.listing__user
-        ) subq_23
-      ) subq_24
+            subq_2.user = subq_13.listing__user
+        ) subq_14
+      ) subq_15
       WHERE user__listing__user__average_booking_value > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_16
+  ) subq_17
+) subq_18

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_39.listings AS listings
+    subq_32.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_21.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_39
+  ) subq_21
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_50
+  ) subq_32
   ON
-    subq_39.user = subq_50.listing__user
-) subq_52
+    subq_21.user = subq_32.listing__user
+) subq_34
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_multi_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_40.third_hop_count
+  subq_22.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_39.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_21.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_38.third_hop_count
+      subq_20.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_37.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-        , subq_37.third_hop_count
+        subq_19.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+        , subq_19.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
         SELECT
-          subq_36.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-          , subq_36.third_hop_count
+          subq_18.customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+          , subq_18.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_20.customer_third_hop_id AS customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
-            , subq_35.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
-            , subq_20.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_19.customer_third_hop_id
-              , subq_19.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_18.third_hop_ds__day
-                , subq_18.third_hop_ds__week
-                , subq_18.third_hop_ds__month
-                , subq_18.third_hop_ds__quarter
-                , subq_18.third_hop_ds__year
-                , subq_18.third_hop_ds__extract_year
-                , subq_18.third_hop_ds__extract_quarter
-                , subq_18.third_hop_ds__extract_month
-                , subq_18.third_hop_ds__extract_day
-                , subq_18.third_hop_ds__extract_dow
-                , subq_18.third_hop_ds__extract_doy
-                , subq_18.customer_third_hop_id__third_hop_ds__day
-                , subq_18.customer_third_hop_id__third_hop_ds__week
-                , subq_18.customer_third_hop_id__third_hop_ds__month
-                , subq_18.customer_third_hop_id__third_hop_ds__quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_18.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_18.third_hop_ds__day AS metric_time__day
-                , subq_18.third_hop_ds__week AS metric_time__week
-                , subq_18.third_hop_ds__month AS metric_time__month
-                , subq_18.third_hop_ds__quarter AS metric_time__quarter
-                , subq_18.third_hop_ds__year AS metric_time__year
-                , subq_18.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_18.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_18.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_18.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_18.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_18.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_18.customer_third_hop_id
-                , subq_18.value
-                , subq_18.customer_third_hop_id__value
-                , subq_18.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,105 +101,105 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_18
-            ) subq_19
-          ) subq_20
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
             SELECT
-              subq_34.account_id__customer_id__customer_third_hop_id
-              , subq_34.account_id__customer_id__customer_third_hop_id__txn_count
+              subq_16.account_id__customer_id__customer_third_hop_id
+              , subq_16.account_id__customer_id__customer_third_hop_id__txn_count
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_33.account_id__customer_id__customer_third_hop_id
-                , subq_33.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
+                subq_15.account_id__customer_id__customer_third_hop_id
+                , subq_15.txn_count AS account_id__customer_id__customer_third_hop_id__txn_count
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_32.account_id__customer_id__customer_third_hop_id
-                  , SUM(subq_32.txn_count) AS txn_count
+                  subq_14.account_id__customer_id__customer_third_hop_id
+                  , SUM(subq_14.txn_count) AS txn_count
                 FROM (
                   -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_third_hop_id']
                   SELECT
-                    subq_31.account_id__customer_id__customer_third_hop_id
-                    , subq_31.txn_count
+                    subq_13.account_id__customer_id__customer_third_hop_id
+                    , subq_13.txn_count
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_23.ds_partitioned__day AS ds_partitioned__day
-                      , subq_30.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_23.account_id AS account_id
-                      , subq_30.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
-                      , subq_23.txn_count AS txn_count
+                      subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
+                      , subq_5.account_id AS account_id
+                      , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
                       SELECT
-                        subq_22.ds_partitioned__day
-                        , subq_22.account_id
-                        , subq_22.txn_count
+                        subq_4.ds_partitioned__day
+                        , subq_4.account_id
+                        , subq_4.txn_count
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_21.ds_partitioned__day
-                          , subq_21.ds_partitioned__week
-                          , subq_21.ds_partitioned__month
-                          , subq_21.ds_partitioned__quarter
-                          , subq_21.ds_partitioned__year
-                          , subq_21.ds_partitioned__extract_year
-                          , subq_21.ds_partitioned__extract_quarter
-                          , subq_21.ds_partitioned__extract_month
-                          , subq_21.ds_partitioned__extract_day
-                          , subq_21.ds_partitioned__extract_dow
-                          , subq_21.ds_partitioned__extract_doy
-                          , subq_21.ds__day
-                          , subq_21.ds__week
-                          , subq_21.ds__month
-                          , subq_21.ds__quarter
-                          , subq_21.ds__year
-                          , subq_21.ds__extract_year
-                          , subq_21.ds__extract_quarter
-                          , subq_21.ds__extract_month
-                          , subq_21.ds__extract_day
-                          , subq_21.ds__extract_dow
-                          , subq_21.ds__extract_doy
-                          , subq_21.account_id__ds_partitioned__day
-                          , subq_21.account_id__ds_partitioned__week
-                          , subq_21.account_id__ds_partitioned__month
-                          , subq_21.account_id__ds_partitioned__quarter
-                          , subq_21.account_id__ds_partitioned__year
-                          , subq_21.account_id__ds_partitioned__extract_year
-                          , subq_21.account_id__ds_partitioned__extract_quarter
-                          , subq_21.account_id__ds_partitioned__extract_month
-                          , subq_21.account_id__ds_partitioned__extract_day
-                          , subq_21.account_id__ds_partitioned__extract_dow
-                          , subq_21.account_id__ds_partitioned__extract_doy
-                          , subq_21.account_id__ds__day
-                          , subq_21.account_id__ds__week
-                          , subq_21.account_id__ds__month
-                          , subq_21.account_id__ds__quarter
-                          , subq_21.account_id__ds__year
-                          , subq_21.account_id__ds__extract_year
-                          , subq_21.account_id__ds__extract_quarter
-                          , subq_21.account_id__ds__extract_month
-                          , subq_21.account_id__ds__extract_day
-                          , subq_21.account_id__ds__extract_dow
-                          , subq_21.account_id__ds__extract_doy
-                          , subq_21.ds__day AS metric_time__day
-                          , subq_21.ds__week AS metric_time__week
-                          , subq_21.ds__month AS metric_time__month
-                          , subq_21.ds__quarter AS metric_time__quarter
-                          , subq_21.ds__year AS metric_time__year
-                          , subq_21.ds__extract_year AS metric_time__extract_year
-                          , subq_21.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_21.ds__extract_month AS metric_time__extract_month
-                          , subq_21.ds__extract_day AS metric_time__extract_day
-                          , subq_21.ds__extract_dow AS metric_time__extract_dow
-                          , subq_21.ds__extract_doy AS metric_time__extract_doy
-                          , subq_21.account_id
-                          , subq_21.account_month
-                          , subq_21.account_id__account_month
-                          , subq_21.txn_count
+                          subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.account_id__ds_partitioned__day
+                          , subq_3.account_id__ds_partitioned__week
+                          , subq_3.account_id__ds_partitioned__month
+                          , subq_3.account_id__ds_partitioned__quarter
+                          , subq_3.account_id__ds_partitioned__year
+                          , subq_3.account_id__ds_partitioned__extract_year
+                          , subq_3.account_id__ds_partitioned__extract_quarter
+                          , subq_3.account_id__ds_partitioned__extract_month
+                          , subq_3.account_id__ds_partitioned__extract_day
+                          , subq_3.account_id__ds_partitioned__extract_dow
+                          , subq_3.account_id__ds_partitioned__extract_doy
+                          , subq_3.account_id__ds__day
+                          , subq_3.account_id__ds__week
+                          , subq_3.account_id__ds__month
+                          , subq_3.account_id__ds__quarter
+                          , subq_3.account_id__ds__year
+                          , subq_3.account_id__ds__extract_year
+                          , subq_3.account_id__ds__extract_quarter
+                          , subq_3.account_id__ds__extract_month
+                          , subq_3.account_id__ds__extract_day
+                          , subq_3.account_id__ds__extract_dow
+                          , subq_3.account_id__ds__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.account_id
+                          , subq_3.account_month
+                          , subq_3.account_id__account_month
+                          , subq_3.txn_count
                         FROM (
                           -- Read Elements From Semantic Model 'account_month_txns'
                           SELECT
@@ -252,164 +252,164 @@ FROM (
                             , account_month_txns_src_22000.account_month AS account_id__account_month
                             , account_month_txns_src_22000.account_id
                           FROM ***************************.account_month_txns account_month_txns_src_22000
-                        ) subq_21
-                      ) subq_22
-                    ) subq_23
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     LEFT OUTER JOIN (
                       -- Pass Only Elements: ['ds_partitioned__day', 'account_id', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_29.ds_partitioned__day
-                        , subq_29.account_id
-                        , subq_29.customer_id__customer_third_hop_id
+                        subq_11.ds_partitioned__day
+                        , subq_11.account_id
+                        , subq_11.customer_id__customer_third_hop_id
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_25.ds_partitioned__day AS ds_partitioned__day
-                          , subq_25.ds_partitioned__week AS ds_partitioned__week
-                          , subq_25.ds_partitioned__month AS ds_partitioned__month
-                          , subq_25.ds_partitioned__quarter AS ds_partitioned__quarter
-                          , subq_25.ds_partitioned__year AS ds_partitioned__year
-                          , subq_25.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                          , subq_25.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                          , subq_25.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                          , subq_25.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                          , subq_25.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                          , subq_25.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                          , subq_25.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-                          , subq_25.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-                          , subq_25.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-                          , subq_25.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-                          , subq_25.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-                          , subq_25.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-                          , subq_25.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-                          , subq_25.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-                          , subq_25.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-                          , subq_25.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-                          , subq_25.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-                          , subq_25.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-                          , subq_25.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-                          , subq_25.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-                          , subq_25.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-                          , subq_25.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-                          , subq_25.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-                          , subq_25.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-                          , subq_25.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-                          , subq_25.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-                          , subq_25.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-                          , subq_25.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-                          , subq_25.metric_time__day AS metric_time__day
-                          , subq_25.metric_time__week AS metric_time__week
-                          , subq_25.metric_time__month AS metric_time__month
-                          , subq_25.metric_time__quarter AS metric_time__quarter
-                          , subq_25.metric_time__year AS metric_time__year
-                          , subq_25.metric_time__extract_year AS metric_time__extract_year
-                          , subq_25.metric_time__extract_quarter AS metric_time__extract_quarter
-                          , subq_25.metric_time__extract_month AS metric_time__extract_month
-                          , subq_25.metric_time__extract_day AS metric_time__extract_day
-                          , subq_25.metric_time__extract_dow AS metric_time__extract_dow
-                          , subq_25.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_28.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_28.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_28.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_28.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_28.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_28.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_28.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_28.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_28.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_28.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_28.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_28.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_28.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_28.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_28.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_28.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_28.metric_time__day AS customer_id__metric_time__day
-                          , subq_28.metric_time__week AS customer_id__metric_time__week
-                          , subq_28.metric_time__month AS customer_id__metric_time__month
-                          , subq_28.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_28.metric_time__year AS customer_id__metric_time__year
-                          , subq_28.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_28.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_28.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_28.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_28.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_28.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-                          , subq_25.account_id AS account_id
-                          , subq_25.customer_id AS customer_id
-                          , subq_25.account_id__customer_id AS account_id__customer_id
-                          , subq_25.bridge_account__account_id AS bridge_account__account_id
-                          , subq_25.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_28.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_28.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
-                          , subq_25.extra_dim AS extra_dim
-                          , subq_25.account_id__extra_dim AS account_id__extra_dim
-                          , subq_25.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_28.country AS customer_id__country
-                          , subq_28.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
-                          , subq_25.account_customer_combos AS account_customer_combos
+                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          , subq_7.ds_partitioned__week AS ds_partitioned__week
+                          , subq_7.ds_partitioned__month AS ds_partitioned__month
+                          , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+                          , subq_7.ds_partitioned__year AS ds_partitioned__year
+                          , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                          , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                          , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                          , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                          , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                          , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                          , subq_7.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+                          , subq_7.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+                          , subq_7.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+                          , subq_7.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+                          , subq_7.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+                          , subq_7.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+                          , subq_7.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+                          , subq_7.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+                          , subq_7.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+                          , subq_7.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+                          , subq_7.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+                          , subq_7.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+                          , subq_7.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+                          , subq_7.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+                          , subq_7.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+                          , subq_7.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+                          , subq_7.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+                          , subq_7.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+                          , subq_7.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+                          , subq_7.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+                          , subq_7.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+                          , subq_7.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+                          , subq_7.metric_time__day AS metric_time__day
+                          , subq_7.metric_time__week AS metric_time__week
+                          , subq_7.metric_time__month AS metric_time__month
+                          , subq_7.metric_time__quarter AS metric_time__quarter
+                          , subq_7.metric_time__year AS metric_time__year
+                          , subq_7.metric_time__extract_year AS metric_time__extract_year
+                          , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+                          , subq_7.metric_time__extract_month AS metric_time__extract_month
+                          , subq_7.metric_time__extract_day AS metric_time__extract_day
+                          , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+                          , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_7.account_id AS account_id
+                          , subq_7.customer_id AS customer_id
+                          , subq_7.account_id__customer_id AS account_id__customer_id
+                          , subq_7.bridge_account__account_id AS bridge_account__account_id
+                          , subq_7.bridge_account__customer_id AS bridge_account__customer_id
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.extra_dim AS extra_dim
+                          , subq_7.account_id__extra_dim AS account_id__extra_dim
+                          , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
+                          , subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'
                           SELECT
-                            subq_24.ds_partitioned__day
-                            , subq_24.ds_partitioned__week
-                            , subq_24.ds_partitioned__month
-                            , subq_24.ds_partitioned__quarter
-                            , subq_24.ds_partitioned__year
-                            , subq_24.ds_partitioned__extract_year
-                            , subq_24.ds_partitioned__extract_quarter
-                            , subq_24.ds_partitioned__extract_month
-                            , subq_24.ds_partitioned__extract_day
-                            , subq_24.ds_partitioned__extract_dow
-                            , subq_24.ds_partitioned__extract_doy
-                            , subq_24.account_id__ds_partitioned__day
-                            , subq_24.account_id__ds_partitioned__week
-                            , subq_24.account_id__ds_partitioned__month
-                            , subq_24.account_id__ds_partitioned__quarter
-                            , subq_24.account_id__ds_partitioned__year
-                            , subq_24.account_id__ds_partitioned__extract_year
-                            , subq_24.account_id__ds_partitioned__extract_quarter
-                            , subq_24.account_id__ds_partitioned__extract_month
-                            , subq_24.account_id__ds_partitioned__extract_day
-                            , subq_24.account_id__ds_partitioned__extract_dow
-                            , subq_24.account_id__ds_partitioned__extract_doy
-                            , subq_24.bridge_account__ds_partitioned__day
-                            , subq_24.bridge_account__ds_partitioned__week
-                            , subq_24.bridge_account__ds_partitioned__month
-                            , subq_24.bridge_account__ds_partitioned__quarter
-                            , subq_24.bridge_account__ds_partitioned__year
-                            , subq_24.bridge_account__ds_partitioned__extract_year
-                            , subq_24.bridge_account__ds_partitioned__extract_quarter
-                            , subq_24.bridge_account__ds_partitioned__extract_month
-                            , subq_24.bridge_account__ds_partitioned__extract_day
-                            , subq_24.bridge_account__ds_partitioned__extract_dow
-                            , subq_24.bridge_account__ds_partitioned__extract_doy
-                            , subq_24.ds_partitioned__day AS metric_time__day
-                            , subq_24.ds_partitioned__week AS metric_time__week
-                            , subq_24.ds_partitioned__month AS metric_time__month
-                            , subq_24.ds_partitioned__quarter AS metric_time__quarter
-                            , subq_24.ds_partitioned__year AS metric_time__year
-                            , subq_24.ds_partitioned__extract_year AS metric_time__extract_year
-                            , subq_24.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                            , subq_24.ds_partitioned__extract_month AS metric_time__extract_month
-                            , subq_24.ds_partitioned__extract_day AS metric_time__extract_day
-                            , subq_24.ds_partitioned__extract_dow AS metric_time__extract_dow
-                            , subq_24.ds_partitioned__extract_doy AS metric_time__extract_doy
-                            , subq_24.account_id
-                            , subq_24.customer_id
-                            , subq_24.account_id__customer_id
-                            , subq_24.bridge_account__account_id
-                            , subq_24.bridge_account__customer_id
-                            , subq_24.extra_dim
-                            , subq_24.account_id__extra_dim
-                            , subq_24.bridge_account__extra_dim
-                            , subq_24.account_customer_combos
+                            subq_6.ds_partitioned__day
+                            , subq_6.ds_partitioned__week
+                            , subq_6.ds_partitioned__month
+                            , subq_6.ds_partitioned__quarter
+                            , subq_6.ds_partitioned__year
+                            , subq_6.ds_partitioned__extract_year
+                            , subq_6.ds_partitioned__extract_quarter
+                            , subq_6.ds_partitioned__extract_month
+                            , subq_6.ds_partitioned__extract_day
+                            , subq_6.ds_partitioned__extract_dow
+                            , subq_6.ds_partitioned__extract_doy
+                            , subq_6.account_id__ds_partitioned__day
+                            , subq_6.account_id__ds_partitioned__week
+                            , subq_6.account_id__ds_partitioned__month
+                            , subq_6.account_id__ds_partitioned__quarter
+                            , subq_6.account_id__ds_partitioned__year
+                            , subq_6.account_id__ds_partitioned__extract_year
+                            , subq_6.account_id__ds_partitioned__extract_quarter
+                            , subq_6.account_id__ds_partitioned__extract_month
+                            , subq_6.account_id__ds_partitioned__extract_day
+                            , subq_6.account_id__ds_partitioned__extract_dow
+                            , subq_6.account_id__ds_partitioned__extract_doy
+                            , subq_6.bridge_account__ds_partitioned__day
+                            , subq_6.bridge_account__ds_partitioned__week
+                            , subq_6.bridge_account__ds_partitioned__month
+                            , subq_6.bridge_account__ds_partitioned__quarter
+                            , subq_6.bridge_account__ds_partitioned__year
+                            , subq_6.bridge_account__ds_partitioned__extract_year
+                            , subq_6.bridge_account__ds_partitioned__extract_quarter
+                            , subq_6.bridge_account__ds_partitioned__extract_month
+                            , subq_6.bridge_account__ds_partitioned__extract_day
+                            , subq_6.bridge_account__ds_partitioned__extract_dow
+                            , subq_6.bridge_account__ds_partitioned__extract_doy
+                            , subq_6.ds_partitioned__day AS metric_time__day
+                            , subq_6.ds_partitioned__week AS metric_time__week
+                            , subq_6.ds_partitioned__month AS metric_time__month
+                            , subq_6.ds_partitioned__quarter AS metric_time__quarter
+                            , subq_6.ds_partitioned__year AS metric_time__year
+                            , subq_6.ds_partitioned__extract_year AS metric_time__extract_year
+                            , subq_6.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                            , subq_6.ds_partitioned__extract_month AS metric_time__extract_month
+                            , subq_6.ds_partitioned__extract_day AS metric_time__extract_day
+                            , subq_6.ds_partitioned__extract_dow AS metric_time__extract_dow
+                            , subq_6.ds_partitioned__extract_doy AS metric_time__extract_doy
+                            , subq_6.account_id
+                            , subq_6.customer_id
+                            , subq_6.account_id__customer_id
+                            , subq_6.bridge_account__account_id
+                            , subq_6.bridge_account__customer_id
+                            , subq_6.extra_dim
+                            , subq_6.account_id__extra_dim
+                            , subq_6.bridge_account__extra_dim
+                            , subq_6.account_customer_combos
                           FROM (
                             -- Read Elements From Semantic Model 'bridge_table'
                             SELECT
@@ -456,8 +456,8 @@ FROM (
                               , bridge_table_src_22000.account_id AS bridge_account__account_id
                               , bridge_table_src_22000.customer_id AS bridge_account__customer_id
                             FROM ***************************.bridge_table bridge_table_src_22000
-                          ) subq_24
-                        ) subq_25
+                          ) subq_6
+                        ) subq_7
                         LEFT OUTER JOIN (
                           -- Pass Only Elements: [
                           --   'country',
@@ -513,112 +513,112 @@ FROM (
                           --   'customer_third_hop_id__customer_id',
                           -- ]
                           SELECT
-                            subq_27.acquired_ds__day
-                            , subq_27.acquired_ds__week
-                            , subq_27.acquired_ds__month
-                            , subq_27.acquired_ds__quarter
-                            , subq_27.acquired_ds__year
-                            , subq_27.acquired_ds__extract_year
-                            , subq_27.acquired_ds__extract_quarter
-                            , subq_27.acquired_ds__extract_month
-                            , subq_27.acquired_ds__extract_day
-                            , subq_27.acquired_ds__extract_dow
-                            , subq_27.acquired_ds__extract_doy
-                            , subq_27.customer_id__acquired_ds__day
-                            , subq_27.customer_id__acquired_ds__week
-                            , subq_27.customer_id__acquired_ds__month
-                            , subq_27.customer_id__acquired_ds__quarter
-                            , subq_27.customer_id__acquired_ds__year
-                            , subq_27.customer_id__acquired_ds__extract_year
-                            , subq_27.customer_id__acquired_ds__extract_quarter
-                            , subq_27.customer_id__acquired_ds__extract_month
-                            , subq_27.customer_id__acquired_ds__extract_day
-                            , subq_27.customer_id__acquired_ds__extract_dow
-                            , subq_27.customer_id__acquired_ds__extract_doy
-                            , subq_27.customer_third_hop_id__acquired_ds__day
-                            , subq_27.customer_third_hop_id__acquired_ds__week
-                            , subq_27.customer_third_hop_id__acquired_ds__month
-                            , subq_27.customer_third_hop_id__acquired_ds__quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_27.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_27.metric_time__day
-                            , subq_27.metric_time__week
-                            , subq_27.metric_time__month
-                            , subq_27.metric_time__quarter
-                            , subq_27.metric_time__year
-                            , subq_27.metric_time__extract_year
-                            , subq_27.metric_time__extract_quarter
-                            , subq_27.metric_time__extract_month
-                            , subq_27.metric_time__extract_day
-                            , subq_27.metric_time__extract_dow
-                            , subq_27.metric_time__extract_doy
-                            , subq_27.customer_id
-                            , subq_27.customer_third_hop_id
-                            , subq_27.customer_id__customer_third_hop_id
-                            , subq_27.customer_third_hop_id__customer_id
-                            , subq_27.country
-                            , subq_27.customer_id__country
-                            , subq_27.customer_third_hop_id__country
+                            subq_9.acquired_ds__day
+                            , subq_9.acquired_ds__week
+                            , subq_9.acquired_ds__month
+                            , subq_9.acquired_ds__quarter
+                            , subq_9.acquired_ds__year
+                            , subq_9.acquired_ds__extract_year
+                            , subq_9.acquired_ds__extract_quarter
+                            , subq_9.acquired_ds__extract_month
+                            , subq_9.acquired_ds__extract_day
+                            , subq_9.acquired_ds__extract_dow
+                            , subq_9.acquired_ds__extract_doy
+                            , subq_9.customer_id__acquired_ds__day
+                            , subq_9.customer_id__acquired_ds__week
+                            , subq_9.customer_id__acquired_ds__month
+                            , subq_9.customer_id__acquired_ds__quarter
+                            , subq_9.customer_id__acquired_ds__year
+                            , subq_9.customer_id__acquired_ds__extract_year
+                            , subq_9.customer_id__acquired_ds__extract_quarter
+                            , subq_9.customer_id__acquired_ds__extract_month
+                            , subq_9.customer_id__acquired_ds__extract_day
+                            , subq_9.customer_id__acquired_ds__extract_dow
+                            , subq_9.customer_id__acquired_ds__extract_doy
+                            , subq_9.customer_third_hop_id__acquired_ds__day
+                            , subq_9.customer_third_hop_id__acquired_ds__week
+                            , subq_9.customer_third_hop_id__acquired_ds__month
+                            , subq_9.customer_third_hop_id__acquired_ds__quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_9.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_9.metric_time__day
+                            , subq_9.metric_time__week
+                            , subq_9.metric_time__month
+                            , subq_9.metric_time__quarter
+                            , subq_9.metric_time__year
+                            , subq_9.metric_time__extract_year
+                            , subq_9.metric_time__extract_quarter
+                            , subq_9.metric_time__extract_month
+                            , subq_9.metric_time__extract_day
+                            , subq_9.metric_time__extract_dow
+                            , subq_9.metric_time__extract_doy
+                            , subq_9.customer_id
+                            , subq_9.customer_third_hop_id
+                            , subq_9.customer_id__customer_third_hop_id
+                            , subq_9.customer_third_hop_id__customer_id
+                            , subq_9.country
+                            , subq_9.customer_id__country
+                            , subq_9.customer_third_hop_id__country
                           FROM (
                             -- Metric Time Dimension 'acquired_ds'
                             SELECT
-                              subq_26.acquired_ds__day
-                              , subq_26.acquired_ds__week
-                              , subq_26.acquired_ds__month
-                              , subq_26.acquired_ds__quarter
-                              , subq_26.acquired_ds__year
-                              , subq_26.acquired_ds__extract_year
-                              , subq_26.acquired_ds__extract_quarter
-                              , subq_26.acquired_ds__extract_month
-                              , subq_26.acquired_ds__extract_day
-                              , subq_26.acquired_ds__extract_dow
-                              , subq_26.acquired_ds__extract_doy
-                              , subq_26.customer_id__acquired_ds__day
-                              , subq_26.customer_id__acquired_ds__week
-                              , subq_26.customer_id__acquired_ds__month
-                              , subq_26.customer_id__acquired_ds__quarter
-                              , subq_26.customer_id__acquired_ds__year
-                              , subq_26.customer_id__acquired_ds__extract_year
-                              , subq_26.customer_id__acquired_ds__extract_quarter
-                              , subq_26.customer_id__acquired_ds__extract_month
-                              , subq_26.customer_id__acquired_ds__extract_day
-                              , subq_26.customer_id__acquired_ds__extract_dow
-                              , subq_26.customer_id__acquired_ds__extract_doy
-                              , subq_26.customer_third_hop_id__acquired_ds__day
-                              , subq_26.customer_third_hop_id__acquired_ds__week
-                              , subq_26.customer_third_hop_id__acquired_ds__month
-                              , subq_26.customer_third_hop_id__acquired_ds__quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_year
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_quarter
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_month
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_day
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_dow
-                              , subq_26.customer_third_hop_id__acquired_ds__extract_doy
-                              , subq_26.acquired_ds__day AS metric_time__day
-                              , subq_26.acquired_ds__week AS metric_time__week
-                              , subq_26.acquired_ds__month AS metric_time__month
-                              , subq_26.acquired_ds__quarter AS metric_time__quarter
-                              , subq_26.acquired_ds__year AS metric_time__year
-                              , subq_26.acquired_ds__extract_year AS metric_time__extract_year
-                              , subq_26.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                              , subq_26.acquired_ds__extract_month AS metric_time__extract_month
-                              , subq_26.acquired_ds__extract_day AS metric_time__extract_day
-                              , subq_26.acquired_ds__extract_dow AS metric_time__extract_dow
-                              , subq_26.acquired_ds__extract_doy AS metric_time__extract_doy
-                              , subq_26.customer_id
-                              , subq_26.customer_third_hop_id
-                              , subq_26.customer_id__customer_third_hop_id
-                              , subq_26.customer_third_hop_id__customer_id
-                              , subq_26.country
-                              , subq_26.customer_id__country
-                              , subq_26.customer_third_hop_id__country
-                              , subq_26.customers_with_other_data
+                              subq_8.acquired_ds__day
+                              , subq_8.acquired_ds__week
+                              , subq_8.acquired_ds__month
+                              , subq_8.acquired_ds__quarter
+                              , subq_8.acquired_ds__year
+                              , subq_8.acquired_ds__extract_year
+                              , subq_8.acquired_ds__extract_quarter
+                              , subq_8.acquired_ds__extract_month
+                              , subq_8.acquired_ds__extract_day
+                              , subq_8.acquired_ds__extract_dow
+                              , subq_8.acquired_ds__extract_doy
+                              , subq_8.customer_id__acquired_ds__day
+                              , subq_8.customer_id__acquired_ds__week
+                              , subq_8.customer_id__acquired_ds__month
+                              , subq_8.customer_id__acquired_ds__quarter
+                              , subq_8.customer_id__acquired_ds__year
+                              , subq_8.customer_id__acquired_ds__extract_year
+                              , subq_8.customer_id__acquired_ds__extract_quarter
+                              , subq_8.customer_id__acquired_ds__extract_month
+                              , subq_8.customer_id__acquired_ds__extract_day
+                              , subq_8.customer_id__acquired_ds__extract_dow
+                              , subq_8.customer_id__acquired_ds__extract_doy
+                              , subq_8.customer_third_hop_id__acquired_ds__day
+                              , subq_8.customer_third_hop_id__acquired_ds__week
+                              , subq_8.customer_third_hop_id__acquired_ds__month
+                              , subq_8.customer_third_hop_id__acquired_ds__quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_year
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_quarter
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_month
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_day
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_dow
+                              , subq_8.customer_third_hop_id__acquired_ds__extract_doy
+                              , subq_8.acquired_ds__day AS metric_time__day
+                              , subq_8.acquired_ds__week AS metric_time__week
+                              , subq_8.acquired_ds__month AS metric_time__month
+                              , subq_8.acquired_ds__quarter AS metric_time__quarter
+                              , subq_8.acquired_ds__year AS metric_time__year
+                              , subq_8.acquired_ds__extract_year AS metric_time__extract_year
+                              , subq_8.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                              , subq_8.acquired_ds__extract_month AS metric_time__extract_month
+                              , subq_8.acquired_ds__extract_day AS metric_time__extract_day
+                              , subq_8.acquired_ds__extract_dow AS metric_time__extract_dow
+                              , subq_8.acquired_ds__extract_doy AS metric_time__extract_doy
+                              , subq_8.customer_id
+                              , subq_8.customer_third_hop_id
+                              , subq_8.customer_id__customer_third_hop_id
+                              , subq_8.customer_third_hop_id__customer_id
+                              , subq_8.country
+                              , subq_8.customer_id__country
+                              , subq_8.customer_third_hop_id__country
+                              , subq_8.customers_with_other_data
                             FROM (
                               -- Read Elements From Semantic Model 'customer_other_data'
                               SELECT
@@ -664,31 +664,31 @@ FROM (
                                 , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                                 , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                               FROM ***************************.customer_other_data customer_other_data_src_22000
-                            ) subq_26
-                          ) subq_27
-                        ) subq_28
+                            ) subq_8
+                          ) subq_9
+                        ) subq_10
                         ON
-                          subq_25.customer_id = subq_28.customer_id
-                      ) subq_29
-                    ) subq_30
+                          subq_7.customer_id = subq_10.customer_id
+                      ) subq_11
+                    ) subq_12
                     ON
                       (
-                        subq_23.account_id = subq_30.account_id
+                        subq_5.account_id = subq_12.account_id
                       ) AND (
-                        subq_23.ds_partitioned__day = subq_30.ds_partitioned__day
+                        subq_5.ds_partitioned__day = subq_12.ds_partitioned__day
                       )
-                  ) subq_31
-                ) subq_32
+                  ) subq_13
+                ) subq_14
                 GROUP BY
-                  subq_32.account_id__customer_id__customer_third_hop_id
-              ) subq_33
-            ) subq_34
-          ) subq_35
+                  subq_14.account_id__customer_id__customer_third_hop_id
+              ) subq_15
+            ) subq_16
+          ) subq_17
           ON
-            subq_20.customer_third_hop_id = subq_35.account_id__customer_id__customer_third_hop_id
-        ) subq_36
-      ) subq_37
+            subq_2.customer_third_hop_id = subq_17.account_id__customer_id__customer_third_hop_id
+        ) subq_18
+      ) subq_19
       WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2
-    ) subq_38
-  ) subq_39
-) subq_40
+    ) subq_20
+  ) subq_21
+) subq_22

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_40.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_35.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_71
+    ) subq_35
     ON
       (
-        account_month_txns_src_22000.account_id = subq_71.account_id
+        account_month_txns_src_22000.account_id = subq_35.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_35.ds_partitioned__day
       )
     GROUP BY
-      subq_71.customer_id__customer_third_hop_id
-  ) subq_76
+      subq_35.customer_id__customer_third_hop_id
+  ) subq_40
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
-) subq_78
+    third_hop_table_src_22000.customer_third_hop_id = subq_40.account_id__customer_id__customer_third_hop_id
+) subq_42
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0.sql
@@ -1,76 +1,76 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_25.third_hop_count
+  subq_16.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_24.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_23.third_hop_count
+      subq_14.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_22.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_22.third_hop_count
+        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_13.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_21.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_21.third_hop_count
+          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_12.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.customer_third_hop_id AS customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_20.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-            , subq_11.third_hop_count AS third_hop_count
+            subq_2.customer_third_hop_id AS customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
             SELECT
-              subq_10.customer_third_hop_id
-              , subq_10.third_hop_count
+              subq_1.customer_third_hop_id
+              , subq_1.third_hop_count
             FROM (
               -- Metric Time Dimension 'third_hop_ds'
               SELECT
-                subq_9.third_hop_ds__day
-                , subq_9.third_hop_ds__week
-                , subq_9.third_hop_ds__month
-                , subq_9.third_hop_ds__quarter
-                , subq_9.third_hop_ds__year
-                , subq_9.third_hop_ds__extract_year
-                , subq_9.third_hop_ds__extract_quarter
-                , subq_9.third_hop_ds__extract_month
-                , subq_9.third_hop_ds__extract_day
-                , subq_9.third_hop_ds__extract_dow
-                , subq_9.third_hop_ds__extract_doy
-                , subq_9.customer_third_hop_id__third_hop_ds__day
-                , subq_9.customer_third_hop_id__third_hop_ds__week
-                , subq_9.customer_third_hop_id__third_hop_ds__month
-                , subq_9.customer_third_hop_id__third_hop_ds__quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_year
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_quarter
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_month
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_day
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_dow
-                , subq_9.customer_third_hop_id__third_hop_ds__extract_doy
-                , subq_9.third_hop_ds__day AS metric_time__day
-                , subq_9.third_hop_ds__week AS metric_time__week
-                , subq_9.third_hop_ds__month AS metric_time__month
-                , subq_9.third_hop_ds__quarter AS metric_time__quarter
-                , subq_9.third_hop_ds__year AS metric_time__year
-                , subq_9.third_hop_ds__extract_year AS metric_time__extract_year
-                , subq_9.third_hop_ds__extract_quarter AS metric_time__extract_quarter
-                , subq_9.third_hop_ds__extract_month AS metric_time__extract_month
-                , subq_9.third_hop_ds__extract_day AS metric_time__extract_day
-                , subq_9.third_hop_ds__extract_dow AS metric_time__extract_dow
-                , subq_9.third_hop_ds__extract_doy AS metric_time__extract_doy
-                , subq_9.customer_third_hop_id
-                , subq_9.value
-                , subq_9.customer_third_hop_id__value
-                , subq_9.third_hop_count
+                subq_0.third_hop_ds__day
+                , subq_0.third_hop_ds__week
+                , subq_0.third_hop_ds__month
+                , subq_0.third_hop_ds__quarter
+                , subq_0.third_hop_ds__year
+                , subq_0.third_hop_ds__extract_year
+                , subq_0.third_hop_ds__extract_quarter
+                , subq_0.third_hop_ds__extract_month
+                , subq_0.third_hop_ds__extract_day
+                , subq_0.third_hop_ds__extract_dow
+                , subq_0.third_hop_ds__extract_doy
+                , subq_0.customer_third_hop_id__third_hop_ds__day
+                , subq_0.customer_third_hop_id__third_hop_ds__week
+                , subq_0.customer_third_hop_id__third_hop_ds__month
+                , subq_0.customer_third_hop_id__third_hop_ds__quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_year
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_quarter
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_month
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_day
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_dow
+                , subq_0.customer_third_hop_id__third_hop_ds__extract_doy
+                , subq_0.third_hop_ds__day AS metric_time__day
+                , subq_0.third_hop_ds__week AS metric_time__week
+                , subq_0.third_hop_ds__month AS metric_time__month
+                , subq_0.third_hop_ds__quarter AS metric_time__quarter
+                , subq_0.third_hop_ds__year AS metric_time__year
+                , subq_0.third_hop_ds__extract_year AS metric_time__extract_year
+                , subq_0.third_hop_ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.third_hop_ds__extract_month AS metric_time__extract_month
+                , subq_0.third_hop_ds__extract_day AS metric_time__extract_day
+                , subq_0.third_hop_ds__extract_dow AS metric_time__extract_dow
+                , subq_0.third_hop_ds__extract_doy AS metric_time__extract_doy
+                , subq_0.customer_third_hop_id
+                , subq_0.value
+                , subq_0.customer_third_hop_id__value
+                , subq_0.third_hop_count
               FROM (
                 -- Read Elements From Semantic Model 'third_hop_table'
                 SELECT
@@ -101,151 +101,151 @@ FROM (
                   , EXTRACT(doy FROM third_hop_table_src_22000.third_hop_ds) AS customer_third_hop_id__third_hop_ds__extract_doy
                   , third_hop_table_src_22000.customer_third_hop_id
                 FROM ***************************.third_hop_table third_hop_table_src_22000
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_19.customer_id__customer_third_hop_id
-              , subq_19.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_10.customer_id__customer_third_hop_id
+              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_18.customer_id__customer_third_hop_id
-                , subq_18.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_9.customer_id__customer_third_hop_id
+                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_17.customer_id__customer_third_hop_id
-                  , SUM(subq_17.customers_with_other_data) AS customers_with_other_data
+                  subq_8.customer_id__customer_third_hop_id
+                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_16.customer_id__customer_third_hop_id
-                    , subq_16.customers_with_other_data
+                    subq_7.customer_id__customer_third_hop_id
+                    , subq_7.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_15.customer_id__customer_third_hop_id
-                      , subq_15.customer_id__country
-                      , subq_15.customers_with_other_data
+                      subq_6.customer_id__customer_third_hop_id
+                      , subq_6.customer_id__country
+                      , subq_6.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_14.customer_id__customer_third_hop_id
-                        , subq_14.customer_id__country
-                        , subq_14.customers_with_other_data
+                        subq_5.customer_id__customer_third_hop_id
+                        , subq_5.customer_id__country
+                        , subq_5.customers_with_other_data
                       FROM (
                         -- Constrain Output with WHERE
                         SELECT
-                          subq_13.acquired_ds__day
-                          , subq_13.acquired_ds__week
-                          , subq_13.acquired_ds__month
-                          , subq_13.acquired_ds__quarter
-                          , subq_13.acquired_ds__year
-                          , subq_13.acquired_ds__extract_year
-                          , subq_13.acquired_ds__extract_quarter
-                          , subq_13.acquired_ds__extract_month
-                          , subq_13.acquired_ds__extract_day
-                          , subq_13.acquired_ds__extract_dow
-                          , subq_13.acquired_ds__extract_doy
-                          , subq_13.customer_id__acquired_ds__day
-                          , subq_13.customer_id__acquired_ds__week
-                          , subq_13.customer_id__acquired_ds__month
-                          , subq_13.customer_id__acquired_ds__quarter
-                          , subq_13.customer_id__acquired_ds__year
-                          , subq_13.customer_id__acquired_ds__extract_year
-                          , subq_13.customer_id__acquired_ds__extract_quarter
-                          , subq_13.customer_id__acquired_ds__extract_month
-                          , subq_13.customer_id__acquired_ds__extract_day
-                          , subq_13.customer_id__acquired_ds__extract_dow
-                          , subq_13.customer_id__acquired_ds__extract_doy
-                          , subq_13.customer_third_hop_id__acquired_ds__day
-                          , subq_13.customer_third_hop_id__acquired_ds__week
-                          , subq_13.customer_third_hop_id__acquired_ds__month
-                          , subq_13.customer_third_hop_id__acquired_ds__quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_13.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_13.metric_time__day
-                          , subq_13.metric_time__week
-                          , subq_13.metric_time__month
-                          , subq_13.metric_time__quarter
-                          , subq_13.metric_time__year
-                          , subq_13.metric_time__extract_year
-                          , subq_13.metric_time__extract_quarter
-                          , subq_13.metric_time__extract_month
-                          , subq_13.metric_time__extract_day
-                          , subq_13.metric_time__extract_dow
-                          , subq_13.metric_time__extract_doy
-                          , subq_13.customer_id
-                          , subq_13.customer_third_hop_id
-                          , subq_13.customer_id__customer_third_hop_id
-                          , subq_13.customer_third_hop_id__customer_id
-                          , subq_13.country
-                          , subq_13.customer_id__country
-                          , subq_13.customer_third_hop_id__country
-                          , subq_13.customers_with_other_data
+                          subq_4.acquired_ds__day
+                          , subq_4.acquired_ds__week
+                          , subq_4.acquired_ds__month
+                          , subq_4.acquired_ds__quarter
+                          , subq_4.acquired_ds__year
+                          , subq_4.acquired_ds__extract_year
+                          , subq_4.acquired_ds__extract_quarter
+                          , subq_4.acquired_ds__extract_month
+                          , subq_4.acquired_ds__extract_day
+                          , subq_4.acquired_ds__extract_dow
+                          , subq_4.acquired_ds__extract_doy
+                          , subq_4.customer_id__acquired_ds__day
+                          , subq_4.customer_id__acquired_ds__week
+                          , subq_4.customer_id__acquired_ds__month
+                          , subq_4.customer_id__acquired_ds__quarter
+                          , subq_4.customer_id__acquired_ds__year
+                          , subq_4.customer_id__acquired_ds__extract_year
+                          , subq_4.customer_id__acquired_ds__extract_quarter
+                          , subq_4.customer_id__acquired_ds__extract_month
+                          , subq_4.customer_id__acquired_ds__extract_day
+                          , subq_4.customer_id__acquired_ds__extract_dow
+                          , subq_4.customer_id__acquired_ds__extract_doy
+                          , subq_4.customer_third_hop_id__acquired_ds__day
+                          , subq_4.customer_third_hop_id__acquired_ds__week
+                          , subq_4.customer_third_hop_id__acquired_ds__month
+                          , subq_4.customer_third_hop_id__acquired_ds__quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_4.metric_time__day
+                          , subq_4.metric_time__week
+                          , subq_4.metric_time__month
+                          , subq_4.metric_time__quarter
+                          , subq_4.metric_time__year
+                          , subq_4.metric_time__extract_year
+                          , subq_4.metric_time__extract_quarter
+                          , subq_4.metric_time__extract_month
+                          , subq_4.metric_time__extract_day
+                          , subq_4.metric_time__extract_dow
+                          , subq_4.metric_time__extract_doy
+                          , subq_4.customer_id
+                          , subq_4.customer_third_hop_id
+                          , subq_4.customer_id__customer_third_hop_id
+                          , subq_4.customer_third_hop_id__customer_id
+                          , subq_4.country
+                          , subq_4.customer_id__country
+                          , subq_4.customer_third_hop_id__country
+                          , subq_4.customers_with_other_data
                         FROM (
                           -- Metric Time Dimension 'acquired_ds'
                           SELECT
-                            subq_12.acquired_ds__day
-                            , subq_12.acquired_ds__week
-                            , subq_12.acquired_ds__month
-                            , subq_12.acquired_ds__quarter
-                            , subq_12.acquired_ds__year
-                            , subq_12.acquired_ds__extract_year
-                            , subq_12.acquired_ds__extract_quarter
-                            , subq_12.acquired_ds__extract_month
-                            , subq_12.acquired_ds__extract_day
-                            , subq_12.acquired_ds__extract_dow
-                            , subq_12.acquired_ds__extract_doy
-                            , subq_12.customer_id__acquired_ds__day
-                            , subq_12.customer_id__acquired_ds__week
-                            , subq_12.customer_id__acquired_ds__month
-                            , subq_12.customer_id__acquired_ds__quarter
-                            , subq_12.customer_id__acquired_ds__year
-                            , subq_12.customer_id__acquired_ds__extract_year
-                            , subq_12.customer_id__acquired_ds__extract_quarter
-                            , subq_12.customer_id__acquired_ds__extract_month
-                            , subq_12.customer_id__acquired_ds__extract_day
-                            , subq_12.customer_id__acquired_ds__extract_dow
-                            , subq_12.customer_id__acquired_ds__extract_doy
-                            , subq_12.customer_third_hop_id__acquired_ds__day
-                            , subq_12.customer_third_hop_id__acquired_ds__week
-                            , subq_12.customer_third_hop_id__acquired_ds__month
-                            , subq_12.customer_third_hop_id__acquired_ds__quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_12.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_12.acquired_ds__day AS metric_time__day
-                            , subq_12.acquired_ds__week AS metric_time__week
-                            , subq_12.acquired_ds__month AS metric_time__month
-                            , subq_12.acquired_ds__quarter AS metric_time__quarter
-                            , subq_12.acquired_ds__year AS metric_time__year
-                            , subq_12.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_12.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_12.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_12.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_12.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_12.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_12.customer_id
-                            , subq_12.customer_third_hop_id
-                            , subq_12.customer_id__customer_third_hop_id
-                            , subq_12.customer_third_hop_id__customer_id
-                            , subq_12.country
-                            , subq_12.customer_id__country
-                            , subq_12.customer_third_hop_id__country
-                            , subq_12.customers_with_other_data
+                            subq_3.acquired_ds__day
+                            , subq_3.acquired_ds__week
+                            , subq_3.acquired_ds__month
+                            , subq_3.acquired_ds__quarter
+                            , subq_3.acquired_ds__year
+                            , subq_3.acquired_ds__extract_year
+                            , subq_3.acquired_ds__extract_quarter
+                            , subq_3.acquired_ds__extract_month
+                            , subq_3.acquired_ds__extract_day
+                            , subq_3.acquired_ds__extract_dow
+                            , subq_3.acquired_ds__extract_doy
+                            , subq_3.customer_id__acquired_ds__day
+                            , subq_3.customer_id__acquired_ds__week
+                            , subq_3.customer_id__acquired_ds__month
+                            , subq_3.customer_id__acquired_ds__quarter
+                            , subq_3.customer_id__acquired_ds__year
+                            , subq_3.customer_id__acquired_ds__extract_year
+                            , subq_3.customer_id__acquired_ds__extract_quarter
+                            , subq_3.customer_id__acquired_ds__extract_month
+                            , subq_3.customer_id__acquired_ds__extract_day
+                            , subq_3.customer_id__acquired_ds__extract_dow
+                            , subq_3.customer_id__acquired_ds__extract_doy
+                            , subq_3.customer_third_hop_id__acquired_ds__day
+                            , subq_3.customer_third_hop_id__acquired_ds__week
+                            , subq_3.customer_third_hop_id__acquired_ds__month
+                            , subq_3.customer_third_hop_id__acquired_ds__quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                            , subq_3.acquired_ds__day AS metric_time__day
+                            , subq_3.acquired_ds__week AS metric_time__week
+                            , subq_3.acquired_ds__month AS metric_time__month
+                            , subq_3.acquired_ds__quarter AS metric_time__quarter
+                            , subq_3.acquired_ds__year AS metric_time__year
+                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                            , subq_3.customer_id
+                            , subq_3.customer_third_hop_id
+                            , subq_3.customer_id__customer_third_hop_id
+                            , subq_3.customer_third_hop_id__customer_id
+                            , subq_3.country
+                            , subq_3.customer_id__country
+                            , subq_3.customer_third_hop_id__country
+                            , subq_3.customers_with_other_data
                           FROM (
                             -- Read Elements From Semantic Model 'customer_other_data'
                             SELECT
@@ -291,24 +291,24 @@ FROM (
                               , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
                               , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
                             FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_12
-                        ) subq_13
+                          ) subq_3
+                        ) subq_4
                         WHERE customer_id__country = 'paraguay'
-                      ) subq_14
-                    ) subq_15
+                      ) subq_5
+                    ) subq_6
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_16
-                ) subq_17
+                  ) subq_7
+                ) subq_8
                 GROUP BY
-                  subq_17.customer_id__customer_third_hop_id
-              ) subq_18
-            ) subq_19
-          ) subq_20
+                  subq_8.customer_id__customer_third_hop_id
+              ) subq_9
+            ) subq_10
+          ) subq_11
           ON
-            subq_11.customer_third_hop_id = subq_20.customer_id__customer_third_hop_id
-        ) subq_21
-      ) subq_22
+            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
+        ) subq_12
+      ) subq_13
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_23
-  ) subq_24
-) subq_25
+    ) subq_14
+  ) subq_15
+) subq_16

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_39
+      ) subq_21
       WHERE customer_id__country = 'paraguay'
-    ) subq_41
+    ) subq_23
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_46
+  ) subq_28
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
-) subq_48
+    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
+) subq_30
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0.sql
@@ -1,136 +1,136 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.bookers
+  subq_13.bookers
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_16.bookers) AS bookers
+    COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
     -- Pass Only Elements: ['bookers',]
     SELECT
-      subq_15.bookers
+      subq_11.bookers
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookers
-        , subq_14.bookers
+        subq_10.listing__bookers
+        , subq_10.bookers
       FROM (
         -- Pass Only Elements: ['bookers', 'listing__bookers']
         SELECT
-          subq_13.listing__bookers
-          , subq_13.bookers
+          subq_9.listing__bookers
+          , subq_9.bookers
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookers AS listing__bookers
-            , subq_6.bookers AS bookers
+            subq_2.listing AS listing
+            , subq_8.listing__bookers AS listing__bookers
+            , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.bookers
+              subq_1.listing
+              , subq_1.bookers
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.ds_partitioned__day
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.ds_partitioned__extract_year
-                , subq_4.ds_partitioned__extract_quarter
-                , subq_4.ds_partitioned__extract_month
-                , subq_4.ds_partitioned__extract_day
-                , subq_4.ds_partitioned__extract_dow
-                , subq_4.ds_partitioned__extract_doy
-                , subq_4.paid_at__day
-                , subq_4.paid_at__week
-                , subq_4.paid_at__month
-                , subq_4.paid_at__quarter
-                , subq_4.paid_at__year
-                , subq_4.paid_at__extract_year
-                , subq_4.paid_at__extract_quarter
-                , subq_4.paid_at__extract_month
-                , subq_4.paid_at__extract_day
-                , subq_4.paid_at__extract_dow
-                , subq_4.paid_at__extract_doy
-                , subq_4.booking__ds__day
-                , subq_4.booking__ds__week
-                , subq_4.booking__ds__month
-                , subq_4.booking__ds__quarter
-                , subq_4.booking__ds__year
-                , subq_4.booking__ds__extract_year
-                , subq_4.booking__ds__extract_quarter
-                , subq_4.booking__ds__extract_month
-                , subq_4.booking__ds__extract_day
-                , subq_4.booking__ds__extract_dow
-                , subq_4.booking__ds__extract_doy
-                , subq_4.booking__ds_partitioned__day
-                , subq_4.booking__ds_partitioned__week
-                , subq_4.booking__ds_partitioned__month
-                , subq_4.booking__ds_partitioned__quarter
-                , subq_4.booking__ds_partitioned__year
-                , subq_4.booking__ds_partitioned__extract_year
-                , subq_4.booking__ds_partitioned__extract_quarter
-                , subq_4.booking__ds_partitioned__extract_month
-                , subq_4.booking__ds_partitioned__extract_day
-                , subq_4.booking__ds_partitioned__extract_dow
-                , subq_4.booking__ds_partitioned__extract_doy
-                , subq_4.booking__paid_at__day
-                , subq_4.booking__paid_at__week
-                , subq_4.booking__paid_at__month
-                , subq_4.booking__paid_at__quarter
-                , subq_4.booking__paid_at__year
-                , subq_4.booking__paid_at__extract_year
-                , subq_4.booking__paid_at__extract_quarter
-                , subq_4.booking__paid_at__extract_month
-                , subq_4.booking__paid_at__extract_day
-                , subq_4.booking__paid_at__extract_dow
-                , subq_4.booking__paid_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.booking__listing
-                , subq_4.booking__guest
-                , subq_4.booking__host
-                , subq_4.is_instant
-                , subq_4.booking__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
-                , subq_4.median_booking_value
-                , subq_4.booking_value_p99
-                , subq_4.discrete_booking_value_p99
-                , subq_4.approximate_continuous_booking_value_p99
-                , subq_4.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -223,130 +223,130 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookers
+              subq_7.listing
+              , subq_7.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookers AS listing__bookers
+                subq_6.listing
+                , subq_6.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , COUNT(DISTINCT subq_9.bookers) AS bookers
+                  subq_5.listing
+                  , COUNT(DISTINCT subq_5.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookers
+                    subq_4.listing
+                    , subq_4.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -439,19 +439,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookers > 1.00
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_30.listing__bookers AS listing__bookers
-    , subq_24.bookers AS bookers
+    subq_22.listing__bookers AS listing__bookers
+    , subq_16.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_with_metric_in_where_filter__plan0.sql
@@ -1,112 +1,112 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time__day
-  , subq_17.listings AS active_listings
+  subq_13.metric_time__day
+  , subq_13.listings AS active_listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.metric_time__day
-    , SUM(subq_16.listings) AS listings
+    subq_12.metric_time__day
+    , SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'metric_time__day']
     SELECT
-      subq_15.metric_time__day
-      , subq_15.listings
+      subq_11.metric_time__day
+      , subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.metric_time__day
-        , subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.metric_time__day
+        , subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
         SELECT
-          subq_13.metric_time__day
-          , subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.metric_time__day
+          , subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.metric_time__day AS metric_time__day
-            , subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']
             SELECT
-              subq_5.metric_time__day
-              , subq_5.listing
-              , subq_5.listings
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -167,130 +167,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -383,21 +383,21 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
+    ) subq_11
+  ) subq_12
   GROUP BY
-    subq_16.metric_time__day
-) subq_17
+    subq_12.metric_time__day
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_24.metric_time__day AS metric_time__day
-    , subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_16.metric_time__day AS metric_time__day
+    , subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.user__revenue_all_time
-        , subq_14.listings
+        subq_10.user__revenue_all_time
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__revenue_all_time']
         SELECT
-          subq_13.user__revenue_all_time
-          , subq_13.listings
+          subq_9.user__revenue_all_time
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.user AS user
-            , subq_12.user__revenue_all_time AS user__revenue_all_time
-            , subq_6.listings AS listings
+            subq_2.user AS user
+            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
             SELECT
-              subq_5.user
-              , subq_5.listings
+              subq_1.user
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,68 +160,68 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['user', 'user__revenue_all_time']
             SELECT
-              subq_11.user
-              , subq_11.user__revenue_all_time
+              subq_7.user
+              , subq_7.user__revenue_all_time
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.user
-                , subq_10.txn_revenue AS user__revenue_all_time
+                subq_6.user
+                , subq_6.txn_revenue AS user__revenue_all_time
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.user
-                  , SUM(subq_9.txn_revenue) AS txn_revenue
+                  subq_5.user
+                  , SUM(subq_5.txn_revenue) AS txn_revenue
                 FROM (
                   -- Pass Only Elements: ['txn_revenue', 'user']
                   SELECT
-                    subq_8.user
-                    , subq_8.txn_revenue
+                    subq_4.user
+                    , subq_4.txn_revenue
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.revenue_instance__ds__day
-                      , subq_7.revenue_instance__ds__week
-                      , subq_7.revenue_instance__ds__month
-                      , subq_7.revenue_instance__ds__quarter
-                      , subq_7.revenue_instance__ds__year
-                      , subq_7.revenue_instance__ds__extract_year
-                      , subq_7.revenue_instance__ds__extract_quarter
-                      , subq_7.revenue_instance__ds__extract_month
-                      , subq_7.revenue_instance__ds__extract_day
-                      , subq_7.revenue_instance__ds__extract_dow
-                      , subq_7.revenue_instance__ds__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.user
-                      , subq_7.revenue_instance__user
-                      , subq_7.txn_revenue
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.revenue_instance__ds__day
+                      , subq_3.revenue_instance__ds__week
+                      , subq_3.revenue_instance__ds__month
+                      , subq_3.revenue_instance__ds__quarter
+                      , subq_3.revenue_instance__ds__year
+                      , subq_3.revenue_instance__ds__extract_year
+                      , subq_3.revenue_instance__ds__extract_quarter
+                      , subq_3.revenue_instance__ds__extract_month
+                      , subq_3.revenue_instance__ds__extract_day
+                      , subq_3.revenue_instance__ds__extract_dow
+                      , subq_3.revenue_instance__ds__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.user
+                      , subq_3.revenue_instance__user
+                      , subq_3.txn_revenue
                     FROM (
                       -- Read Elements From Semantic Model 'revenue'
                       SELECT
@@ -251,19 +251,19 @@ FROM (
                         , revenue_src_28000.user_id AS user
                         , revenue_src_28000.user_id AS revenue_instance__user
                       FROM ***************************.fct_revenue revenue_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.user
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.user
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.user = subq_12.user
-        ) subq_13
-      ) subq_14
+            subq_2.user = subq_8.user
+        ) subq_9
+      ) subq_10
       WHERE user__revenue_all_time > 1
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_30.user__revenue_all_time AS user__revenue_all_time
-    , subq_24.listings AS listings
+    subq_22.user__revenue_all_time AS user__revenue_all_time
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.user = subq_30.user
-) subq_32
+    subq_16.user = subq_22.user
+) subq_24
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__views_times_booking_value
-        , subq_28.listings
+        subq_17.listing__views_times_booking_value
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
         SELECT
-          subq_27.listing__views_times_booking_value
-          , subq_27.listings
+          subq_16.listing__views_times_booking_value
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__views_times_booking_value AS listing__views_times_booking_value
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
             SELECT
-              subq_25.listing
-              , subq_25.listing__views_times_booking_value
+              subq_14.listing
+              , subq_14.listing__views_times_booking_value
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
+                subq_13.listing
                 , booking_value * views AS listing__views_times_booking_value
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.booking_value) AS booking_value
-                  , MAX(subq_23.views) AS views
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.booking_value) AS booking_value
+                  , MAX(subq_12.views) AS views
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.booking_value
+                    subq_6.listing
+                    , subq_6.booking_value
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.booking_value) AS booking_value
+                      subq_5.listing
+                      , SUM(subq_5.booking_value) AS booking_value
                     FROM (
                       -- Pass Only Elements: ['booking_value', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.booking_value
+                        subq_4.listing
+                        , subq_4.booking_value
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,91 +387,91 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.views
+                    subq_11.listing
+                    , subq_11.views
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , SUM(subq_21.views) AS views
+                      subq_10.listing
+                      , SUM(subq_10.views) AS views
                     FROM (
                       -- Pass Only Elements: ['views', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.views
+                        subq_9.listing
+                        , subq_9.views
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.view__ds__day
-                          , subq_19.view__ds__week
-                          , subq_19.view__ds__month
-                          , subq_19.view__ds__quarter
-                          , subq_19.view__ds__year
-                          , subq_19.view__ds__extract_year
-                          , subq_19.view__ds__extract_quarter
-                          , subq_19.view__ds__extract_month
-                          , subq_19.view__ds__extract_day
-                          , subq_19.view__ds__extract_dow
-                          , subq_19.view__ds__extract_doy
-                          , subq_19.view__ds_partitioned__day
-                          , subq_19.view__ds_partitioned__week
-                          , subq_19.view__ds_partitioned__month
-                          , subq_19.view__ds_partitioned__quarter
-                          , subq_19.view__ds_partitioned__year
-                          , subq_19.view__ds_partitioned__extract_year
-                          , subq_19.view__ds_partitioned__extract_quarter
-                          , subq_19.view__ds_partitioned__extract_month
-                          , subq_19.view__ds_partitioned__extract_day
-                          , subq_19.view__ds_partitioned__extract_dow
-                          , subq_19.view__ds_partitioned__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.user
-                          , subq_19.view__listing
-                          , subq_19.view__user
-                          , subq_19.views
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.view__ds__day
+                          , subq_8.view__ds__week
+                          , subq_8.view__ds__month
+                          , subq_8.view__ds__quarter
+                          , subq_8.view__ds__year
+                          , subq_8.view__ds__extract_year
+                          , subq_8.view__ds__extract_quarter
+                          , subq_8.view__ds__extract_month
+                          , subq_8.view__ds__extract_day
+                          , subq_8.view__ds__extract_dow
+                          , subq_8.view__ds__extract_doy
+                          , subq_8.view__ds_partitioned__day
+                          , subq_8.view__ds_partitioned__week
+                          , subq_8.view__ds_partitioned__month
+                          , subq_8.view__ds_partitioned__quarter
+                          , subq_8.view__ds_partitioned__year
+                          , subq_8.view__ds_partitioned__extract_year
+                          , subq_8.view__ds_partitioned__extract_quarter
+                          , subq_8.view__ds_partitioned__extract_month
+                          , subq_8.view__ds_partitioned__extract_day
+                          , subq_8.view__ds_partitioned__extract_dow
+                          , subq_8.view__ds_partitioned__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.user
+                          , subq_8.view__listing
+                          , subq_8.view__user
+                          , subq_8.views
                         FROM (
                           -- Read Elements From Semantic Model 'views_source'
                           SELECT
@@ -525,25 +525,25 @@ FROM (
                             , views_source_src_28000.listing_id AS view__listing
                             , views_source_src_28000.user_id AS view__user
                           FROM ***************************.fct_views views_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__views_times_booking_value > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_45.listings AS listings
+    subq_36.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_50.listing, subq_55.listing) AS listing
-        , MAX(subq_50.booking_value) AS booking_value
-        , MAX(subq_55.views) AS views
+        COALESCE(subq_28.listing, subq_33.listing) AS listing
+        , MAX(subq_28.booking_value) AS booking_value
+        , MAX(subq_33.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_50
+      ) subq_28
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_53
+        ) subq_31
         GROUP BY
           listing
-      ) subq_55
+      ) subq_33
       ON
-        subq_50.listing = subq_55.listing
+        subq_28.listing = subq_33.listing
       GROUP BY
-        COALESCE(subq_50.listing, subq_55.listing)
-    ) subq_56
-  ) subq_58
+        COALESCE(subq_28.listing, subq_33.listing)
+    ) subq_34
+  ) subq_36
   ON
-    subq_45.listing = subq_58.listing
-) subq_60
+    subq_23.listing = subq_36.listing
+) subq_38
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -1,108 +1,108 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.listings
+  subq_19.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_26.listings) AS listings
+    SUM(subq_18.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_25.listings
+      subq_17.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_24.listing__bookings
-        , subq_24.listing__bookers
-        , subq_24.listings
+        subq_16.listing__bookings
+        , subq_16.listing__bookers
+        , subq_16.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
         SELECT
-          subq_23.listing__bookings
-          , subq_23.listing__bookers
-          , subq_23.listings
+          subq_15.listing__bookings
+          , subq_15.listing__bookers
+          , subq_15.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_10.listing AS listing
-            , subq_16.listing__bookings AS listing__bookings
-            , subq_22.listing__bookers AS listing__bookers
-            , subq_10.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']
             SELECT
-              subq_9.listing
-              , subq_9.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_8.ds__day
-                , subq_8.ds__week
-                , subq_8.ds__month
-                , subq_8.ds__quarter
-                , subq_8.ds__year
-                , subq_8.ds__extract_year
-                , subq_8.ds__extract_quarter
-                , subq_8.ds__extract_month
-                , subq_8.ds__extract_day
-                , subq_8.ds__extract_dow
-                , subq_8.ds__extract_doy
-                , subq_8.created_at__day
-                , subq_8.created_at__week
-                , subq_8.created_at__month
-                , subq_8.created_at__quarter
-                , subq_8.created_at__year
-                , subq_8.created_at__extract_year
-                , subq_8.created_at__extract_quarter
-                , subq_8.created_at__extract_month
-                , subq_8.created_at__extract_day
-                , subq_8.created_at__extract_dow
-                , subq_8.created_at__extract_doy
-                , subq_8.listing__ds__day
-                , subq_8.listing__ds__week
-                , subq_8.listing__ds__month
-                , subq_8.listing__ds__quarter
-                , subq_8.listing__ds__year
-                , subq_8.listing__ds__extract_year
-                , subq_8.listing__ds__extract_quarter
-                , subq_8.listing__ds__extract_month
-                , subq_8.listing__ds__extract_day
-                , subq_8.listing__ds__extract_dow
-                , subq_8.listing__ds__extract_doy
-                , subq_8.listing__created_at__day
-                , subq_8.listing__created_at__week
-                , subq_8.listing__created_at__month
-                , subq_8.listing__created_at__quarter
-                , subq_8.listing__created_at__year
-                , subq_8.listing__created_at__extract_year
-                , subq_8.listing__created_at__extract_quarter
-                , subq_8.listing__created_at__extract_month
-                , subq_8.listing__created_at__extract_day
-                , subq_8.listing__created_at__extract_dow
-                , subq_8.listing__created_at__extract_doy
-                , subq_8.ds__day AS metric_time__day
-                , subq_8.ds__week AS metric_time__week
-                , subq_8.ds__month AS metric_time__month
-                , subq_8.ds__quarter AS metric_time__quarter
-                , subq_8.ds__year AS metric_time__year
-                , subq_8.ds__extract_year AS metric_time__extract_year
-                , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_8.ds__extract_month AS metric_time__extract_month
-                , subq_8.ds__extract_day AS metric_time__extract_day
-                , subq_8.ds__extract_dow AS metric_time__extract_dow
-                , subq_8.ds__extract_doy AS metric_time__extract_doy
-                , subq_8.listing
-                , subq_8.user
-                , subq_8.listing__user
-                , subq_8.country_latest
-                , subq_8.is_lux_latest
-                , subq_8.capacity_latest
-                , subq_8.listing__country_latest
-                , subq_8.listing__is_lux_latest
-                , subq_8.listing__capacity_latest
-                , subq_8.listings
-                , subq_8.largest_listing
-                , subq_8.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -163,130 +163,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_8
-            ) subq_9
-          ) subq_10
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_15.listing
-              , subq_15.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_14.listing
-                , subq_14.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_13.listing
-                  , SUM(subq_13.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_12.listing
-                    , subq_12.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_11.ds__day
-                      , subq_11.ds__week
-                      , subq_11.ds__month
-                      , subq_11.ds__quarter
-                      , subq_11.ds__year
-                      , subq_11.ds__extract_year
-                      , subq_11.ds__extract_quarter
-                      , subq_11.ds__extract_month
-                      , subq_11.ds__extract_day
-                      , subq_11.ds__extract_dow
-                      , subq_11.ds__extract_doy
-                      , subq_11.ds_partitioned__day
-                      , subq_11.ds_partitioned__week
-                      , subq_11.ds_partitioned__month
-                      , subq_11.ds_partitioned__quarter
-                      , subq_11.ds_partitioned__year
-                      , subq_11.ds_partitioned__extract_year
-                      , subq_11.ds_partitioned__extract_quarter
-                      , subq_11.ds_partitioned__extract_month
-                      , subq_11.ds_partitioned__extract_day
-                      , subq_11.ds_partitioned__extract_dow
-                      , subq_11.ds_partitioned__extract_doy
-                      , subq_11.paid_at__day
-                      , subq_11.paid_at__week
-                      , subq_11.paid_at__month
-                      , subq_11.paid_at__quarter
-                      , subq_11.paid_at__year
-                      , subq_11.paid_at__extract_year
-                      , subq_11.paid_at__extract_quarter
-                      , subq_11.paid_at__extract_month
-                      , subq_11.paid_at__extract_day
-                      , subq_11.paid_at__extract_dow
-                      , subq_11.paid_at__extract_doy
-                      , subq_11.booking__ds__day
-                      , subq_11.booking__ds__week
-                      , subq_11.booking__ds__month
-                      , subq_11.booking__ds__quarter
-                      , subq_11.booking__ds__year
-                      , subq_11.booking__ds__extract_year
-                      , subq_11.booking__ds__extract_quarter
-                      , subq_11.booking__ds__extract_month
-                      , subq_11.booking__ds__extract_day
-                      , subq_11.booking__ds__extract_dow
-                      , subq_11.booking__ds__extract_doy
-                      , subq_11.booking__ds_partitioned__day
-                      , subq_11.booking__ds_partitioned__week
-                      , subq_11.booking__ds_partitioned__month
-                      , subq_11.booking__ds_partitioned__quarter
-                      , subq_11.booking__ds_partitioned__year
-                      , subq_11.booking__ds_partitioned__extract_year
-                      , subq_11.booking__ds_partitioned__extract_quarter
-                      , subq_11.booking__ds_partitioned__extract_month
-                      , subq_11.booking__ds_partitioned__extract_day
-                      , subq_11.booking__ds_partitioned__extract_dow
-                      , subq_11.booking__ds_partitioned__extract_doy
-                      , subq_11.booking__paid_at__day
-                      , subq_11.booking__paid_at__week
-                      , subq_11.booking__paid_at__month
-                      , subq_11.booking__paid_at__quarter
-                      , subq_11.booking__paid_at__year
-                      , subq_11.booking__paid_at__extract_year
-                      , subq_11.booking__paid_at__extract_quarter
-                      , subq_11.booking__paid_at__extract_month
-                      , subq_11.booking__paid_at__extract_day
-                      , subq_11.booking__paid_at__extract_dow
-                      , subq_11.booking__paid_at__extract_doy
-                      , subq_11.ds__day AS metric_time__day
-                      , subq_11.ds__week AS metric_time__week
-                      , subq_11.ds__month AS metric_time__month
-                      , subq_11.ds__quarter AS metric_time__quarter
-                      , subq_11.ds__year AS metric_time__year
-                      , subq_11.ds__extract_year AS metric_time__extract_year
-                      , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_11.ds__extract_month AS metric_time__extract_month
-                      , subq_11.ds__extract_day AS metric_time__extract_day
-                      , subq_11.ds__extract_dow AS metric_time__extract_dow
-                      , subq_11.ds__extract_doy AS metric_time__extract_doy
-                      , subq_11.listing
-                      , subq_11.guest
-                      , subq_11.host
-                      , subq_11.booking__listing
-                      , subq_11.booking__guest
-                      , subq_11.booking__host
-                      , subq_11.is_instant
-                      , subq_11.booking__is_instant
-                      , subq_11.bookings
-                      , subq_11.instant_bookings
-                      , subq_11.booking_value
-                      , subq_11.max_booking_value
-                      , subq_11.min_booking_value
-                      , subq_11.bookers
-                      , subq_11.average_booking_value
-                      , subq_11.referred_bookings
-                      , subq_11.median_booking_value
-                      , subq_11.booking_value_p99
-                      , subq_11.discrete_booking_value_p99
-                      , subq_11.approximate_continuous_booking_value_p99
-                      , subq_11.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -379,137 +379,137 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_11
-                  ) subq_12
-                ) subq_13
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_13.listing
-              ) subq_14
-            ) subq_15
-          ) subq_16
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_10.listing = subq_16.listing
+            subq_2.listing = subq_8.listing
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookers']
             SELECT
-              subq_21.listing
-              , subq_21.listing__bookers
+              subq_13.listing
+              , subq_13.listing__bookers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_20.listing
-                , subq_20.bookers AS listing__bookers
+                subq_12.listing
+                , subq_12.bookers AS listing__bookers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_19.listing
-                  , COUNT(DISTINCT subq_19.bookers) AS bookers
+                  subq_11.listing
+                  , COUNT(DISTINCT subq_11.bookers) AS bookers
                 FROM (
                   -- Pass Only Elements: ['bookers', 'listing']
                   SELECT
-                    subq_18.listing
-                    , subq_18.bookers
+                    subq_10.listing
+                    , subq_10.bookers
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.ds_partitioned__day
-                      , subq_17.ds_partitioned__week
-                      , subq_17.ds_partitioned__month
-                      , subq_17.ds_partitioned__quarter
-                      , subq_17.ds_partitioned__year
-                      , subq_17.ds_partitioned__extract_year
-                      , subq_17.ds_partitioned__extract_quarter
-                      , subq_17.ds_partitioned__extract_month
-                      , subq_17.ds_partitioned__extract_day
-                      , subq_17.ds_partitioned__extract_dow
-                      , subq_17.ds_partitioned__extract_doy
-                      , subq_17.paid_at__day
-                      , subq_17.paid_at__week
-                      , subq_17.paid_at__month
-                      , subq_17.paid_at__quarter
-                      , subq_17.paid_at__year
-                      , subq_17.paid_at__extract_year
-                      , subq_17.paid_at__extract_quarter
-                      , subq_17.paid_at__extract_month
-                      , subq_17.paid_at__extract_day
-                      , subq_17.paid_at__extract_dow
-                      , subq_17.paid_at__extract_doy
-                      , subq_17.booking__ds__day
-                      , subq_17.booking__ds__week
-                      , subq_17.booking__ds__month
-                      , subq_17.booking__ds__quarter
-                      , subq_17.booking__ds__year
-                      , subq_17.booking__ds__extract_year
-                      , subq_17.booking__ds__extract_quarter
-                      , subq_17.booking__ds__extract_month
-                      , subq_17.booking__ds__extract_day
-                      , subq_17.booking__ds__extract_dow
-                      , subq_17.booking__ds__extract_doy
-                      , subq_17.booking__ds_partitioned__day
-                      , subq_17.booking__ds_partitioned__week
-                      , subq_17.booking__ds_partitioned__month
-                      , subq_17.booking__ds_partitioned__quarter
-                      , subq_17.booking__ds_partitioned__year
-                      , subq_17.booking__ds_partitioned__extract_year
-                      , subq_17.booking__ds_partitioned__extract_quarter
-                      , subq_17.booking__ds_partitioned__extract_month
-                      , subq_17.booking__ds_partitioned__extract_day
-                      , subq_17.booking__ds_partitioned__extract_dow
-                      , subq_17.booking__ds_partitioned__extract_doy
-                      , subq_17.booking__paid_at__day
-                      , subq_17.booking__paid_at__week
-                      , subq_17.booking__paid_at__month
-                      , subq_17.booking__paid_at__quarter
-                      , subq_17.booking__paid_at__year
-                      , subq_17.booking__paid_at__extract_year
-                      , subq_17.booking__paid_at__extract_quarter
-                      , subq_17.booking__paid_at__extract_month
-                      , subq_17.booking__paid_at__extract_day
-                      , subq_17.booking__paid_at__extract_dow
-                      , subq_17.booking__paid_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.guest
-                      , subq_17.host
-                      , subq_17.booking__listing
-                      , subq_17.booking__guest
-                      , subq_17.booking__host
-                      , subq_17.is_instant
-                      , subq_17.booking__is_instant
-                      , subq_17.bookings
-                      , subq_17.instant_bookings
-                      , subq_17.booking_value
-                      , subq_17.max_booking_value
-                      , subq_17.min_booking_value
-                      , subq_17.bookers
-                      , subq_17.average_booking_value
-                      , subq_17.referred_bookings
-                      , subq_17.median_booking_value
-                      , subq_17.booking_value_p99
-                      , subq_17.discrete_booking_value_p99
-                      , subq_17.approximate_continuous_booking_value_p99
-                      , subq_17.approximate_discrete_booking_value_p99
+                      subq_9.ds__day
+                      , subq_9.ds__week
+                      , subq_9.ds__month
+                      , subq_9.ds__quarter
+                      , subq_9.ds__year
+                      , subq_9.ds__extract_year
+                      , subq_9.ds__extract_quarter
+                      , subq_9.ds__extract_month
+                      , subq_9.ds__extract_day
+                      , subq_9.ds__extract_dow
+                      , subq_9.ds__extract_doy
+                      , subq_9.ds_partitioned__day
+                      , subq_9.ds_partitioned__week
+                      , subq_9.ds_partitioned__month
+                      , subq_9.ds_partitioned__quarter
+                      , subq_9.ds_partitioned__year
+                      , subq_9.ds_partitioned__extract_year
+                      , subq_9.ds_partitioned__extract_quarter
+                      , subq_9.ds_partitioned__extract_month
+                      , subq_9.ds_partitioned__extract_day
+                      , subq_9.ds_partitioned__extract_dow
+                      , subq_9.ds_partitioned__extract_doy
+                      , subq_9.paid_at__day
+                      , subq_9.paid_at__week
+                      , subq_9.paid_at__month
+                      , subq_9.paid_at__quarter
+                      , subq_9.paid_at__year
+                      , subq_9.paid_at__extract_year
+                      , subq_9.paid_at__extract_quarter
+                      , subq_9.paid_at__extract_month
+                      , subq_9.paid_at__extract_day
+                      , subq_9.paid_at__extract_dow
+                      , subq_9.paid_at__extract_doy
+                      , subq_9.booking__ds__day
+                      , subq_9.booking__ds__week
+                      , subq_9.booking__ds__month
+                      , subq_9.booking__ds__quarter
+                      , subq_9.booking__ds__year
+                      , subq_9.booking__ds__extract_year
+                      , subq_9.booking__ds__extract_quarter
+                      , subq_9.booking__ds__extract_month
+                      , subq_9.booking__ds__extract_day
+                      , subq_9.booking__ds__extract_dow
+                      , subq_9.booking__ds__extract_doy
+                      , subq_9.booking__ds_partitioned__day
+                      , subq_9.booking__ds_partitioned__week
+                      , subq_9.booking__ds_partitioned__month
+                      , subq_9.booking__ds_partitioned__quarter
+                      , subq_9.booking__ds_partitioned__year
+                      , subq_9.booking__ds_partitioned__extract_year
+                      , subq_9.booking__ds_partitioned__extract_quarter
+                      , subq_9.booking__ds_partitioned__extract_month
+                      , subq_9.booking__ds_partitioned__extract_day
+                      , subq_9.booking__ds_partitioned__extract_dow
+                      , subq_9.booking__ds_partitioned__extract_doy
+                      , subq_9.booking__paid_at__day
+                      , subq_9.booking__paid_at__week
+                      , subq_9.booking__paid_at__month
+                      , subq_9.booking__paid_at__quarter
+                      , subq_9.booking__paid_at__year
+                      , subq_9.booking__paid_at__extract_year
+                      , subq_9.booking__paid_at__extract_quarter
+                      , subq_9.booking__paid_at__extract_month
+                      , subq_9.booking__paid_at__extract_day
+                      , subq_9.booking__paid_at__extract_dow
+                      , subq_9.booking__paid_at__extract_doy
+                      , subq_9.ds__day AS metric_time__day
+                      , subq_9.ds__week AS metric_time__week
+                      , subq_9.ds__month AS metric_time__month
+                      , subq_9.ds__quarter AS metric_time__quarter
+                      , subq_9.ds__year AS metric_time__year
+                      , subq_9.ds__extract_year AS metric_time__extract_year
+                      , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_9.ds__extract_month AS metric_time__extract_month
+                      , subq_9.ds__extract_day AS metric_time__extract_day
+                      , subq_9.ds__extract_dow AS metric_time__extract_dow
+                      , subq_9.ds__extract_doy AS metric_time__extract_doy
+                      , subq_9.listing
+                      , subq_9.guest
+                      , subq_9.host
+                      , subq_9.booking__listing
+                      , subq_9.booking__guest
+                      , subq_9.booking__host
+                      , subq_9.is_instant
+                      , subq_9.booking__is_instant
+                      , subq_9.bookings
+                      , subq_9.instant_bookings
+                      , subq_9.booking_value
+                      , subq_9.max_booking_value
+                      , subq_9.min_booking_value
+                      , subq_9.bookers
+                      , subq_9.average_booking_value
+                      , subq_9.referred_bookings
+                      , subq_9.median_booking_value
+                      , subq_9.booking_value_p99
+                      , subq_9.discrete_booking_value_p99
+                      , subq_9.approximate_continuous_booking_value_p99
+                      , subq_9.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -602,19 +602,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_9
+                  ) subq_10
+                ) subq_11
                 GROUP BY
-                  subq_19.listing
-              ) subq_20
-            ) subq_21
-          ) subq_22
+                  subq_11.listing
+              ) subq_12
+            ) subq_13
+          ) subq_14
           ON
-            subq_10.listing = subq_22.listing
-        ) subq_23
-      ) subq_24
+            subq_2.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       WHERE listing__bookings > 2 AND listing__bookers > 1
-    ) subq_25
-  ) subq_26
-) subq_27
+    ) subq_17
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_44.listing__bookings AS listing__bookings
-    , subq_50.listing__bookers AS listing__bookers
-    , subq_38.listings AS listings
+    subq_28.listing__bookings AS listing__bookings
+    , subq_34.listing__bookers AS listing__bookers
+    , subq_22.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_38
+  ) subq_22
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_41
+    ) subq_25
     GROUP BY
       listing
-  ) subq_44
+  ) subq_28
   ON
-    subq_38.listing = subq_44.listing
+    subq_22.listing = subq_28.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_50
+  ) subq_34
   ON
-    subq_38.listing = subq_50.listing
-) subq_52
+    subq_22.listing = subq_34.listing
+) subq_36
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_31.listings
+  subq_20.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_30.listings) AS listings
+    SUM(subq_19.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_29.listings
+      subq_18.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_28.listing__bookings_per_booker
-        , subq_28.listings
+        subq_17.listing__bookings_per_booker
+        , subq_17.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
         SELECT
-          subq_27.listing__bookings_per_booker
-          , subq_27.listings
+          subq_16.listing__bookings_per_booker
+          , subq_16.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_13.listing AS listing
-            , subq_26.listing__bookings_per_booker AS listing__bookings_per_booker
-            , subq_13.listings AS listings
+            subq_2.listing AS listing
+            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_12.listing
-              , subq_12.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_11.ds__day
-                , subq_11.ds__week
-                , subq_11.ds__month
-                , subq_11.ds__quarter
-                , subq_11.ds__year
-                , subq_11.ds__extract_year
-                , subq_11.ds__extract_quarter
-                , subq_11.ds__extract_month
-                , subq_11.ds__extract_day
-                , subq_11.ds__extract_dow
-                , subq_11.ds__extract_doy
-                , subq_11.created_at__day
-                , subq_11.created_at__week
-                , subq_11.created_at__month
-                , subq_11.created_at__quarter
-                , subq_11.created_at__year
-                , subq_11.created_at__extract_year
-                , subq_11.created_at__extract_quarter
-                , subq_11.created_at__extract_month
-                , subq_11.created_at__extract_day
-                , subq_11.created_at__extract_dow
-                , subq_11.created_at__extract_doy
-                , subq_11.listing__ds__day
-                , subq_11.listing__ds__week
-                , subq_11.listing__ds__month
-                , subq_11.listing__ds__quarter
-                , subq_11.listing__ds__year
-                , subq_11.listing__ds__extract_year
-                , subq_11.listing__ds__extract_quarter
-                , subq_11.listing__ds__extract_month
-                , subq_11.listing__ds__extract_day
-                , subq_11.listing__ds__extract_dow
-                , subq_11.listing__ds__extract_doy
-                , subq_11.listing__created_at__day
-                , subq_11.listing__created_at__week
-                , subq_11.listing__created_at__month
-                , subq_11.listing__created_at__quarter
-                , subq_11.listing__created_at__year
-                , subq_11.listing__created_at__extract_year
-                , subq_11.listing__created_at__extract_quarter
-                , subq_11.listing__created_at__extract_month
-                , subq_11.listing__created_at__extract_day
-                , subq_11.listing__created_at__extract_dow
-                , subq_11.listing__created_at__extract_doy
-                , subq_11.ds__day AS metric_time__day
-                , subq_11.ds__week AS metric_time__week
-                , subq_11.ds__month AS metric_time__month
-                , subq_11.ds__quarter AS metric_time__quarter
-                , subq_11.ds__year AS metric_time__year
-                , subq_11.ds__extract_year AS metric_time__extract_year
-                , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_11.ds__extract_month AS metric_time__extract_month
-                , subq_11.ds__extract_day AS metric_time__extract_day
-                , subq_11.ds__extract_dow AS metric_time__extract_dow
-                , subq_11.ds__extract_doy AS metric_time__extract_doy
-                , subq_11.listing
-                , subq_11.user
-                , subq_11.listing__user
-                , subq_11.country_latest
-                , subq_11.is_lux_latest
-                , subq_11.capacity_latest
-                , subq_11.listing__country_latest
-                , subq_11.listing__is_lux_latest
-                , subq_11.listing__capacity_latest
-                , subq_11.listings
-                , subq_11.largest_listing
-                , subq_11.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,141 +160,141 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_11
-            ) subq_12
-          ) subq_13
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings_per_booker']
             SELECT
-              subq_25.listing
-              , subq_25.listing__bookings_per_booker
+              subq_14.listing
+              , subq_14.listing__bookings_per_booker
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_24.listing
-                , CAST(subq_24.bookings AS DOUBLE) / CAST(NULLIF(subq_24.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+                subq_13.listing
+                , CAST(subq_13.bookings AS DOUBLE) / CAST(NULLIF(subq_13.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
               FROM (
                 -- Combine Aggregated Outputs
                 SELECT
-                  COALESCE(subq_18.listing, subq_23.listing) AS listing
-                  , MAX(subq_18.bookings) AS bookings
-                  , MAX(subq_23.bookers) AS bookers
+                  COALESCE(subq_7.listing, subq_12.listing) AS listing
+                  , MAX(subq_7.bookings) AS bookings
+                  , MAX(subq_12.bookers) AS bookers
                 FROM (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_17.listing
-                    , subq_17.bookings
+                    subq_6.listing
+                    , subq_6.bookings
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_16.listing
-                      , SUM(subq_16.bookings) AS bookings
+                      subq_5.listing
+                      , SUM(subq_5.bookings) AS bookings
                     FROM (
                       -- Pass Only Elements: ['bookings', 'listing']
                       SELECT
-                        subq_15.listing
-                        , subq_15.bookings
+                        subq_4.listing
+                        , subq_4.bookings
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_14.ds__day
-                          , subq_14.ds__week
-                          , subq_14.ds__month
-                          , subq_14.ds__quarter
-                          , subq_14.ds__year
-                          , subq_14.ds__extract_year
-                          , subq_14.ds__extract_quarter
-                          , subq_14.ds__extract_month
-                          , subq_14.ds__extract_day
-                          , subq_14.ds__extract_dow
-                          , subq_14.ds__extract_doy
-                          , subq_14.ds_partitioned__day
-                          , subq_14.ds_partitioned__week
-                          , subq_14.ds_partitioned__month
-                          , subq_14.ds_partitioned__quarter
-                          , subq_14.ds_partitioned__year
-                          , subq_14.ds_partitioned__extract_year
-                          , subq_14.ds_partitioned__extract_quarter
-                          , subq_14.ds_partitioned__extract_month
-                          , subq_14.ds_partitioned__extract_day
-                          , subq_14.ds_partitioned__extract_dow
-                          , subq_14.ds_partitioned__extract_doy
-                          , subq_14.paid_at__day
-                          , subq_14.paid_at__week
-                          , subq_14.paid_at__month
-                          , subq_14.paid_at__quarter
-                          , subq_14.paid_at__year
-                          , subq_14.paid_at__extract_year
-                          , subq_14.paid_at__extract_quarter
-                          , subq_14.paid_at__extract_month
-                          , subq_14.paid_at__extract_day
-                          , subq_14.paid_at__extract_dow
-                          , subq_14.paid_at__extract_doy
-                          , subq_14.booking__ds__day
-                          , subq_14.booking__ds__week
-                          , subq_14.booking__ds__month
-                          , subq_14.booking__ds__quarter
-                          , subq_14.booking__ds__year
-                          , subq_14.booking__ds__extract_year
-                          , subq_14.booking__ds__extract_quarter
-                          , subq_14.booking__ds__extract_month
-                          , subq_14.booking__ds__extract_day
-                          , subq_14.booking__ds__extract_dow
-                          , subq_14.booking__ds__extract_doy
-                          , subq_14.booking__ds_partitioned__day
-                          , subq_14.booking__ds_partitioned__week
-                          , subq_14.booking__ds_partitioned__month
-                          , subq_14.booking__ds_partitioned__quarter
-                          , subq_14.booking__ds_partitioned__year
-                          , subq_14.booking__ds_partitioned__extract_year
-                          , subq_14.booking__ds_partitioned__extract_quarter
-                          , subq_14.booking__ds_partitioned__extract_month
-                          , subq_14.booking__ds_partitioned__extract_day
-                          , subq_14.booking__ds_partitioned__extract_dow
-                          , subq_14.booking__ds_partitioned__extract_doy
-                          , subq_14.booking__paid_at__day
-                          , subq_14.booking__paid_at__week
-                          , subq_14.booking__paid_at__month
-                          , subq_14.booking__paid_at__quarter
-                          , subq_14.booking__paid_at__year
-                          , subq_14.booking__paid_at__extract_year
-                          , subq_14.booking__paid_at__extract_quarter
-                          , subq_14.booking__paid_at__extract_month
-                          , subq_14.booking__paid_at__extract_day
-                          , subq_14.booking__paid_at__extract_dow
-                          , subq_14.booking__paid_at__extract_doy
-                          , subq_14.ds__day AS metric_time__day
-                          , subq_14.ds__week AS metric_time__week
-                          , subq_14.ds__month AS metric_time__month
-                          , subq_14.ds__quarter AS metric_time__quarter
-                          , subq_14.ds__year AS metric_time__year
-                          , subq_14.ds__extract_year AS metric_time__extract_year
-                          , subq_14.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_14.ds__extract_month AS metric_time__extract_month
-                          , subq_14.ds__extract_day AS metric_time__extract_day
-                          , subq_14.ds__extract_dow AS metric_time__extract_dow
-                          , subq_14.ds__extract_doy AS metric_time__extract_doy
-                          , subq_14.listing
-                          , subq_14.guest
-                          , subq_14.host
-                          , subq_14.booking__listing
-                          , subq_14.booking__guest
-                          , subq_14.booking__host
-                          , subq_14.is_instant
-                          , subq_14.booking__is_instant
-                          , subq_14.bookings
-                          , subq_14.instant_bookings
-                          , subq_14.booking_value
-                          , subq_14.max_booking_value
-                          , subq_14.min_booking_value
-                          , subq_14.bookers
-                          , subq_14.average_booking_value
-                          , subq_14.referred_bookings
-                          , subq_14.median_booking_value
-                          , subq_14.booking_value_p99
-                          , subq_14.discrete_booking_value_p99
-                          , subq_14.approximate_continuous_booking_value_p99
-                          , subq_14.approximate_discrete_booking_value_p99
+                          subq_3.ds__day
+                          , subq_3.ds__week
+                          , subq_3.ds__month
+                          , subq_3.ds__quarter
+                          , subq_3.ds__year
+                          , subq_3.ds__extract_year
+                          , subq_3.ds__extract_quarter
+                          , subq_3.ds__extract_month
+                          , subq_3.ds__extract_day
+                          , subq_3.ds__extract_dow
+                          , subq_3.ds__extract_doy
+                          , subq_3.ds_partitioned__day
+                          , subq_3.ds_partitioned__week
+                          , subq_3.ds_partitioned__month
+                          , subq_3.ds_partitioned__quarter
+                          , subq_3.ds_partitioned__year
+                          , subq_3.ds_partitioned__extract_year
+                          , subq_3.ds_partitioned__extract_quarter
+                          , subq_3.ds_partitioned__extract_month
+                          , subq_3.ds_partitioned__extract_day
+                          , subq_3.ds_partitioned__extract_dow
+                          , subq_3.ds_partitioned__extract_doy
+                          , subq_3.paid_at__day
+                          , subq_3.paid_at__week
+                          , subq_3.paid_at__month
+                          , subq_3.paid_at__quarter
+                          , subq_3.paid_at__year
+                          , subq_3.paid_at__extract_year
+                          , subq_3.paid_at__extract_quarter
+                          , subq_3.paid_at__extract_month
+                          , subq_3.paid_at__extract_day
+                          , subq_3.paid_at__extract_dow
+                          , subq_3.paid_at__extract_doy
+                          , subq_3.booking__ds__day
+                          , subq_3.booking__ds__week
+                          , subq_3.booking__ds__month
+                          , subq_3.booking__ds__quarter
+                          , subq_3.booking__ds__year
+                          , subq_3.booking__ds__extract_year
+                          , subq_3.booking__ds__extract_quarter
+                          , subq_3.booking__ds__extract_month
+                          , subq_3.booking__ds__extract_day
+                          , subq_3.booking__ds__extract_dow
+                          , subq_3.booking__ds__extract_doy
+                          , subq_3.booking__ds_partitioned__day
+                          , subq_3.booking__ds_partitioned__week
+                          , subq_3.booking__ds_partitioned__month
+                          , subq_3.booking__ds_partitioned__quarter
+                          , subq_3.booking__ds_partitioned__year
+                          , subq_3.booking__ds_partitioned__extract_year
+                          , subq_3.booking__ds_partitioned__extract_quarter
+                          , subq_3.booking__ds_partitioned__extract_month
+                          , subq_3.booking__ds_partitioned__extract_day
+                          , subq_3.booking__ds_partitioned__extract_dow
+                          , subq_3.booking__ds_partitioned__extract_doy
+                          , subq_3.booking__paid_at__day
+                          , subq_3.booking__paid_at__week
+                          , subq_3.booking__paid_at__month
+                          , subq_3.booking__paid_at__quarter
+                          , subq_3.booking__paid_at__year
+                          , subq_3.booking__paid_at__extract_year
+                          , subq_3.booking__paid_at__extract_quarter
+                          , subq_3.booking__paid_at__extract_month
+                          , subq_3.booking__paid_at__extract_day
+                          , subq_3.booking__paid_at__extract_dow
+                          , subq_3.booking__paid_at__extract_doy
+                          , subq_3.ds__day AS metric_time__day
+                          , subq_3.ds__week AS metric_time__week
+                          , subq_3.ds__month AS metric_time__month
+                          , subq_3.ds__quarter AS metric_time__quarter
+                          , subq_3.ds__year AS metric_time__year
+                          , subq_3.ds__extract_year AS metric_time__extract_year
+                          , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.ds__extract_month AS metric_time__extract_month
+                          , subq_3.ds__extract_day AS metric_time__extract_day
+                          , subq_3.ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.listing
+                          , subq_3.guest
+                          , subq_3.host
+                          , subq_3.booking__listing
+                          , subq_3.booking__guest
+                          , subq_3.booking__host
+                          , subq_3.is_instant
+                          , subq_3.booking__is_instant
+                          , subq_3.bookings
+                          , subq_3.instant_bookings
+                          , subq_3.booking_value
+                          , subq_3.max_booking_value
+                          , subq_3.min_booking_value
+                          , subq_3.bookers
+                          , subq_3.average_booking_value
+                          , subq_3.referred_bookings
+                          , subq_3.median_booking_value
+                          , subq_3.booking_value_p99
+                          , subq_3.discrete_booking_value_p99
+                          , subq_3.approximate_continuous_booking_value_p99
+                          , subq_3.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -387,129 +387,129 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_14
-                      ) subq_15
-                    ) subq_16
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     GROUP BY
-                      subq_16.listing
-                  ) subq_17
-                ) subq_18
+                      subq_5.listing
+                  ) subq_6
+                ) subq_7
                 FULL OUTER JOIN (
                   -- Compute Metrics via Expressions
                   SELECT
-                    subq_22.listing
-                    , subq_22.bookers
+                    subq_11.listing
+                    , subq_11.bookers
                   FROM (
                     -- Aggregate Measures
                     SELECT
-                      subq_21.listing
-                      , COUNT(DISTINCT subq_21.bookers) AS bookers
+                      subq_10.listing
+                      , COUNT(DISTINCT subq_10.bookers) AS bookers
                     FROM (
                       -- Pass Only Elements: ['bookers', 'listing']
                       SELECT
-                        subq_20.listing
-                        , subq_20.bookers
+                        subq_9.listing
+                        , subq_9.bookers
                       FROM (
                         -- Metric Time Dimension 'ds'
                         SELECT
-                          subq_19.ds__day
-                          , subq_19.ds__week
-                          , subq_19.ds__month
-                          , subq_19.ds__quarter
-                          , subq_19.ds__year
-                          , subq_19.ds__extract_year
-                          , subq_19.ds__extract_quarter
-                          , subq_19.ds__extract_month
-                          , subq_19.ds__extract_day
-                          , subq_19.ds__extract_dow
-                          , subq_19.ds__extract_doy
-                          , subq_19.ds_partitioned__day
-                          , subq_19.ds_partitioned__week
-                          , subq_19.ds_partitioned__month
-                          , subq_19.ds_partitioned__quarter
-                          , subq_19.ds_partitioned__year
-                          , subq_19.ds_partitioned__extract_year
-                          , subq_19.ds_partitioned__extract_quarter
-                          , subq_19.ds_partitioned__extract_month
-                          , subq_19.ds_partitioned__extract_day
-                          , subq_19.ds_partitioned__extract_dow
-                          , subq_19.ds_partitioned__extract_doy
-                          , subq_19.paid_at__day
-                          , subq_19.paid_at__week
-                          , subq_19.paid_at__month
-                          , subq_19.paid_at__quarter
-                          , subq_19.paid_at__year
-                          , subq_19.paid_at__extract_year
-                          , subq_19.paid_at__extract_quarter
-                          , subq_19.paid_at__extract_month
-                          , subq_19.paid_at__extract_day
-                          , subq_19.paid_at__extract_dow
-                          , subq_19.paid_at__extract_doy
-                          , subq_19.booking__ds__day
-                          , subq_19.booking__ds__week
-                          , subq_19.booking__ds__month
-                          , subq_19.booking__ds__quarter
-                          , subq_19.booking__ds__year
-                          , subq_19.booking__ds__extract_year
-                          , subq_19.booking__ds__extract_quarter
-                          , subq_19.booking__ds__extract_month
-                          , subq_19.booking__ds__extract_day
-                          , subq_19.booking__ds__extract_dow
-                          , subq_19.booking__ds__extract_doy
-                          , subq_19.booking__ds_partitioned__day
-                          , subq_19.booking__ds_partitioned__week
-                          , subq_19.booking__ds_partitioned__month
-                          , subq_19.booking__ds_partitioned__quarter
-                          , subq_19.booking__ds_partitioned__year
-                          , subq_19.booking__ds_partitioned__extract_year
-                          , subq_19.booking__ds_partitioned__extract_quarter
-                          , subq_19.booking__ds_partitioned__extract_month
-                          , subq_19.booking__ds_partitioned__extract_day
-                          , subq_19.booking__ds_partitioned__extract_dow
-                          , subq_19.booking__ds_partitioned__extract_doy
-                          , subq_19.booking__paid_at__day
-                          , subq_19.booking__paid_at__week
-                          , subq_19.booking__paid_at__month
-                          , subq_19.booking__paid_at__quarter
-                          , subq_19.booking__paid_at__year
-                          , subq_19.booking__paid_at__extract_year
-                          , subq_19.booking__paid_at__extract_quarter
-                          , subq_19.booking__paid_at__extract_month
-                          , subq_19.booking__paid_at__extract_day
-                          , subq_19.booking__paid_at__extract_dow
-                          , subq_19.booking__paid_at__extract_doy
-                          , subq_19.ds__day AS metric_time__day
-                          , subq_19.ds__week AS metric_time__week
-                          , subq_19.ds__month AS metric_time__month
-                          , subq_19.ds__quarter AS metric_time__quarter
-                          , subq_19.ds__year AS metric_time__year
-                          , subq_19.ds__extract_year AS metric_time__extract_year
-                          , subq_19.ds__extract_quarter AS metric_time__extract_quarter
-                          , subq_19.ds__extract_month AS metric_time__extract_month
-                          , subq_19.ds__extract_day AS metric_time__extract_day
-                          , subq_19.ds__extract_dow AS metric_time__extract_dow
-                          , subq_19.ds__extract_doy AS metric_time__extract_doy
-                          , subq_19.listing
-                          , subq_19.guest
-                          , subq_19.host
-                          , subq_19.booking__listing
-                          , subq_19.booking__guest
-                          , subq_19.booking__host
-                          , subq_19.is_instant
-                          , subq_19.booking__is_instant
-                          , subq_19.bookings
-                          , subq_19.instant_bookings
-                          , subq_19.booking_value
-                          , subq_19.max_booking_value
-                          , subq_19.min_booking_value
-                          , subq_19.bookers
-                          , subq_19.average_booking_value
-                          , subq_19.referred_bookings
-                          , subq_19.median_booking_value
-                          , subq_19.booking_value_p99
-                          , subq_19.discrete_booking_value_p99
-                          , subq_19.approximate_continuous_booking_value_p99
-                          , subq_19.approximate_discrete_booking_value_p99
+                          subq_8.ds__day
+                          , subq_8.ds__week
+                          , subq_8.ds__month
+                          , subq_8.ds__quarter
+                          , subq_8.ds__year
+                          , subq_8.ds__extract_year
+                          , subq_8.ds__extract_quarter
+                          , subq_8.ds__extract_month
+                          , subq_8.ds__extract_day
+                          , subq_8.ds__extract_dow
+                          , subq_8.ds__extract_doy
+                          , subq_8.ds_partitioned__day
+                          , subq_8.ds_partitioned__week
+                          , subq_8.ds_partitioned__month
+                          , subq_8.ds_partitioned__quarter
+                          , subq_8.ds_partitioned__year
+                          , subq_8.ds_partitioned__extract_year
+                          , subq_8.ds_partitioned__extract_quarter
+                          , subq_8.ds_partitioned__extract_month
+                          , subq_8.ds_partitioned__extract_day
+                          , subq_8.ds_partitioned__extract_dow
+                          , subq_8.ds_partitioned__extract_doy
+                          , subq_8.paid_at__day
+                          , subq_8.paid_at__week
+                          , subq_8.paid_at__month
+                          , subq_8.paid_at__quarter
+                          , subq_8.paid_at__year
+                          , subq_8.paid_at__extract_year
+                          , subq_8.paid_at__extract_quarter
+                          , subq_8.paid_at__extract_month
+                          , subq_8.paid_at__extract_day
+                          , subq_8.paid_at__extract_dow
+                          , subq_8.paid_at__extract_doy
+                          , subq_8.booking__ds__day
+                          , subq_8.booking__ds__week
+                          , subq_8.booking__ds__month
+                          , subq_8.booking__ds__quarter
+                          , subq_8.booking__ds__year
+                          , subq_8.booking__ds__extract_year
+                          , subq_8.booking__ds__extract_quarter
+                          , subq_8.booking__ds__extract_month
+                          , subq_8.booking__ds__extract_day
+                          , subq_8.booking__ds__extract_dow
+                          , subq_8.booking__ds__extract_doy
+                          , subq_8.booking__ds_partitioned__day
+                          , subq_8.booking__ds_partitioned__week
+                          , subq_8.booking__ds_partitioned__month
+                          , subq_8.booking__ds_partitioned__quarter
+                          , subq_8.booking__ds_partitioned__year
+                          , subq_8.booking__ds_partitioned__extract_year
+                          , subq_8.booking__ds_partitioned__extract_quarter
+                          , subq_8.booking__ds_partitioned__extract_month
+                          , subq_8.booking__ds_partitioned__extract_day
+                          , subq_8.booking__ds_partitioned__extract_dow
+                          , subq_8.booking__ds_partitioned__extract_doy
+                          , subq_8.booking__paid_at__day
+                          , subq_8.booking__paid_at__week
+                          , subq_8.booking__paid_at__month
+                          , subq_8.booking__paid_at__quarter
+                          , subq_8.booking__paid_at__year
+                          , subq_8.booking__paid_at__extract_year
+                          , subq_8.booking__paid_at__extract_quarter
+                          , subq_8.booking__paid_at__extract_month
+                          , subq_8.booking__paid_at__extract_day
+                          , subq_8.booking__paid_at__extract_dow
+                          , subq_8.booking__paid_at__extract_doy
+                          , subq_8.ds__day AS metric_time__day
+                          , subq_8.ds__week AS metric_time__week
+                          , subq_8.ds__month AS metric_time__month
+                          , subq_8.ds__quarter AS metric_time__quarter
+                          , subq_8.ds__year AS metric_time__year
+                          , subq_8.ds__extract_year AS metric_time__extract_year
+                          , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_8.ds__extract_month AS metric_time__extract_month
+                          , subq_8.ds__extract_day AS metric_time__extract_day
+                          , subq_8.ds__extract_dow AS metric_time__extract_dow
+                          , subq_8.ds__extract_doy AS metric_time__extract_doy
+                          , subq_8.listing
+                          , subq_8.guest
+                          , subq_8.host
+                          , subq_8.booking__listing
+                          , subq_8.booking__guest
+                          , subq_8.booking__host
+                          , subq_8.is_instant
+                          , subq_8.booking__is_instant
+                          , subq_8.bookings
+                          , subq_8.instant_bookings
+                          , subq_8.booking_value
+                          , subq_8.max_booking_value
+                          , subq_8.min_booking_value
+                          , subq_8.bookers
+                          , subq_8.average_booking_value
+                          , subq_8.referred_bookings
+                          , subq_8.median_booking_value
+                          , subq_8.booking_value_p99
+                          , subq_8.discrete_booking_value_p99
+                          , subq_8.approximate_continuous_booking_value_p99
+                          , subq_8.approximate_discrete_booking_value_p99
                         FROM (
                           -- Read Elements From Semantic Model 'bookings_source'
                           SELECT
@@ -602,25 +602,25 @@ FROM (
                             , bookings_source_src_28000.guest_id AS booking__guest
                             , bookings_source_src_28000.host_id AS booking__host
                           FROM ***************************.fct_bookings bookings_source_src_28000
-                        ) subq_19
-                      ) subq_20
-                    ) subq_21
+                        ) subq_8
+                      ) subq_9
+                    ) subq_10
                     GROUP BY
-                      subq_21.listing
-                  ) subq_22
-                ) subq_23
+                      subq_10.listing
+                  ) subq_11
+                ) subq_12
                 ON
-                  subq_18.listing = subq_23.listing
+                  subq_7.listing = subq_12.listing
                 GROUP BY
-                  COALESCE(subq_18.listing, subq_23.listing)
-              ) subq_24
-            ) subq_25
-          ) subq_26
+                  COALESCE(subq_7.listing, subq_12.listing)
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_13.listing = subq_26.listing
-        ) subq_27
-      ) subq_28
+            subq_2.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       WHERE listing__bookings_per_booker > 1
-    ) subq_29
-  ) subq_30
-) subq_31
+    ) subq_18
+  ) subq_19
+) subq_20

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_56.bookings AS DOUBLE) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
-    , subq_45.listings AS listings
+    CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_45
+  ) subq_23
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_50.listing, subq_55.listing) AS listing
-      , MAX(subq_50.bookings) AS bookings
-      , MAX(subq_55.bookers) AS bookers
+      COALESCE(subq_28.listing, subq_33.listing) AS listing
+      , MAX(subq_28.bookings) AS bookings
+      , MAX(subq_33.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_48
+      ) subq_26
       GROUP BY
         listing
-    ) subq_50
+    ) subq_28
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_55
+    ) subq_33
     ON
-      subq_50.listing = subq_55.listing
+      subq_28.listing = subq_33.listing
     GROUP BY
-      COALESCE(subq_50.listing, subq_55.listing)
-  ) subq_56
+      COALESCE(subq_28.listing, subq_33.listing)
+  ) subq_34
   ON
-    subq_45.listing = subq_56.listing
-) subq_60
+    subq_23.listing = subq_34.listing
+) subq_38
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -1,105 +1,105 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.listings
+  subq_13.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_16.listings) AS listings
+    SUM(subq_12.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings',]
     SELECT
-      subq_15.listings
+      subq_11.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_14.listing__bookings
-        , subq_14.listings
+        subq_10.listing__bookings
+        , subq_10.listings
       FROM (
         -- Pass Only Elements: ['listings', 'listing__bookings']
         SELECT
-          subq_13.listing__bookings
-          , subq_13.listings
+          subq_9.listing__bookings
+          , subq_9.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_6.listing AS listing
-            , subq_12.listing__bookings AS listing__bookings
-            , subq_6.listings AS listings
+            subq_2.listing AS listing
+            , subq_8.listing__bookings AS listing__bookings
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']
             SELECT
-              subq_5.listing
-              , subq_5.listings
+              subq_1.listing
+              , subq_1.listings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -160,130 +160,130 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['listing', 'listing__bookings']
             SELECT
-              subq_11.listing
-              , subq_11.listing__bookings
+              subq_7.listing
+              , subq_7.listing__bookings
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_10.listing
-                , subq_10.bookings AS listing__bookings
+                subq_6.listing
+                , subq_6.bookings AS listing__bookings
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_9.listing
-                  , SUM(subq_9.bookings) AS bookings
+                  subq_5.listing
+                  , SUM(subq_5.bookings) AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'listing']
                   SELECT
-                    subq_8.listing
-                    , subq_8.bookings
+                    subq_4.listing
+                    , subq_4.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_7.ds__day
-                      , subq_7.ds__week
-                      , subq_7.ds__month
-                      , subq_7.ds__quarter
-                      , subq_7.ds__year
-                      , subq_7.ds__extract_year
-                      , subq_7.ds__extract_quarter
-                      , subq_7.ds__extract_month
-                      , subq_7.ds__extract_day
-                      , subq_7.ds__extract_dow
-                      , subq_7.ds__extract_doy
-                      , subq_7.ds_partitioned__day
-                      , subq_7.ds_partitioned__week
-                      , subq_7.ds_partitioned__month
-                      , subq_7.ds_partitioned__quarter
-                      , subq_7.ds_partitioned__year
-                      , subq_7.ds_partitioned__extract_year
-                      , subq_7.ds_partitioned__extract_quarter
-                      , subq_7.ds_partitioned__extract_month
-                      , subq_7.ds_partitioned__extract_day
-                      , subq_7.ds_partitioned__extract_dow
-                      , subq_7.ds_partitioned__extract_doy
-                      , subq_7.paid_at__day
-                      , subq_7.paid_at__week
-                      , subq_7.paid_at__month
-                      , subq_7.paid_at__quarter
-                      , subq_7.paid_at__year
-                      , subq_7.paid_at__extract_year
-                      , subq_7.paid_at__extract_quarter
-                      , subq_7.paid_at__extract_month
-                      , subq_7.paid_at__extract_day
-                      , subq_7.paid_at__extract_dow
-                      , subq_7.paid_at__extract_doy
-                      , subq_7.booking__ds__day
-                      , subq_7.booking__ds__week
-                      , subq_7.booking__ds__month
-                      , subq_7.booking__ds__quarter
-                      , subq_7.booking__ds__year
-                      , subq_7.booking__ds__extract_year
-                      , subq_7.booking__ds__extract_quarter
-                      , subq_7.booking__ds__extract_month
-                      , subq_7.booking__ds__extract_day
-                      , subq_7.booking__ds__extract_dow
-                      , subq_7.booking__ds__extract_doy
-                      , subq_7.booking__ds_partitioned__day
-                      , subq_7.booking__ds_partitioned__week
-                      , subq_7.booking__ds_partitioned__month
-                      , subq_7.booking__ds_partitioned__quarter
-                      , subq_7.booking__ds_partitioned__year
-                      , subq_7.booking__ds_partitioned__extract_year
-                      , subq_7.booking__ds_partitioned__extract_quarter
-                      , subq_7.booking__ds_partitioned__extract_month
-                      , subq_7.booking__ds_partitioned__extract_day
-                      , subq_7.booking__ds_partitioned__extract_dow
-                      , subq_7.booking__ds_partitioned__extract_doy
-                      , subq_7.booking__paid_at__day
-                      , subq_7.booking__paid_at__week
-                      , subq_7.booking__paid_at__month
-                      , subq_7.booking__paid_at__quarter
-                      , subq_7.booking__paid_at__year
-                      , subq_7.booking__paid_at__extract_year
-                      , subq_7.booking__paid_at__extract_quarter
-                      , subq_7.booking__paid_at__extract_month
-                      , subq_7.booking__paid_at__extract_day
-                      , subq_7.booking__paid_at__extract_dow
-                      , subq_7.booking__paid_at__extract_doy
-                      , subq_7.ds__day AS metric_time__day
-                      , subq_7.ds__week AS metric_time__week
-                      , subq_7.ds__month AS metric_time__month
-                      , subq_7.ds__quarter AS metric_time__quarter
-                      , subq_7.ds__year AS metric_time__year
-                      , subq_7.ds__extract_year AS metric_time__extract_year
-                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_7.ds__extract_month AS metric_time__extract_month
-                      , subq_7.ds__extract_day AS metric_time__extract_day
-                      , subq_7.ds__extract_dow AS metric_time__extract_dow
-                      , subq_7.ds__extract_doy AS metric_time__extract_doy
-                      , subq_7.listing
-                      , subq_7.guest
-                      , subq_7.host
-                      , subq_7.booking__listing
-                      , subq_7.booking__guest
-                      , subq_7.booking__host
-                      , subq_7.is_instant
-                      , subq_7.booking__is_instant
-                      , subq_7.bookings
-                      , subq_7.instant_bookings
-                      , subq_7.booking_value
-                      , subq_7.max_booking_value
-                      , subq_7.min_booking_value
-                      , subq_7.bookers
-                      , subq_7.average_booking_value
-                      , subq_7.referred_bookings
-                      , subq_7.median_booking_value
-                      , subq_7.booking_value_p99
-                      , subq_7.discrete_booking_value_p99
-                      , subq_7.approximate_continuous_booking_value_p99
-                      , subq_7.approximate_discrete_booking_value_p99
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.ds_partitioned__day
+                      , subq_3.ds_partitioned__week
+                      , subq_3.ds_partitioned__month
+                      , subq_3.ds_partitioned__quarter
+                      , subq_3.ds_partitioned__year
+                      , subq_3.ds_partitioned__extract_year
+                      , subq_3.ds_partitioned__extract_quarter
+                      , subq_3.ds_partitioned__extract_month
+                      , subq_3.ds_partitioned__extract_day
+                      , subq_3.ds_partitioned__extract_dow
+                      , subq_3.ds_partitioned__extract_doy
+                      , subq_3.paid_at__day
+                      , subq_3.paid_at__week
+                      , subq_3.paid_at__month
+                      , subq_3.paid_at__quarter
+                      , subq_3.paid_at__year
+                      , subq_3.paid_at__extract_year
+                      , subq_3.paid_at__extract_quarter
+                      , subq_3.paid_at__extract_month
+                      , subq_3.paid_at__extract_day
+                      , subq_3.paid_at__extract_dow
+                      , subq_3.paid_at__extract_doy
+                      , subq_3.booking__ds__day
+                      , subq_3.booking__ds__week
+                      , subq_3.booking__ds__month
+                      , subq_3.booking__ds__quarter
+                      , subq_3.booking__ds__year
+                      , subq_3.booking__ds__extract_year
+                      , subq_3.booking__ds__extract_quarter
+                      , subq_3.booking__ds__extract_month
+                      , subq_3.booking__ds__extract_day
+                      , subq_3.booking__ds__extract_dow
+                      , subq_3.booking__ds__extract_doy
+                      , subq_3.booking__ds_partitioned__day
+                      , subq_3.booking__ds_partitioned__week
+                      , subq_3.booking__ds_partitioned__month
+                      , subq_3.booking__ds_partitioned__quarter
+                      , subq_3.booking__ds_partitioned__year
+                      , subq_3.booking__ds_partitioned__extract_year
+                      , subq_3.booking__ds_partitioned__extract_quarter
+                      , subq_3.booking__ds_partitioned__extract_month
+                      , subq_3.booking__ds_partitioned__extract_day
+                      , subq_3.booking__ds_partitioned__extract_dow
+                      , subq_3.booking__ds_partitioned__extract_doy
+                      , subq_3.booking__paid_at__day
+                      , subq_3.booking__paid_at__week
+                      , subq_3.booking__paid_at__month
+                      , subq_3.booking__paid_at__quarter
+                      , subq_3.booking__paid_at__year
+                      , subq_3.booking__paid_at__extract_year
+                      , subq_3.booking__paid_at__extract_quarter
+                      , subq_3.booking__paid_at__extract_month
+                      , subq_3.booking__paid_at__extract_day
+                      , subq_3.booking__paid_at__extract_dow
+                      , subq_3.booking__paid_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.guest
+                      , subq_3.host
+                      , subq_3.booking__listing
+                      , subq_3.booking__guest
+                      , subq_3.booking__host
+                      , subq_3.is_instant
+                      , subq_3.booking__is_instant
+                      , subq_3.bookings
+                      , subq_3.instant_bookings
+                      , subq_3.booking_value
+                      , subq_3.max_booking_value
+                      , subq_3.min_booking_value
+                      , subq_3.bookers
+                      , subq_3.average_booking_value
+                      , subq_3.referred_bookings
+                      , subq_3.median_booking_value
+                      , subq_3.booking_value_p99
+                      , subq_3.discrete_booking_value_p99
+                      , subq_3.approximate_continuous_booking_value_p99
+                      , subq_3.approximate_discrete_booking_value_p99
                     FROM (
                       -- Read Elements From Semantic Model 'bookings_source'
                       SELECT
@@ -376,19 +376,19 @@ FROM (
                         , bookings_source_src_28000.guest_id AS booking__guest
                         , bookings_source_src_28000.host_id AS booking__host
                       FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_7
-                  ) subq_8
-                ) subq_9
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 GROUP BY
-                  subq_9.listing
-              ) subq_10
-            ) subq_11
-          ) subq_12
+                  subq_5.listing
+              ) subq_6
+            ) subq_7
+          ) subq_8
           ON
-            subq_6.listing = subq_12.listing
-        ) subq_13
-      ) subq_14
+            subq_2.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
       WHERE listing__bookings > 2
-    ) subq_15
-  ) subq_16
-) subq_17
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_30.listing__bookings AS listing__bookings
-    , subq_24.listings AS listings
+    subq_22.listing__bookings AS listing__bookings
+    , subq_16.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_24
+  ) subq_16
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_27
+    ) subq_19
     GROUP BY
       listing
-  ) subq_30
+  ) subq_22
   ON
-    subq_24.listing = subq_30.listing
-) subq_32
+    subq_16.listing = subq_22.listing
+) subq_24
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.average_booking_value AS FLOAT64) / CAST(NULLIF(subq_15.max_booking_value, 0) AS FLOAT64) AS instant_booking_fraction_of_max_value
+  subq_13.metric_time__day
+  , CAST(subq_13.average_booking_value AS FLOAT64) / CAST(NULLIF(subq_13.max_booking_value, 0) AS FLOAT64) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.average_booking_value) AS average_booking_value
-    , MAX(subq_14.max_booking_value) AS max_booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.average_booking_value) AS average_booking_value
+    , MAX(subq_12.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.average_booking_value
+      subq_6.metric_time__day
+      , subq_6.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , AVG(subq_7.average_booking_value) AS average_booking_value
+        subq_5.metric_time__day
+        , AVG(subq_5.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.average_booking_value
+          subq_4.metric_time__day
+          , subq_4.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.average_booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.average_booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.average_booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
         metric_time__day
-    ) subq_8
-  ) subq_9
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.max_booking_value
+      subq_11.metric_time__day
+      , subq_11.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , MAX(subq_12.max_booking_value) AS max_booking_value
+        subq_10.metric_time__day
+        , MAX(subq_10.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.max_booking_value
+          subq_9.metric_time__day
+          , subq_9.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
         metric_time__day
-    ) subq_13
-  ) subq_14
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
     metric_time__day
-) subq_15
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.average_booking_value) AS average_booking_value
-    , MAX(subq_30.max_booking_value) AS max_booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.average_booking_value) AS average_booking_value
+    , MAX(subq_26.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       metric_time__day
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
     metric_time__day
-) subq_31
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,186 +1,186 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user__home_state_latest
-  , subq_12.listings
+  subq_10.user__home_state_latest
+  , subq_10.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.user__home_state_latest
-    , SUM(subq_11.listings) AS listings
+    subq_9.user__home_state_latest
+    , SUM(subq_9.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_10.user__home_state_latest
-      , subq_10.listings
+      subq_8.user__home_state_latest
+      , subq_8.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.listing__is_lux_latest
-        , subq_9.listing__capacity_latest
-        , subq_9.user__home_state_latest
-        , subq_9.listings
+        subq_7.listing__is_lux_latest
+        , subq_7.listing__capacity_latest
+        , subq_7.user__home_state_latest
+        , subq_7.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_8.listing__is_lux_latest
-          , subq_8.listing__capacity_latest
-          , subq_8.user__home_state_latest
-          , subq_8.listings
+          subq_6.listing__is_lux_latest
+          , subq_6.listing__capacity_latest
+          , subq_6.user__home_state_latest
+          , subq_6.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.user AS user
-            , subq_5.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_5.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state_latest AS user__home_state_latest
-            , subq_5.listings AS listings
+            subq_3.user AS user
+            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_3.listing__capacity_latest AS listing__capacity_latest
+            , subq_5.home_state_latest AS user__home_state_latest
+            , subq_3.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.listing__is_lux_latest
-              , subq_4.listing__capacity_latest
-              , subq_4.listings
+              subq_2.user
+              , subq_2.listing__is_lux_latest
+              , subq_2.listing__capacity_latest
+              , subq_2.listings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.created_at__day
-                , subq_3.created_at__week
-                , subq_3.created_at__month
-                , subq_3.created_at__quarter
-                , subq_3.created_at__year
-                , subq_3.created_at__extract_year
-                , subq_3.created_at__extract_quarter
-                , subq_3.created_at__extract_month
-                , subq_3.created_at__extract_day
-                , subq_3.created_at__extract_dow
-                , subq_3.created_at__extract_doy
-                , subq_3.listing__ds__day
-                , subq_3.listing__ds__week
-                , subq_3.listing__ds__month
-                , subq_3.listing__ds__quarter
-                , subq_3.listing__ds__year
-                , subq_3.listing__ds__extract_year
-                , subq_3.listing__ds__extract_quarter
-                , subq_3.listing__ds__extract_month
-                , subq_3.listing__ds__extract_day
-                , subq_3.listing__ds__extract_dow
-                , subq_3.listing__ds__extract_doy
-                , subq_3.listing__created_at__day
-                , subq_3.listing__created_at__week
-                , subq_3.listing__created_at__month
-                , subq_3.listing__created_at__quarter
-                , subq_3.listing__created_at__year
-                , subq_3.listing__created_at__extract_year
-                , subq_3.listing__created_at__extract_quarter
-                , subq_3.listing__created_at__extract_month
-                , subq_3.listing__created_at__extract_day
-                , subq_3.listing__created_at__extract_dow
-                , subq_3.listing__created_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.user
-                , subq_3.listing__user
-                , subq_3.country_latest
-                , subq_3.is_lux_latest
-                , subq_3.capacity_latest
-                , subq_3.listing__country_latest
-                , subq_3.listing__is_lux_latest
-                , subq_3.listing__capacity_latest
-                , subq_3.listings
-                , subq_3.largest_listing
-                , subq_3.smallest_listing
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.created_at__day
+                , subq_1.created_at__week
+                , subq_1.created_at__month
+                , subq_1.created_at__quarter
+                , subq_1.created_at__year
+                , subq_1.created_at__extract_year
+                , subq_1.created_at__extract_quarter
+                , subq_1.created_at__extract_month
+                , subq_1.created_at__extract_day
+                , subq_1.created_at__extract_dow
+                , subq_1.created_at__extract_doy
+                , subq_1.listing__ds__day
+                , subq_1.listing__ds__week
+                , subq_1.listing__ds__month
+                , subq_1.listing__ds__quarter
+                , subq_1.listing__ds__year
+                , subq_1.listing__ds__extract_year
+                , subq_1.listing__ds__extract_quarter
+                , subq_1.listing__ds__extract_month
+                , subq_1.listing__ds__extract_day
+                , subq_1.listing__ds__extract_dow
+                , subq_1.listing__ds__extract_doy
+                , subq_1.listing__created_at__day
+                , subq_1.listing__created_at__week
+                , subq_1.listing__created_at__month
+                , subq_1.listing__created_at__quarter
+                , subq_1.listing__created_at__year
+                , subq_1.listing__created_at__extract_year
+                , subq_1.listing__created_at__extract_quarter
+                , subq_1.listing__created_at__extract_month
+                , subq_1.listing__created_at__extract_day
+                , subq_1.listing__created_at__extract_dow
+                , subq_1.listing__created_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.user
+                , subq_1.listing__user
+                , subq_1.country_latest
+                , subq_1.is_lux_latest
+                , subq_1.capacity_latest
+                , subq_1.listing__country_latest
+                , subq_1.listing__is_lux_latest
+                , subq_1.listing__capacity_latest
+                , subq_1.listings
+                , subq_1.largest_listing
+                , subq_1.smallest_listing
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.created_at__day
-                  , subq_2.created_at__week
-                  , subq_2.created_at__month
-                  , subq_2.created_at__quarter
-                  , subq_2.created_at__year
-                  , subq_2.created_at__extract_year
-                  , subq_2.created_at__extract_quarter
-                  , subq_2.created_at__extract_month
-                  , subq_2.created_at__extract_day
-                  , subq_2.created_at__extract_dow
-                  , subq_2.created_at__extract_doy
-                  , subq_2.listing__ds__day
-                  , subq_2.listing__ds__week
-                  , subq_2.listing__ds__month
-                  , subq_2.listing__ds__quarter
-                  , subq_2.listing__ds__year
-                  , subq_2.listing__ds__extract_year
-                  , subq_2.listing__ds__extract_quarter
-                  , subq_2.listing__ds__extract_month
-                  , subq_2.listing__ds__extract_day
-                  , subq_2.listing__ds__extract_dow
-                  , subq_2.listing__ds__extract_doy
-                  , subq_2.listing__created_at__day
-                  , subq_2.listing__created_at__week
-                  , subq_2.listing__created_at__month
-                  , subq_2.listing__created_at__quarter
-                  , subq_2.listing__created_at__year
-                  , subq_2.listing__created_at__extract_year
-                  , subq_2.listing__created_at__extract_quarter
-                  , subq_2.listing__created_at__extract_month
-                  , subq_2.listing__created_at__extract_day
-                  , subq_2.listing__created_at__extract_dow
-                  , subq_2.listing__created_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.user
-                  , subq_2.listing__user
-                  , subq_2.country_latest
-                  , subq_2.is_lux_latest
-                  , subq_2.capacity_latest
-                  , subq_2.listing__country_latest
-                  , subq_2.listing__is_lux_latest
-                  , subq_2.listing__capacity_latest
-                  , subq_2.listings
-                  , subq_2.largest_listing
-                  , subq_2.smallest_listing
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.created_at__day
+                  , subq_0.created_at__week
+                  , subq_0.created_at__month
+                  , subq_0.created_at__quarter
+                  , subq_0.created_at__year
+                  , subq_0.created_at__extract_year
+                  , subq_0.created_at__extract_quarter
+                  , subq_0.created_at__extract_month
+                  , subq_0.created_at__extract_day
+                  , subq_0.created_at__extract_dow
+                  , subq_0.created_at__extract_doy
+                  , subq_0.listing__ds__day
+                  , subq_0.listing__ds__week
+                  , subq_0.listing__ds__month
+                  , subq_0.listing__ds__quarter
+                  , subq_0.listing__ds__year
+                  , subq_0.listing__ds__extract_year
+                  , subq_0.listing__ds__extract_quarter
+                  , subq_0.listing__ds__extract_month
+                  , subq_0.listing__ds__extract_day
+                  , subq_0.listing__ds__extract_dow
+                  , subq_0.listing__ds__extract_doy
+                  , subq_0.listing__created_at__day
+                  , subq_0.listing__created_at__week
+                  , subq_0.listing__created_at__month
+                  , subq_0.listing__created_at__quarter
+                  , subq_0.listing__created_at__year
+                  , subq_0.listing__created_at__extract_year
+                  , subq_0.listing__created_at__extract_quarter
+                  , subq_0.listing__created_at__extract_month
+                  , subq_0.listing__created_at__extract_day
+                  , subq_0.listing__created_at__extract_dow
+                  , subq_0.listing__created_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.user
+                  , subq_0.listing__user
+                  , subq_0.country_latest
+                  , subq_0.is_lux_latest
+                  , subq_0.capacity_latest
+                  , subq_0.listing__country_latest
+                  , subq_0.listing__is_lux_latest
+                  , subq_0.listing__capacity_latest
+                  , subq_0.listings
+                  , subq_0.largest_listing
+                  , subq_0.smallest_listing
                 FROM (
                   -- Read Elements From Semantic Model 'listings_latest'
                   SELECT
@@ -241,16 +241,16 @@ FROM (
                     , listings_latest_src_28000.user_id AS user
                     , listings_latest_src_28000.user_id AS listing__user
                   FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_6.user
-              , subq_6.home_state_latest
+              subq_4.user
+              , subq_4.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +280,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_6
-          ) subq_7
+            ) subq_4
+          ) subq_5
           ON
-            subq_5.user = subq_7.user
-        ) subq_8
-      ) subq_9
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
     user__home_state_latest
-) subq_12
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_18.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_18.listing__capacity_latest AS listing__capacity_latest
+    subq_14.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_14.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_18.listings AS listings
+    , subq_14.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_16.user
+      subq_12.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_16
+    ) subq_12
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_18.user = users_latest_src_28000.user_id
-) subq_22
+    subq_14.user = users_latest_src_28000.user_id
+) subq_18
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,244 +1,244 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.listing__country_latest
-  , subq_13.bookings
+  subq_11.listing__country_latest
+  , subq_11.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.listing__country_latest
-    , SUM(subq_12.bookings) AS bookings
+    subq_10.listing__country_latest
+    , SUM(subq_10.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_11.listing__country_latest
-      , subq_11.bookings
+      subq_9.listing__country_latest
+      , subq_9.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_10.booking__is_instant
-        , subq_10.listing__country_latest
-        , subq_10.bookings
+        subq_8.booking__is_instant
+        , subq_8.listing__country_latest
+        , subq_8.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_9.booking__is_instant
-          , subq_9.listing__country_latest
-          , subq_9.bookings
+          subq_7.booking__is_instant
+          , subq_7.listing__country_latest
+          , subq_7.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.listing AS listing
-            , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
-            , subq_5.bookings AS bookings
+            subq_3.listing AS listing
+            , subq_3.booking__is_instant AS booking__is_instant
+            , subq_6.country_latest AS listing__country_latest
+            , subq_3.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_4.listing
-              , subq_4.booking__is_instant
-              , subq_4.bookings
+              subq_2.listing
+              , subq_2.booking__is_instant
+              , subq_2.bookings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -331,86 +331,86 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['country_latest', 'listing']
             SELECT
-              subq_7.listing
-              , subq_7.country_latest
+              subq_5.listing
+              , subq_5.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_6.ds__day
-                , subq_6.ds__week
-                , subq_6.ds__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.created_at__day
-                , subq_6.created_at__week
-                , subq_6.created_at__month
-                , subq_6.created_at__quarter
-                , subq_6.created_at__year
-                , subq_6.created_at__extract_year
-                , subq_6.created_at__extract_quarter
-                , subq_6.created_at__extract_month
-                , subq_6.created_at__extract_day
-                , subq_6.created_at__extract_dow
-                , subq_6.created_at__extract_doy
-                , subq_6.listing__ds__day
-                , subq_6.listing__ds__week
-                , subq_6.listing__ds__month
-                , subq_6.listing__ds__quarter
-                , subq_6.listing__ds__year
-                , subq_6.listing__ds__extract_year
-                , subq_6.listing__ds__extract_quarter
-                , subq_6.listing__ds__extract_month
-                , subq_6.listing__ds__extract_day
-                , subq_6.listing__ds__extract_dow
-                , subq_6.listing__ds__extract_doy
-                , subq_6.listing__created_at__day
-                , subq_6.listing__created_at__week
-                , subq_6.listing__created_at__month
-                , subq_6.listing__created_at__quarter
-                , subq_6.listing__created_at__year
-                , subq_6.listing__created_at__extract_year
-                , subq_6.listing__created_at__extract_quarter
-                , subq_6.listing__created_at__extract_month
-                , subq_6.listing__created_at__extract_day
-                , subq_6.listing__created_at__extract_dow
-                , subq_6.listing__created_at__extract_doy
-                , subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week AS metric_time__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter AS metric_time__quarter
-                , subq_6.ds__year AS metric_time__year
-                , subq_6.ds__extract_year AS metric_time__extract_year
-                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_6.ds__extract_month AS metric_time__extract_month
-                , subq_6.ds__extract_day AS metric_time__extract_day
-                , subq_6.ds__extract_dow AS metric_time__extract_dow
-                , subq_6.ds__extract_doy AS metric_time__extract_doy
-                , subq_6.listing
-                , subq_6.user
-                , subq_6.listing__user
-                , subq_6.country_latest
-                , subq_6.is_lux_latest
-                , subq_6.capacity_latest
-                , subq_6.listing__country_latest
-                , subq_6.listing__is_lux_latest
-                , subq_6.listing__capacity_latest
-                , subq_6.listings
-                , subq_6.largest_listing
-                , subq_6.smallest_listing
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.created_at__day
+                , subq_4.created_at__week
+                , subq_4.created_at__month
+                , subq_4.created_at__quarter
+                , subq_4.created_at__year
+                , subq_4.created_at__extract_year
+                , subq_4.created_at__extract_quarter
+                , subq_4.created_at__extract_month
+                , subq_4.created_at__extract_day
+                , subq_4.created_at__extract_dow
+                , subq_4.created_at__extract_doy
+                , subq_4.listing__ds__day
+                , subq_4.listing__ds__week
+                , subq_4.listing__ds__month
+                , subq_4.listing__ds__quarter
+                , subq_4.listing__ds__year
+                , subq_4.listing__ds__extract_year
+                , subq_4.listing__ds__extract_quarter
+                , subq_4.listing__ds__extract_month
+                , subq_4.listing__ds__extract_day
+                , subq_4.listing__ds__extract_dow
+                , subq_4.listing__ds__extract_doy
+                , subq_4.listing__created_at__day
+                , subq_4.listing__created_at__week
+                , subq_4.listing__created_at__month
+                , subq_4.listing__created_at__quarter
+                , subq_4.listing__created_at__year
+                , subq_4.listing__created_at__extract_year
+                , subq_4.listing__created_at__extract_quarter
+                , subq_4.listing__created_at__extract_month
+                , subq_4.listing__created_at__extract_day
+                , subq_4.listing__created_at__extract_dow
+                , subq_4.listing__created_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.user
+                , subq_4.listing__user
+                , subq_4.country_latest
+                , subq_4.is_lux_latest
+                , subq_4.capacity_latest
+                , subq_4.listing__country_latest
+                , subq_4.listing__is_lux_latest
+                , subq_4.listing__capacity_latest
+                , subq_4.listings
+                , subq_4.largest_listing
+                , subq_4.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +471,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_4
+            ) subq_5
+          ) subq_6
           ON
-            subq_5.listing = subq_8.listing
-        ) subq_9
-      ) subq_10
+            subq_3.listing = subq_6.listing
+        ) subq_7
+      ) subq_8
       WHERE booking__is_instant
-    ) subq_11
-  ) subq_12
+    ) subq_9
+  ) subq_10
   GROUP BY
     listing__country_latest
-) subq_13
+) subq_11

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_19.booking__is_instant AS booking__is_instant
+    subq_15.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_19.bookings AS bookings
+    , subq_15.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
-  ) subq_19
+  ) subq_15
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_19.listing = listings_latest_src_28000.listing_id
-) subq_24
+    subq_15.listing = listings_latest_src_28000.listing_id
+) subq_20
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_15.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
+  subq_13.metric_time__day
+  , CAST(subq_13.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.average_booking_value) AS average_booking_value
-    , MAX(subq_14.max_booking_value) AS max_booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.average_booking_value) AS average_booking_value
+    , MAX(subq_12.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.average_booking_value
+      subq_6.metric_time__day
+      , subq_6.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , AVG(subq_7.average_booking_value) AS average_booking_value
+        subq_5.metric_time__day
+        , AVG(subq_5.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.average_booking_value
+          subq_4.metric_time__day
+          , subq_4.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.average_booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.average_booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.average_booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.max_booking_value
+      subq_11.metric_time__day
+      , subq_11.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , MAX(subq_12.max_booking_value) AS max_booking_value
+        subq_10.metric_time__day
+        , MAX(subq_10.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.max_booking_value
+          subq_9.metric_time__day
+          , subq_9.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.average_booking_value) AS average_booking_value
-    , MAX(subq_30.max_booking_value) AS max_booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.average_booking_value) AS average_booking_value
+    , MAX(subq_26.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,186 +1,186 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user__home_state_latest
-  , subq_12.listings
+  subq_10.user__home_state_latest
+  , subq_10.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.user__home_state_latest
-    , SUM(subq_11.listings) AS listings
+    subq_9.user__home_state_latest
+    , SUM(subq_9.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_10.user__home_state_latest
-      , subq_10.listings
+      subq_8.user__home_state_latest
+      , subq_8.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.listing__is_lux_latest
-        , subq_9.listing__capacity_latest
-        , subq_9.user__home_state_latest
-        , subq_9.listings
+        subq_7.listing__is_lux_latest
+        , subq_7.listing__capacity_latest
+        , subq_7.user__home_state_latest
+        , subq_7.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_8.listing__is_lux_latest
-          , subq_8.listing__capacity_latest
-          , subq_8.user__home_state_latest
-          , subq_8.listings
+          subq_6.listing__is_lux_latest
+          , subq_6.listing__capacity_latest
+          , subq_6.user__home_state_latest
+          , subq_6.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.user AS user
-            , subq_5.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_5.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state_latest AS user__home_state_latest
-            , subq_5.listings AS listings
+            subq_3.user AS user
+            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_3.listing__capacity_latest AS listing__capacity_latest
+            , subq_5.home_state_latest AS user__home_state_latest
+            , subq_3.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.listing__is_lux_latest
-              , subq_4.listing__capacity_latest
-              , subq_4.listings
+              subq_2.user
+              , subq_2.listing__is_lux_latest
+              , subq_2.listing__capacity_latest
+              , subq_2.listings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.created_at__day
-                , subq_3.created_at__week
-                , subq_3.created_at__month
-                , subq_3.created_at__quarter
-                , subq_3.created_at__year
-                , subq_3.created_at__extract_year
-                , subq_3.created_at__extract_quarter
-                , subq_3.created_at__extract_month
-                , subq_3.created_at__extract_day
-                , subq_3.created_at__extract_dow
-                , subq_3.created_at__extract_doy
-                , subq_3.listing__ds__day
-                , subq_3.listing__ds__week
-                , subq_3.listing__ds__month
-                , subq_3.listing__ds__quarter
-                , subq_3.listing__ds__year
-                , subq_3.listing__ds__extract_year
-                , subq_3.listing__ds__extract_quarter
-                , subq_3.listing__ds__extract_month
-                , subq_3.listing__ds__extract_day
-                , subq_3.listing__ds__extract_dow
-                , subq_3.listing__ds__extract_doy
-                , subq_3.listing__created_at__day
-                , subq_3.listing__created_at__week
-                , subq_3.listing__created_at__month
-                , subq_3.listing__created_at__quarter
-                , subq_3.listing__created_at__year
-                , subq_3.listing__created_at__extract_year
-                , subq_3.listing__created_at__extract_quarter
-                , subq_3.listing__created_at__extract_month
-                , subq_3.listing__created_at__extract_day
-                , subq_3.listing__created_at__extract_dow
-                , subq_3.listing__created_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.user
-                , subq_3.listing__user
-                , subq_3.country_latest
-                , subq_3.is_lux_latest
-                , subq_3.capacity_latest
-                , subq_3.listing__country_latest
-                , subq_3.listing__is_lux_latest
-                , subq_3.listing__capacity_latest
-                , subq_3.listings
-                , subq_3.largest_listing
-                , subq_3.smallest_listing
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.created_at__day
+                , subq_1.created_at__week
+                , subq_1.created_at__month
+                , subq_1.created_at__quarter
+                , subq_1.created_at__year
+                , subq_1.created_at__extract_year
+                , subq_1.created_at__extract_quarter
+                , subq_1.created_at__extract_month
+                , subq_1.created_at__extract_day
+                , subq_1.created_at__extract_dow
+                , subq_1.created_at__extract_doy
+                , subq_1.listing__ds__day
+                , subq_1.listing__ds__week
+                , subq_1.listing__ds__month
+                , subq_1.listing__ds__quarter
+                , subq_1.listing__ds__year
+                , subq_1.listing__ds__extract_year
+                , subq_1.listing__ds__extract_quarter
+                , subq_1.listing__ds__extract_month
+                , subq_1.listing__ds__extract_day
+                , subq_1.listing__ds__extract_dow
+                , subq_1.listing__ds__extract_doy
+                , subq_1.listing__created_at__day
+                , subq_1.listing__created_at__week
+                , subq_1.listing__created_at__month
+                , subq_1.listing__created_at__quarter
+                , subq_1.listing__created_at__year
+                , subq_1.listing__created_at__extract_year
+                , subq_1.listing__created_at__extract_quarter
+                , subq_1.listing__created_at__extract_month
+                , subq_1.listing__created_at__extract_day
+                , subq_1.listing__created_at__extract_dow
+                , subq_1.listing__created_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.user
+                , subq_1.listing__user
+                , subq_1.country_latest
+                , subq_1.is_lux_latest
+                , subq_1.capacity_latest
+                , subq_1.listing__country_latest
+                , subq_1.listing__is_lux_latest
+                , subq_1.listing__capacity_latest
+                , subq_1.listings
+                , subq_1.largest_listing
+                , subq_1.smallest_listing
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.created_at__day
-                  , subq_2.created_at__week
-                  , subq_2.created_at__month
-                  , subq_2.created_at__quarter
-                  , subq_2.created_at__year
-                  , subq_2.created_at__extract_year
-                  , subq_2.created_at__extract_quarter
-                  , subq_2.created_at__extract_month
-                  , subq_2.created_at__extract_day
-                  , subq_2.created_at__extract_dow
-                  , subq_2.created_at__extract_doy
-                  , subq_2.listing__ds__day
-                  , subq_2.listing__ds__week
-                  , subq_2.listing__ds__month
-                  , subq_2.listing__ds__quarter
-                  , subq_2.listing__ds__year
-                  , subq_2.listing__ds__extract_year
-                  , subq_2.listing__ds__extract_quarter
-                  , subq_2.listing__ds__extract_month
-                  , subq_2.listing__ds__extract_day
-                  , subq_2.listing__ds__extract_dow
-                  , subq_2.listing__ds__extract_doy
-                  , subq_2.listing__created_at__day
-                  , subq_2.listing__created_at__week
-                  , subq_2.listing__created_at__month
-                  , subq_2.listing__created_at__quarter
-                  , subq_2.listing__created_at__year
-                  , subq_2.listing__created_at__extract_year
-                  , subq_2.listing__created_at__extract_quarter
-                  , subq_2.listing__created_at__extract_month
-                  , subq_2.listing__created_at__extract_day
-                  , subq_2.listing__created_at__extract_dow
-                  , subq_2.listing__created_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.user
-                  , subq_2.listing__user
-                  , subq_2.country_latest
-                  , subq_2.is_lux_latest
-                  , subq_2.capacity_latest
-                  , subq_2.listing__country_latest
-                  , subq_2.listing__is_lux_latest
-                  , subq_2.listing__capacity_latest
-                  , subq_2.listings
-                  , subq_2.largest_listing
-                  , subq_2.smallest_listing
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.created_at__day
+                  , subq_0.created_at__week
+                  , subq_0.created_at__month
+                  , subq_0.created_at__quarter
+                  , subq_0.created_at__year
+                  , subq_0.created_at__extract_year
+                  , subq_0.created_at__extract_quarter
+                  , subq_0.created_at__extract_month
+                  , subq_0.created_at__extract_day
+                  , subq_0.created_at__extract_dow
+                  , subq_0.created_at__extract_doy
+                  , subq_0.listing__ds__day
+                  , subq_0.listing__ds__week
+                  , subq_0.listing__ds__month
+                  , subq_0.listing__ds__quarter
+                  , subq_0.listing__ds__year
+                  , subq_0.listing__ds__extract_year
+                  , subq_0.listing__ds__extract_quarter
+                  , subq_0.listing__ds__extract_month
+                  , subq_0.listing__ds__extract_day
+                  , subq_0.listing__ds__extract_dow
+                  , subq_0.listing__ds__extract_doy
+                  , subq_0.listing__created_at__day
+                  , subq_0.listing__created_at__week
+                  , subq_0.listing__created_at__month
+                  , subq_0.listing__created_at__quarter
+                  , subq_0.listing__created_at__year
+                  , subq_0.listing__created_at__extract_year
+                  , subq_0.listing__created_at__extract_quarter
+                  , subq_0.listing__created_at__extract_month
+                  , subq_0.listing__created_at__extract_day
+                  , subq_0.listing__created_at__extract_dow
+                  , subq_0.listing__created_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.user
+                  , subq_0.listing__user
+                  , subq_0.country_latest
+                  , subq_0.is_lux_latest
+                  , subq_0.capacity_latest
+                  , subq_0.listing__country_latest
+                  , subq_0.listing__is_lux_latest
+                  , subq_0.listing__capacity_latest
+                  , subq_0.listings
+                  , subq_0.largest_listing
+                  , subq_0.smallest_listing
                 FROM (
                   -- Read Elements From Semantic Model 'listings_latest'
                   SELECT
@@ -241,16 +241,16 @@ FROM (
                     , listings_latest_src_28000.user_id AS user
                     , listings_latest_src_28000.user_id AS listing__user
                   FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_6.user
-              , subq_6.home_state_latest
+              subq_4.user
+              , subq_4.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +280,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_6
-          ) subq_7
+            ) subq_4
+          ) subq_5
           ON
-            subq_5.user = subq_7.user
-        ) subq_8
-      ) subq_9
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.user__home_state_latest
-) subq_12
+    subq_9.user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_18.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_18.listing__capacity_latest AS listing__capacity_latest
+    subq_14.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_14.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_18.listings AS listings
+    , subq_14.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_16.user
+      subq_12.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_16
+    ) subq_12
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_18.user = users_latest_src_28000.user_id
-) subq_22
+    subq_14.user = users_latest_src_28000.user_id
+) subq_18
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,244 +1,244 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.listing__country_latest
-  , subq_13.bookings
+  subq_11.listing__country_latest
+  , subq_11.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.listing__country_latest
-    , SUM(subq_12.bookings) AS bookings
+    subq_10.listing__country_latest
+    , SUM(subq_10.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_11.listing__country_latest
-      , subq_11.bookings
+      subq_9.listing__country_latest
+      , subq_9.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_10.booking__is_instant
-        , subq_10.listing__country_latest
-        , subq_10.bookings
+        subq_8.booking__is_instant
+        , subq_8.listing__country_latest
+        , subq_8.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_9.booking__is_instant
-          , subq_9.listing__country_latest
-          , subq_9.bookings
+          subq_7.booking__is_instant
+          , subq_7.listing__country_latest
+          , subq_7.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.listing AS listing
-            , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
-            , subq_5.bookings AS bookings
+            subq_3.listing AS listing
+            , subq_3.booking__is_instant AS booking__is_instant
+            , subq_6.country_latest AS listing__country_latest
+            , subq_3.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_4.listing
-              , subq_4.booking__is_instant
-              , subq_4.bookings
+              subq_2.listing
+              , subq_2.booking__is_instant
+              , subq_2.bookings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -331,86 +331,86 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['country_latest', 'listing']
             SELECT
-              subq_7.listing
-              , subq_7.country_latest
+              subq_5.listing
+              , subq_5.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_6.ds__day
-                , subq_6.ds__week
-                , subq_6.ds__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.created_at__day
-                , subq_6.created_at__week
-                , subq_6.created_at__month
-                , subq_6.created_at__quarter
-                , subq_6.created_at__year
-                , subq_6.created_at__extract_year
-                , subq_6.created_at__extract_quarter
-                , subq_6.created_at__extract_month
-                , subq_6.created_at__extract_day
-                , subq_6.created_at__extract_dow
-                , subq_6.created_at__extract_doy
-                , subq_6.listing__ds__day
-                , subq_6.listing__ds__week
-                , subq_6.listing__ds__month
-                , subq_6.listing__ds__quarter
-                , subq_6.listing__ds__year
-                , subq_6.listing__ds__extract_year
-                , subq_6.listing__ds__extract_quarter
-                , subq_6.listing__ds__extract_month
-                , subq_6.listing__ds__extract_day
-                , subq_6.listing__ds__extract_dow
-                , subq_6.listing__ds__extract_doy
-                , subq_6.listing__created_at__day
-                , subq_6.listing__created_at__week
-                , subq_6.listing__created_at__month
-                , subq_6.listing__created_at__quarter
-                , subq_6.listing__created_at__year
-                , subq_6.listing__created_at__extract_year
-                , subq_6.listing__created_at__extract_quarter
-                , subq_6.listing__created_at__extract_month
-                , subq_6.listing__created_at__extract_day
-                , subq_6.listing__created_at__extract_dow
-                , subq_6.listing__created_at__extract_doy
-                , subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week AS metric_time__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter AS metric_time__quarter
-                , subq_6.ds__year AS metric_time__year
-                , subq_6.ds__extract_year AS metric_time__extract_year
-                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_6.ds__extract_month AS metric_time__extract_month
-                , subq_6.ds__extract_day AS metric_time__extract_day
-                , subq_6.ds__extract_dow AS metric_time__extract_dow
-                , subq_6.ds__extract_doy AS metric_time__extract_doy
-                , subq_6.listing
-                , subq_6.user
-                , subq_6.listing__user
-                , subq_6.country_latest
-                , subq_6.is_lux_latest
-                , subq_6.capacity_latest
-                , subq_6.listing__country_latest
-                , subq_6.listing__is_lux_latest
-                , subq_6.listing__capacity_latest
-                , subq_6.listings
-                , subq_6.largest_listing
-                , subq_6.smallest_listing
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.created_at__day
+                , subq_4.created_at__week
+                , subq_4.created_at__month
+                , subq_4.created_at__quarter
+                , subq_4.created_at__year
+                , subq_4.created_at__extract_year
+                , subq_4.created_at__extract_quarter
+                , subq_4.created_at__extract_month
+                , subq_4.created_at__extract_day
+                , subq_4.created_at__extract_dow
+                , subq_4.created_at__extract_doy
+                , subq_4.listing__ds__day
+                , subq_4.listing__ds__week
+                , subq_4.listing__ds__month
+                , subq_4.listing__ds__quarter
+                , subq_4.listing__ds__year
+                , subq_4.listing__ds__extract_year
+                , subq_4.listing__ds__extract_quarter
+                , subq_4.listing__ds__extract_month
+                , subq_4.listing__ds__extract_day
+                , subq_4.listing__ds__extract_dow
+                , subq_4.listing__ds__extract_doy
+                , subq_4.listing__created_at__day
+                , subq_4.listing__created_at__week
+                , subq_4.listing__created_at__month
+                , subq_4.listing__created_at__quarter
+                , subq_4.listing__created_at__year
+                , subq_4.listing__created_at__extract_year
+                , subq_4.listing__created_at__extract_quarter
+                , subq_4.listing__created_at__extract_month
+                , subq_4.listing__created_at__extract_day
+                , subq_4.listing__created_at__extract_dow
+                , subq_4.listing__created_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.user
+                , subq_4.listing__user
+                , subq_4.country_latest
+                , subq_4.is_lux_latest
+                , subq_4.capacity_latest
+                , subq_4.listing__country_latest
+                , subq_4.listing__is_lux_latest
+                , subq_4.listing__capacity_latest
+                , subq_4.listings
+                , subq_4.largest_listing
+                , subq_4.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +471,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_4
+            ) subq_5
+          ) subq_6
           ON
-            subq_5.listing = subq_8.listing
-        ) subq_9
-      ) subq_10
+            subq_3.listing = subq_6.listing
+        ) subq_7
+      ) subq_8
       WHERE booking__is_instant
-    ) subq_11
-  ) subq_12
+    ) subq_9
+  ) subq_10
   GROUP BY
-    subq_12.listing__country_latest
-) subq_13
+    subq_10.listing__country_latest
+) subq_11

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_19.booking__is_instant AS booking__is_instant
+    subq_15.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_19.bookings AS bookings
+    , subq_15.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
-  ) subq_19
+  ) subq_15
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_19.listing = listings_latest_src_28000.listing_id
-) subq_24
+    subq_15.listing = listings_latest_src_28000.listing_id
+) subq_20
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_15.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
+  subq_13.metric_time__day
+  , CAST(subq_13.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.average_booking_value) AS average_booking_value
-    , MAX(subq_14.max_booking_value) AS max_booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.average_booking_value) AS average_booking_value
+    , MAX(subq_12.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.average_booking_value
+      subq_6.metric_time__day
+      , subq_6.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , AVG(subq_7.average_booking_value) AS average_booking_value
+        subq_5.metric_time__day
+        , AVG(subq_5.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.average_booking_value
+          subq_4.metric_time__day
+          , subq_4.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.average_booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.average_booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.average_booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.max_booking_value
+      subq_11.metric_time__day
+      , subq_11.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , MAX(subq_12.max_booking_value) AS max_booking_value
+        subq_10.metric_time__day
+        , MAX(subq_10.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.max_booking_value
+          subq_9.metric_time__day
+          , subq_9.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.average_booking_value) AS average_booking_value
-    , MAX(subq_30.max_booking_value) AS max_booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.average_booking_value) AS average_booking_value
+    , MAX(subq_26.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,186 +1,186 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user__home_state_latest
-  , subq_12.listings
+  subq_10.user__home_state_latest
+  , subq_10.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.user__home_state_latest
-    , SUM(subq_11.listings) AS listings
+    subq_9.user__home_state_latest
+    , SUM(subq_9.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_10.user__home_state_latest
-      , subq_10.listings
+      subq_8.user__home_state_latest
+      , subq_8.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.listing__is_lux_latest
-        , subq_9.listing__capacity_latest
-        , subq_9.user__home_state_latest
-        , subq_9.listings
+        subq_7.listing__is_lux_latest
+        , subq_7.listing__capacity_latest
+        , subq_7.user__home_state_latest
+        , subq_7.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_8.listing__is_lux_latest
-          , subq_8.listing__capacity_latest
-          , subq_8.user__home_state_latest
-          , subq_8.listings
+          subq_6.listing__is_lux_latest
+          , subq_6.listing__capacity_latest
+          , subq_6.user__home_state_latest
+          , subq_6.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.user AS user
-            , subq_5.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_5.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state_latest AS user__home_state_latest
-            , subq_5.listings AS listings
+            subq_3.user AS user
+            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_3.listing__capacity_latest AS listing__capacity_latest
+            , subq_5.home_state_latest AS user__home_state_latest
+            , subq_3.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.listing__is_lux_latest
-              , subq_4.listing__capacity_latest
-              , subq_4.listings
+              subq_2.user
+              , subq_2.listing__is_lux_latest
+              , subq_2.listing__capacity_latest
+              , subq_2.listings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.created_at__day
-                , subq_3.created_at__week
-                , subq_3.created_at__month
-                , subq_3.created_at__quarter
-                , subq_3.created_at__year
-                , subq_3.created_at__extract_year
-                , subq_3.created_at__extract_quarter
-                , subq_3.created_at__extract_month
-                , subq_3.created_at__extract_day
-                , subq_3.created_at__extract_dow
-                , subq_3.created_at__extract_doy
-                , subq_3.listing__ds__day
-                , subq_3.listing__ds__week
-                , subq_3.listing__ds__month
-                , subq_3.listing__ds__quarter
-                , subq_3.listing__ds__year
-                , subq_3.listing__ds__extract_year
-                , subq_3.listing__ds__extract_quarter
-                , subq_3.listing__ds__extract_month
-                , subq_3.listing__ds__extract_day
-                , subq_3.listing__ds__extract_dow
-                , subq_3.listing__ds__extract_doy
-                , subq_3.listing__created_at__day
-                , subq_3.listing__created_at__week
-                , subq_3.listing__created_at__month
-                , subq_3.listing__created_at__quarter
-                , subq_3.listing__created_at__year
-                , subq_3.listing__created_at__extract_year
-                , subq_3.listing__created_at__extract_quarter
-                , subq_3.listing__created_at__extract_month
-                , subq_3.listing__created_at__extract_day
-                , subq_3.listing__created_at__extract_dow
-                , subq_3.listing__created_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.user
-                , subq_3.listing__user
-                , subq_3.country_latest
-                , subq_3.is_lux_latest
-                , subq_3.capacity_latest
-                , subq_3.listing__country_latest
-                , subq_3.listing__is_lux_latest
-                , subq_3.listing__capacity_latest
-                , subq_3.listings
-                , subq_3.largest_listing
-                , subq_3.smallest_listing
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.created_at__day
+                , subq_1.created_at__week
+                , subq_1.created_at__month
+                , subq_1.created_at__quarter
+                , subq_1.created_at__year
+                , subq_1.created_at__extract_year
+                , subq_1.created_at__extract_quarter
+                , subq_1.created_at__extract_month
+                , subq_1.created_at__extract_day
+                , subq_1.created_at__extract_dow
+                , subq_1.created_at__extract_doy
+                , subq_1.listing__ds__day
+                , subq_1.listing__ds__week
+                , subq_1.listing__ds__month
+                , subq_1.listing__ds__quarter
+                , subq_1.listing__ds__year
+                , subq_1.listing__ds__extract_year
+                , subq_1.listing__ds__extract_quarter
+                , subq_1.listing__ds__extract_month
+                , subq_1.listing__ds__extract_day
+                , subq_1.listing__ds__extract_dow
+                , subq_1.listing__ds__extract_doy
+                , subq_1.listing__created_at__day
+                , subq_1.listing__created_at__week
+                , subq_1.listing__created_at__month
+                , subq_1.listing__created_at__quarter
+                , subq_1.listing__created_at__year
+                , subq_1.listing__created_at__extract_year
+                , subq_1.listing__created_at__extract_quarter
+                , subq_1.listing__created_at__extract_month
+                , subq_1.listing__created_at__extract_day
+                , subq_1.listing__created_at__extract_dow
+                , subq_1.listing__created_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.user
+                , subq_1.listing__user
+                , subq_1.country_latest
+                , subq_1.is_lux_latest
+                , subq_1.capacity_latest
+                , subq_1.listing__country_latest
+                , subq_1.listing__is_lux_latest
+                , subq_1.listing__capacity_latest
+                , subq_1.listings
+                , subq_1.largest_listing
+                , subq_1.smallest_listing
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.created_at__day
-                  , subq_2.created_at__week
-                  , subq_2.created_at__month
-                  , subq_2.created_at__quarter
-                  , subq_2.created_at__year
-                  , subq_2.created_at__extract_year
-                  , subq_2.created_at__extract_quarter
-                  , subq_2.created_at__extract_month
-                  , subq_2.created_at__extract_day
-                  , subq_2.created_at__extract_dow
-                  , subq_2.created_at__extract_doy
-                  , subq_2.listing__ds__day
-                  , subq_2.listing__ds__week
-                  , subq_2.listing__ds__month
-                  , subq_2.listing__ds__quarter
-                  , subq_2.listing__ds__year
-                  , subq_2.listing__ds__extract_year
-                  , subq_2.listing__ds__extract_quarter
-                  , subq_2.listing__ds__extract_month
-                  , subq_2.listing__ds__extract_day
-                  , subq_2.listing__ds__extract_dow
-                  , subq_2.listing__ds__extract_doy
-                  , subq_2.listing__created_at__day
-                  , subq_2.listing__created_at__week
-                  , subq_2.listing__created_at__month
-                  , subq_2.listing__created_at__quarter
-                  , subq_2.listing__created_at__year
-                  , subq_2.listing__created_at__extract_year
-                  , subq_2.listing__created_at__extract_quarter
-                  , subq_2.listing__created_at__extract_month
-                  , subq_2.listing__created_at__extract_day
-                  , subq_2.listing__created_at__extract_dow
-                  , subq_2.listing__created_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.user
-                  , subq_2.listing__user
-                  , subq_2.country_latest
-                  , subq_2.is_lux_latest
-                  , subq_2.capacity_latest
-                  , subq_2.listing__country_latest
-                  , subq_2.listing__is_lux_latest
-                  , subq_2.listing__capacity_latest
-                  , subq_2.listings
-                  , subq_2.largest_listing
-                  , subq_2.smallest_listing
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.created_at__day
+                  , subq_0.created_at__week
+                  , subq_0.created_at__month
+                  , subq_0.created_at__quarter
+                  , subq_0.created_at__year
+                  , subq_0.created_at__extract_year
+                  , subq_0.created_at__extract_quarter
+                  , subq_0.created_at__extract_month
+                  , subq_0.created_at__extract_day
+                  , subq_0.created_at__extract_dow
+                  , subq_0.created_at__extract_doy
+                  , subq_0.listing__ds__day
+                  , subq_0.listing__ds__week
+                  , subq_0.listing__ds__month
+                  , subq_0.listing__ds__quarter
+                  , subq_0.listing__ds__year
+                  , subq_0.listing__ds__extract_year
+                  , subq_0.listing__ds__extract_quarter
+                  , subq_0.listing__ds__extract_month
+                  , subq_0.listing__ds__extract_day
+                  , subq_0.listing__ds__extract_dow
+                  , subq_0.listing__ds__extract_doy
+                  , subq_0.listing__created_at__day
+                  , subq_0.listing__created_at__week
+                  , subq_0.listing__created_at__month
+                  , subq_0.listing__created_at__quarter
+                  , subq_0.listing__created_at__year
+                  , subq_0.listing__created_at__extract_year
+                  , subq_0.listing__created_at__extract_quarter
+                  , subq_0.listing__created_at__extract_month
+                  , subq_0.listing__created_at__extract_day
+                  , subq_0.listing__created_at__extract_dow
+                  , subq_0.listing__created_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.user
+                  , subq_0.listing__user
+                  , subq_0.country_latest
+                  , subq_0.is_lux_latest
+                  , subq_0.capacity_latest
+                  , subq_0.listing__country_latest
+                  , subq_0.listing__is_lux_latest
+                  , subq_0.listing__capacity_latest
+                  , subq_0.listings
+                  , subq_0.largest_listing
+                  , subq_0.smallest_listing
                 FROM (
                   -- Read Elements From Semantic Model 'listings_latest'
                   SELECT
@@ -241,16 +241,16 @@ FROM (
                     , listings_latest_src_28000.user_id AS user
                     , listings_latest_src_28000.user_id AS listing__user
                   FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_6.user
-              , subq_6.home_state_latest
+              subq_4.user
+              , subq_4.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +280,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_6
-          ) subq_7
+            ) subq_4
+          ) subq_5
           ON
-            subq_5.user = subq_7.user
-        ) subq_8
-      ) subq_9
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.user__home_state_latest
-) subq_12
+    subq_9.user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_18.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_18.listing__capacity_latest AS listing__capacity_latest
+    subq_14.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_14.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_18.listings AS listings
+    , subq_14.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_16.user
+      subq_12.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_16
+    ) subq_12
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_18.user = users_latest_src_28000.user_id
-) subq_22
+    subq_14.user = users_latest_src_28000.user_id
+) subq_18
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,244 +1,244 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.listing__country_latest
-  , subq_13.bookings
+  subq_11.listing__country_latest
+  , subq_11.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.listing__country_latest
-    , SUM(subq_12.bookings) AS bookings
+    subq_10.listing__country_latest
+    , SUM(subq_10.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_11.listing__country_latest
-      , subq_11.bookings
+      subq_9.listing__country_latest
+      , subq_9.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_10.booking__is_instant
-        , subq_10.listing__country_latest
-        , subq_10.bookings
+        subq_8.booking__is_instant
+        , subq_8.listing__country_latest
+        , subq_8.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_9.booking__is_instant
-          , subq_9.listing__country_latest
-          , subq_9.bookings
+          subq_7.booking__is_instant
+          , subq_7.listing__country_latest
+          , subq_7.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.listing AS listing
-            , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
-            , subq_5.bookings AS bookings
+            subq_3.listing AS listing
+            , subq_3.booking__is_instant AS booking__is_instant
+            , subq_6.country_latest AS listing__country_latest
+            , subq_3.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_4.listing
-              , subq_4.booking__is_instant
-              , subq_4.bookings
+              subq_2.listing
+              , subq_2.booking__is_instant
+              , subq_2.bookings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -331,86 +331,86 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['country_latest', 'listing']
             SELECT
-              subq_7.listing
-              , subq_7.country_latest
+              subq_5.listing
+              , subq_5.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_6.ds__day
-                , subq_6.ds__week
-                , subq_6.ds__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.created_at__day
-                , subq_6.created_at__week
-                , subq_6.created_at__month
-                , subq_6.created_at__quarter
-                , subq_6.created_at__year
-                , subq_6.created_at__extract_year
-                , subq_6.created_at__extract_quarter
-                , subq_6.created_at__extract_month
-                , subq_6.created_at__extract_day
-                , subq_6.created_at__extract_dow
-                , subq_6.created_at__extract_doy
-                , subq_6.listing__ds__day
-                , subq_6.listing__ds__week
-                , subq_6.listing__ds__month
-                , subq_6.listing__ds__quarter
-                , subq_6.listing__ds__year
-                , subq_6.listing__ds__extract_year
-                , subq_6.listing__ds__extract_quarter
-                , subq_6.listing__ds__extract_month
-                , subq_6.listing__ds__extract_day
-                , subq_6.listing__ds__extract_dow
-                , subq_6.listing__ds__extract_doy
-                , subq_6.listing__created_at__day
-                , subq_6.listing__created_at__week
-                , subq_6.listing__created_at__month
-                , subq_6.listing__created_at__quarter
-                , subq_6.listing__created_at__year
-                , subq_6.listing__created_at__extract_year
-                , subq_6.listing__created_at__extract_quarter
-                , subq_6.listing__created_at__extract_month
-                , subq_6.listing__created_at__extract_day
-                , subq_6.listing__created_at__extract_dow
-                , subq_6.listing__created_at__extract_doy
-                , subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week AS metric_time__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter AS metric_time__quarter
-                , subq_6.ds__year AS metric_time__year
-                , subq_6.ds__extract_year AS metric_time__extract_year
-                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_6.ds__extract_month AS metric_time__extract_month
-                , subq_6.ds__extract_day AS metric_time__extract_day
-                , subq_6.ds__extract_dow AS metric_time__extract_dow
-                , subq_6.ds__extract_doy AS metric_time__extract_doy
-                , subq_6.listing
-                , subq_6.user
-                , subq_6.listing__user
-                , subq_6.country_latest
-                , subq_6.is_lux_latest
-                , subq_6.capacity_latest
-                , subq_6.listing__country_latest
-                , subq_6.listing__is_lux_latest
-                , subq_6.listing__capacity_latest
-                , subq_6.listings
-                , subq_6.largest_listing
-                , subq_6.smallest_listing
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.created_at__day
+                , subq_4.created_at__week
+                , subq_4.created_at__month
+                , subq_4.created_at__quarter
+                , subq_4.created_at__year
+                , subq_4.created_at__extract_year
+                , subq_4.created_at__extract_quarter
+                , subq_4.created_at__extract_month
+                , subq_4.created_at__extract_day
+                , subq_4.created_at__extract_dow
+                , subq_4.created_at__extract_doy
+                , subq_4.listing__ds__day
+                , subq_4.listing__ds__week
+                , subq_4.listing__ds__month
+                , subq_4.listing__ds__quarter
+                , subq_4.listing__ds__year
+                , subq_4.listing__ds__extract_year
+                , subq_4.listing__ds__extract_quarter
+                , subq_4.listing__ds__extract_month
+                , subq_4.listing__ds__extract_day
+                , subq_4.listing__ds__extract_dow
+                , subq_4.listing__ds__extract_doy
+                , subq_4.listing__created_at__day
+                , subq_4.listing__created_at__week
+                , subq_4.listing__created_at__month
+                , subq_4.listing__created_at__quarter
+                , subq_4.listing__created_at__year
+                , subq_4.listing__created_at__extract_year
+                , subq_4.listing__created_at__extract_quarter
+                , subq_4.listing__created_at__extract_month
+                , subq_4.listing__created_at__extract_day
+                , subq_4.listing__created_at__extract_dow
+                , subq_4.listing__created_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.user
+                , subq_4.listing__user
+                , subq_4.country_latest
+                , subq_4.is_lux_latest
+                , subq_4.capacity_latest
+                , subq_4.listing__country_latest
+                , subq_4.listing__is_lux_latest
+                , subq_4.listing__capacity_latest
+                , subq_4.listings
+                , subq_4.largest_listing
+                , subq_4.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +471,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_4
+            ) subq_5
+          ) subq_6
           ON
-            subq_5.listing = subq_8.listing
-        ) subq_9
-      ) subq_10
+            subq_3.listing = subq_6.listing
+        ) subq_7
+      ) subq_8
       WHERE booking__is_instant
-    ) subq_11
-  ) subq_12
+    ) subq_9
+  ) subq_10
   GROUP BY
-    subq_12.listing__country_latest
-) subq_13
+    subq_10.listing__country_latest
+) subq_11

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_19.booking__is_instant AS booking__is_instant
+    subq_15.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_19.bookings AS bookings
+    , subq_15.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
-  ) subq_19
+  ) subq_15
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_19.listing = listings_latest_src_28000.listing_id
-) subq_24
+    subq_15.listing = listings_latest_src_28000.listing_id
+) subq_20
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(subq_15.max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
+  subq_13.metric_time__day
+  , CAST(subq_13.average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.average_booking_value) AS average_booking_value
-    , MAX(subq_14.max_booking_value) AS max_booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.average_booking_value) AS average_booking_value
+    , MAX(subq_12.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.average_booking_value
+      subq_6.metric_time__day
+      , subq_6.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , AVG(subq_7.average_booking_value) AS average_booking_value
+        subq_5.metric_time__day
+        , AVG(subq_5.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.average_booking_value
+          subq_4.metric_time__day
+          , subq_4.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.average_booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.average_booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.average_booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.max_booking_value
+      subq_11.metric_time__day
+      , subq_11.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , MAX(subq_12.max_booking_value) AS max_booking_value
+        subq_10.metric_time__day
+        , MAX(subq_10.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.max_booking_value
+          subq_9.metric_time__day
+          , subq_9.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.average_booking_value) AS average_booking_value
-    , MAX(subq_30.max_booking_value) AS max_booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.average_booking_value) AS average_booking_value
+    , MAX(subq_26.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,186 +1,186 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user__home_state_latest
-  , subq_12.listings
+  subq_10.user__home_state_latest
+  , subq_10.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.user__home_state_latest
-    , SUM(subq_11.listings) AS listings
+    subq_9.user__home_state_latest
+    , SUM(subq_9.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_10.user__home_state_latest
-      , subq_10.listings
+      subq_8.user__home_state_latest
+      , subq_8.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.listing__is_lux_latest
-        , subq_9.listing__capacity_latest
-        , subq_9.user__home_state_latest
-        , subq_9.listings
+        subq_7.listing__is_lux_latest
+        , subq_7.listing__capacity_latest
+        , subq_7.user__home_state_latest
+        , subq_7.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_8.listing__is_lux_latest
-          , subq_8.listing__capacity_latest
-          , subq_8.user__home_state_latest
-          , subq_8.listings
+          subq_6.listing__is_lux_latest
+          , subq_6.listing__capacity_latest
+          , subq_6.user__home_state_latest
+          , subq_6.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.user AS user
-            , subq_5.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_5.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state_latest AS user__home_state_latest
-            , subq_5.listings AS listings
+            subq_3.user AS user
+            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_3.listing__capacity_latest AS listing__capacity_latest
+            , subq_5.home_state_latest AS user__home_state_latest
+            , subq_3.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.listing__is_lux_latest
-              , subq_4.listing__capacity_latest
-              , subq_4.listings
+              subq_2.user
+              , subq_2.listing__is_lux_latest
+              , subq_2.listing__capacity_latest
+              , subq_2.listings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.created_at__day
-                , subq_3.created_at__week
-                , subq_3.created_at__month
-                , subq_3.created_at__quarter
-                , subq_3.created_at__year
-                , subq_3.created_at__extract_year
-                , subq_3.created_at__extract_quarter
-                , subq_3.created_at__extract_month
-                , subq_3.created_at__extract_day
-                , subq_3.created_at__extract_dow
-                , subq_3.created_at__extract_doy
-                , subq_3.listing__ds__day
-                , subq_3.listing__ds__week
-                , subq_3.listing__ds__month
-                , subq_3.listing__ds__quarter
-                , subq_3.listing__ds__year
-                , subq_3.listing__ds__extract_year
-                , subq_3.listing__ds__extract_quarter
-                , subq_3.listing__ds__extract_month
-                , subq_3.listing__ds__extract_day
-                , subq_3.listing__ds__extract_dow
-                , subq_3.listing__ds__extract_doy
-                , subq_3.listing__created_at__day
-                , subq_3.listing__created_at__week
-                , subq_3.listing__created_at__month
-                , subq_3.listing__created_at__quarter
-                , subq_3.listing__created_at__year
-                , subq_3.listing__created_at__extract_year
-                , subq_3.listing__created_at__extract_quarter
-                , subq_3.listing__created_at__extract_month
-                , subq_3.listing__created_at__extract_day
-                , subq_3.listing__created_at__extract_dow
-                , subq_3.listing__created_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.user
-                , subq_3.listing__user
-                , subq_3.country_latest
-                , subq_3.is_lux_latest
-                , subq_3.capacity_latest
-                , subq_3.listing__country_latest
-                , subq_3.listing__is_lux_latest
-                , subq_3.listing__capacity_latest
-                , subq_3.listings
-                , subq_3.largest_listing
-                , subq_3.smallest_listing
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.created_at__day
+                , subq_1.created_at__week
+                , subq_1.created_at__month
+                , subq_1.created_at__quarter
+                , subq_1.created_at__year
+                , subq_1.created_at__extract_year
+                , subq_1.created_at__extract_quarter
+                , subq_1.created_at__extract_month
+                , subq_1.created_at__extract_day
+                , subq_1.created_at__extract_dow
+                , subq_1.created_at__extract_doy
+                , subq_1.listing__ds__day
+                , subq_1.listing__ds__week
+                , subq_1.listing__ds__month
+                , subq_1.listing__ds__quarter
+                , subq_1.listing__ds__year
+                , subq_1.listing__ds__extract_year
+                , subq_1.listing__ds__extract_quarter
+                , subq_1.listing__ds__extract_month
+                , subq_1.listing__ds__extract_day
+                , subq_1.listing__ds__extract_dow
+                , subq_1.listing__ds__extract_doy
+                , subq_1.listing__created_at__day
+                , subq_1.listing__created_at__week
+                , subq_1.listing__created_at__month
+                , subq_1.listing__created_at__quarter
+                , subq_1.listing__created_at__year
+                , subq_1.listing__created_at__extract_year
+                , subq_1.listing__created_at__extract_quarter
+                , subq_1.listing__created_at__extract_month
+                , subq_1.listing__created_at__extract_day
+                , subq_1.listing__created_at__extract_dow
+                , subq_1.listing__created_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.user
+                , subq_1.listing__user
+                , subq_1.country_latest
+                , subq_1.is_lux_latest
+                , subq_1.capacity_latest
+                , subq_1.listing__country_latest
+                , subq_1.listing__is_lux_latest
+                , subq_1.listing__capacity_latest
+                , subq_1.listings
+                , subq_1.largest_listing
+                , subq_1.smallest_listing
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.created_at__day
-                  , subq_2.created_at__week
-                  , subq_2.created_at__month
-                  , subq_2.created_at__quarter
-                  , subq_2.created_at__year
-                  , subq_2.created_at__extract_year
-                  , subq_2.created_at__extract_quarter
-                  , subq_2.created_at__extract_month
-                  , subq_2.created_at__extract_day
-                  , subq_2.created_at__extract_dow
-                  , subq_2.created_at__extract_doy
-                  , subq_2.listing__ds__day
-                  , subq_2.listing__ds__week
-                  , subq_2.listing__ds__month
-                  , subq_2.listing__ds__quarter
-                  , subq_2.listing__ds__year
-                  , subq_2.listing__ds__extract_year
-                  , subq_2.listing__ds__extract_quarter
-                  , subq_2.listing__ds__extract_month
-                  , subq_2.listing__ds__extract_day
-                  , subq_2.listing__ds__extract_dow
-                  , subq_2.listing__ds__extract_doy
-                  , subq_2.listing__created_at__day
-                  , subq_2.listing__created_at__week
-                  , subq_2.listing__created_at__month
-                  , subq_2.listing__created_at__quarter
-                  , subq_2.listing__created_at__year
-                  , subq_2.listing__created_at__extract_year
-                  , subq_2.listing__created_at__extract_quarter
-                  , subq_2.listing__created_at__extract_month
-                  , subq_2.listing__created_at__extract_day
-                  , subq_2.listing__created_at__extract_dow
-                  , subq_2.listing__created_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.user
-                  , subq_2.listing__user
-                  , subq_2.country_latest
-                  , subq_2.is_lux_latest
-                  , subq_2.capacity_latest
-                  , subq_2.listing__country_latest
-                  , subq_2.listing__is_lux_latest
-                  , subq_2.listing__capacity_latest
-                  , subq_2.listings
-                  , subq_2.largest_listing
-                  , subq_2.smallest_listing
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.created_at__day
+                  , subq_0.created_at__week
+                  , subq_0.created_at__month
+                  , subq_0.created_at__quarter
+                  , subq_0.created_at__year
+                  , subq_0.created_at__extract_year
+                  , subq_0.created_at__extract_quarter
+                  , subq_0.created_at__extract_month
+                  , subq_0.created_at__extract_day
+                  , subq_0.created_at__extract_dow
+                  , subq_0.created_at__extract_doy
+                  , subq_0.listing__ds__day
+                  , subq_0.listing__ds__week
+                  , subq_0.listing__ds__month
+                  , subq_0.listing__ds__quarter
+                  , subq_0.listing__ds__year
+                  , subq_0.listing__ds__extract_year
+                  , subq_0.listing__ds__extract_quarter
+                  , subq_0.listing__ds__extract_month
+                  , subq_0.listing__ds__extract_day
+                  , subq_0.listing__ds__extract_dow
+                  , subq_0.listing__ds__extract_doy
+                  , subq_0.listing__created_at__day
+                  , subq_0.listing__created_at__week
+                  , subq_0.listing__created_at__month
+                  , subq_0.listing__created_at__quarter
+                  , subq_0.listing__created_at__year
+                  , subq_0.listing__created_at__extract_year
+                  , subq_0.listing__created_at__extract_quarter
+                  , subq_0.listing__created_at__extract_month
+                  , subq_0.listing__created_at__extract_day
+                  , subq_0.listing__created_at__extract_dow
+                  , subq_0.listing__created_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.user
+                  , subq_0.listing__user
+                  , subq_0.country_latest
+                  , subq_0.is_lux_latest
+                  , subq_0.capacity_latest
+                  , subq_0.listing__country_latest
+                  , subq_0.listing__is_lux_latest
+                  , subq_0.listing__capacity_latest
+                  , subq_0.listings
+                  , subq_0.largest_listing
+                  , subq_0.smallest_listing
                 FROM (
                   -- Read Elements From Semantic Model 'listings_latest'
                   SELECT
@@ -241,16 +241,16 @@ FROM (
                     , listings_latest_src_28000.user_id AS user
                     , listings_latest_src_28000.user_id AS listing__user
                   FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_6.user
-              , subq_6.home_state_latest
+              subq_4.user
+              , subq_4.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +280,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_6
-          ) subq_7
+            ) subq_4
+          ) subq_5
           ON
-            subq_5.user = subq_7.user
-        ) subq_8
-      ) subq_9
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.user__home_state_latest
-) subq_12
+    subq_9.user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_18.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_18.listing__capacity_latest AS listing__capacity_latest
+    subq_14.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_14.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_18.listings AS listings
+    , subq_14.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_16.user
+      subq_12.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_16
+    ) subq_12
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_18.user = users_latest_src_28000.user_id
-) subq_22
+    subq_14.user = users_latest_src_28000.user_id
+) subq_18
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,244 +1,244 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.listing__country_latest
-  , subq_13.bookings
+  subq_11.listing__country_latest
+  , subq_11.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.listing__country_latest
-    , SUM(subq_12.bookings) AS bookings
+    subq_10.listing__country_latest
+    , SUM(subq_10.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_11.listing__country_latest
-      , subq_11.bookings
+      subq_9.listing__country_latest
+      , subq_9.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_10.booking__is_instant
-        , subq_10.listing__country_latest
-        , subq_10.bookings
+        subq_8.booking__is_instant
+        , subq_8.listing__country_latest
+        , subq_8.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_9.booking__is_instant
-          , subq_9.listing__country_latest
-          , subq_9.bookings
+          subq_7.booking__is_instant
+          , subq_7.listing__country_latest
+          , subq_7.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.listing AS listing
-            , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
-            , subq_5.bookings AS bookings
+            subq_3.listing AS listing
+            , subq_3.booking__is_instant AS booking__is_instant
+            , subq_6.country_latest AS listing__country_latest
+            , subq_3.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_4.listing
-              , subq_4.booking__is_instant
-              , subq_4.bookings
+              subq_2.listing
+              , subq_2.booking__is_instant
+              , subq_2.bookings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -331,86 +331,86 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['country_latest', 'listing']
             SELECT
-              subq_7.listing
-              , subq_7.country_latest
+              subq_5.listing
+              , subq_5.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_6.ds__day
-                , subq_6.ds__week
-                , subq_6.ds__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.created_at__day
-                , subq_6.created_at__week
-                , subq_6.created_at__month
-                , subq_6.created_at__quarter
-                , subq_6.created_at__year
-                , subq_6.created_at__extract_year
-                , subq_6.created_at__extract_quarter
-                , subq_6.created_at__extract_month
-                , subq_6.created_at__extract_day
-                , subq_6.created_at__extract_dow
-                , subq_6.created_at__extract_doy
-                , subq_6.listing__ds__day
-                , subq_6.listing__ds__week
-                , subq_6.listing__ds__month
-                , subq_6.listing__ds__quarter
-                , subq_6.listing__ds__year
-                , subq_6.listing__ds__extract_year
-                , subq_6.listing__ds__extract_quarter
-                , subq_6.listing__ds__extract_month
-                , subq_6.listing__ds__extract_day
-                , subq_6.listing__ds__extract_dow
-                , subq_6.listing__ds__extract_doy
-                , subq_6.listing__created_at__day
-                , subq_6.listing__created_at__week
-                , subq_6.listing__created_at__month
-                , subq_6.listing__created_at__quarter
-                , subq_6.listing__created_at__year
-                , subq_6.listing__created_at__extract_year
-                , subq_6.listing__created_at__extract_quarter
-                , subq_6.listing__created_at__extract_month
-                , subq_6.listing__created_at__extract_day
-                , subq_6.listing__created_at__extract_dow
-                , subq_6.listing__created_at__extract_doy
-                , subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week AS metric_time__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter AS metric_time__quarter
-                , subq_6.ds__year AS metric_time__year
-                , subq_6.ds__extract_year AS metric_time__extract_year
-                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_6.ds__extract_month AS metric_time__extract_month
-                , subq_6.ds__extract_day AS metric_time__extract_day
-                , subq_6.ds__extract_dow AS metric_time__extract_dow
-                , subq_6.ds__extract_doy AS metric_time__extract_doy
-                , subq_6.listing
-                , subq_6.user
-                , subq_6.listing__user
-                , subq_6.country_latest
-                , subq_6.is_lux_latest
-                , subq_6.capacity_latest
-                , subq_6.listing__country_latest
-                , subq_6.listing__is_lux_latest
-                , subq_6.listing__capacity_latest
-                , subq_6.listings
-                , subq_6.largest_listing
-                , subq_6.smallest_listing
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.created_at__day
+                , subq_4.created_at__week
+                , subq_4.created_at__month
+                , subq_4.created_at__quarter
+                , subq_4.created_at__year
+                , subq_4.created_at__extract_year
+                , subq_4.created_at__extract_quarter
+                , subq_4.created_at__extract_month
+                , subq_4.created_at__extract_day
+                , subq_4.created_at__extract_dow
+                , subq_4.created_at__extract_doy
+                , subq_4.listing__ds__day
+                , subq_4.listing__ds__week
+                , subq_4.listing__ds__month
+                , subq_4.listing__ds__quarter
+                , subq_4.listing__ds__year
+                , subq_4.listing__ds__extract_year
+                , subq_4.listing__ds__extract_quarter
+                , subq_4.listing__ds__extract_month
+                , subq_4.listing__ds__extract_day
+                , subq_4.listing__ds__extract_dow
+                , subq_4.listing__ds__extract_doy
+                , subq_4.listing__created_at__day
+                , subq_4.listing__created_at__week
+                , subq_4.listing__created_at__month
+                , subq_4.listing__created_at__quarter
+                , subq_4.listing__created_at__year
+                , subq_4.listing__created_at__extract_year
+                , subq_4.listing__created_at__extract_quarter
+                , subq_4.listing__created_at__extract_month
+                , subq_4.listing__created_at__extract_day
+                , subq_4.listing__created_at__extract_dow
+                , subq_4.listing__created_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.user
+                , subq_4.listing__user
+                , subq_4.country_latest
+                , subq_4.is_lux_latest
+                , subq_4.capacity_latest
+                , subq_4.listing__country_latest
+                , subq_4.listing__is_lux_latest
+                , subq_4.listing__capacity_latest
+                , subq_4.listings
+                , subq_4.largest_listing
+                , subq_4.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +471,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_4
+            ) subq_5
+          ) subq_6
           ON
-            subq_5.listing = subq_8.listing
-        ) subq_9
-      ) subq_10
+            subq_3.listing = subq_6.listing
+        ) subq_7
+      ) subq_8
       WHERE booking__is_instant
-    ) subq_11
-  ) subq_12
+    ) subq_9
+  ) subq_10
   GROUP BY
-    subq_12.listing__country_latest
-) subq_13
+    subq_10.listing__country_latest
+) subq_11

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_19.booking__is_instant AS booking__is_instant
+    subq_15.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_19.bookings AS bookings
+    , subq_15.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
-  ) subq_19
+  ) subq_15
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_19.listing = listings_latest_src_28000.listing_id
-) subq_24
+    subq_15.listing = listings_latest_src_28000.listing_id
+) subq_20
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(subq_15.max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
+  subq_13.metric_time__day
+  , CAST(subq_13.average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.average_booking_value) AS average_booking_value
-    , MAX(subq_14.max_booking_value) AS max_booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.average_booking_value) AS average_booking_value
+    , MAX(subq_12.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.average_booking_value
+      subq_6.metric_time__day
+      , subq_6.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , AVG(subq_7.average_booking_value) AS average_booking_value
+        subq_5.metric_time__day
+        , AVG(subq_5.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.average_booking_value
+          subq_4.metric_time__day
+          , subq_4.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.average_booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.average_booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.average_booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.max_booking_value
+      subq_11.metric_time__day
+      , subq_11.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , MAX(subq_12.max_booking_value) AS max_booking_value
+        subq_10.metric_time__day
+        , MAX(subq_10.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.max_booking_value
+          subq_9.metric_time__day
+          , subq_9.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.average_booking_value) AS average_booking_value
-    , MAX(subq_30.max_booking_value) AS max_booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.average_booking_value) AS average_booking_value
+    , MAX(subq_26.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,186 +1,186 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user__home_state_latest
-  , subq_12.listings
+  subq_10.user__home_state_latest
+  , subq_10.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.user__home_state_latest
-    , SUM(subq_11.listings) AS listings
+    subq_9.user__home_state_latest
+    , SUM(subq_9.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_10.user__home_state_latest
-      , subq_10.listings
+      subq_8.user__home_state_latest
+      , subq_8.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.listing__is_lux_latest
-        , subq_9.listing__capacity_latest
-        , subq_9.user__home_state_latest
-        , subq_9.listings
+        subq_7.listing__is_lux_latest
+        , subq_7.listing__capacity_latest
+        , subq_7.user__home_state_latest
+        , subq_7.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_8.listing__is_lux_latest
-          , subq_8.listing__capacity_latest
-          , subq_8.user__home_state_latest
-          , subq_8.listings
+          subq_6.listing__is_lux_latest
+          , subq_6.listing__capacity_latest
+          , subq_6.user__home_state_latest
+          , subq_6.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.user AS user
-            , subq_5.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_5.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state_latest AS user__home_state_latest
-            , subq_5.listings AS listings
+            subq_3.user AS user
+            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_3.listing__capacity_latest AS listing__capacity_latest
+            , subq_5.home_state_latest AS user__home_state_latest
+            , subq_3.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.listing__is_lux_latest
-              , subq_4.listing__capacity_latest
-              , subq_4.listings
+              subq_2.user
+              , subq_2.listing__is_lux_latest
+              , subq_2.listing__capacity_latest
+              , subq_2.listings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.created_at__day
-                , subq_3.created_at__week
-                , subq_3.created_at__month
-                , subq_3.created_at__quarter
-                , subq_3.created_at__year
-                , subq_3.created_at__extract_year
-                , subq_3.created_at__extract_quarter
-                , subq_3.created_at__extract_month
-                , subq_3.created_at__extract_day
-                , subq_3.created_at__extract_dow
-                , subq_3.created_at__extract_doy
-                , subq_3.listing__ds__day
-                , subq_3.listing__ds__week
-                , subq_3.listing__ds__month
-                , subq_3.listing__ds__quarter
-                , subq_3.listing__ds__year
-                , subq_3.listing__ds__extract_year
-                , subq_3.listing__ds__extract_quarter
-                , subq_3.listing__ds__extract_month
-                , subq_3.listing__ds__extract_day
-                , subq_3.listing__ds__extract_dow
-                , subq_3.listing__ds__extract_doy
-                , subq_3.listing__created_at__day
-                , subq_3.listing__created_at__week
-                , subq_3.listing__created_at__month
-                , subq_3.listing__created_at__quarter
-                , subq_3.listing__created_at__year
-                , subq_3.listing__created_at__extract_year
-                , subq_3.listing__created_at__extract_quarter
-                , subq_3.listing__created_at__extract_month
-                , subq_3.listing__created_at__extract_day
-                , subq_3.listing__created_at__extract_dow
-                , subq_3.listing__created_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.user
-                , subq_3.listing__user
-                , subq_3.country_latest
-                , subq_3.is_lux_latest
-                , subq_3.capacity_latest
-                , subq_3.listing__country_latest
-                , subq_3.listing__is_lux_latest
-                , subq_3.listing__capacity_latest
-                , subq_3.listings
-                , subq_3.largest_listing
-                , subq_3.smallest_listing
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.created_at__day
+                , subq_1.created_at__week
+                , subq_1.created_at__month
+                , subq_1.created_at__quarter
+                , subq_1.created_at__year
+                , subq_1.created_at__extract_year
+                , subq_1.created_at__extract_quarter
+                , subq_1.created_at__extract_month
+                , subq_1.created_at__extract_day
+                , subq_1.created_at__extract_dow
+                , subq_1.created_at__extract_doy
+                , subq_1.listing__ds__day
+                , subq_1.listing__ds__week
+                , subq_1.listing__ds__month
+                , subq_1.listing__ds__quarter
+                , subq_1.listing__ds__year
+                , subq_1.listing__ds__extract_year
+                , subq_1.listing__ds__extract_quarter
+                , subq_1.listing__ds__extract_month
+                , subq_1.listing__ds__extract_day
+                , subq_1.listing__ds__extract_dow
+                , subq_1.listing__ds__extract_doy
+                , subq_1.listing__created_at__day
+                , subq_1.listing__created_at__week
+                , subq_1.listing__created_at__month
+                , subq_1.listing__created_at__quarter
+                , subq_1.listing__created_at__year
+                , subq_1.listing__created_at__extract_year
+                , subq_1.listing__created_at__extract_quarter
+                , subq_1.listing__created_at__extract_month
+                , subq_1.listing__created_at__extract_day
+                , subq_1.listing__created_at__extract_dow
+                , subq_1.listing__created_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.user
+                , subq_1.listing__user
+                , subq_1.country_latest
+                , subq_1.is_lux_latest
+                , subq_1.capacity_latest
+                , subq_1.listing__country_latest
+                , subq_1.listing__is_lux_latest
+                , subq_1.listing__capacity_latest
+                , subq_1.listings
+                , subq_1.largest_listing
+                , subq_1.smallest_listing
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.created_at__day
-                  , subq_2.created_at__week
-                  , subq_2.created_at__month
-                  , subq_2.created_at__quarter
-                  , subq_2.created_at__year
-                  , subq_2.created_at__extract_year
-                  , subq_2.created_at__extract_quarter
-                  , subq_2.created_at__extract_month
-                  , subq_2.created_at__extract_day
-                  , subq_2.created_at__extract_dow
-                  , subq_2.created_at__extract_doy
-                  , subq_2.listing__ds__day
-                  , subq_2.listing__ds__week
-                  , subq_2.listing__ds__month
-                  , subq_2.listing__ds__quarter
-                  , subq_2.listing__ds__year
-                  , subq_2.listing__ds__extract_year
-                  , subq_2.listing__ds__extract_quarter
-                  , subq_2.listing__ds__extract_month
-                  , subq_2.listing__ds__extract_day
-                  , subq_2.listing__ds__extract_dow
-                  , subq_2.listing__ds__extract_doy
-                  , subq_2.listing__created_at__day
-                  , subq_2.listing__created_at__week
-                  , subq_2.listing__created_at__month
-                  , subq_2.listing__created_at__quarter
-                  , subq_2.listing__created_at__year
-                  , subq_2.listing__created_at__extract_year
-                  , subq_2.listing__created_at__extract_quarter
-                  , subq_2.listing__created_at__extract_month
-                  , subq_2.listing__created_at__extract_day
-                  , subq_2.listing__created_at__extract_dow
-                  , subq_2.listing__created_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.user
-                  , subq_2.listing__user
-                  , subq_2.country_latest
-                  , subq_2.is_lux_latest
-                  , subq_2.capacity_latest
-                  , subq_2.listing__country_latest
-                  , subq_2.listing__is_lux_latest
-                  , subq_2.listing__capacity_latest
-                  , subq_2.listings
-                  , subq_2.largest_listing
-                  , subq_2.smallest_listing
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.created_at__day
+                  , subq_0.created_at__week
+                  , subq_0.created_at__month
+                  , subq_0.created_at__quarter
+                  , subq_0.created_at__year
+                  , subq_0.created_at__extract_year
+                  , subq_0.created_at__extract_quarter
+                  , subq_0.created_at__extract_month
+                  , subq_0.created_at__extract_day
+                  , subq_0.created_at__extract_dow
+                  , subq_0.created_at__extract_doy
+                  , subq_0.listing__ds__day
+                  , subq_0.listing__ds__week
+                  , subq_0.listing__ds__month
+                  , subq_0.listing__ds__quarter
+                  , subq_0.listing__ds__year
+                  , subq_0.listing__ds__extract_year
+                  , subq_0.listing__ds__extract_quarter
+                  , subq_0.listing__ds__extract_month
+                  , subq_0.listing__ds__extract_day
+                  , subq_0.listing__ds__extract_dow
+                  , subq_0.listing__ds__extract_doy
+                  , subq_0.listing__created_at__day
+                  , subq_0.listing__created_at__week
+                  , subq_0.listing__created_at__month
+                  , subq_0.listing__created_at__quarter
+                  , subq_0.listing__created_at__year
+                  , subq_0.listing__created_at__extract_year
+                  , subq_0.listing__created_at__extract_quarter
+                  , subq_0.listing__created_at__extract_month
+                  , subq_0.listing__created_at__extract_day
+                  , subq_0.listing__created_at__extract_dow
+                  , subq_0.listing__created_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.user
+                  , subq_0.listing__user
+                  , subq_0.country_latest
+                  , subq_0.is_lux_latest
+                  , subq_0.capacity_latest
+                  , subq_0.listing__country_latest
+                  , subq_0.listing__is_lux_latest
+                  , subq_0.listing__capacity_latest
+                  , subq_0.listings
+                  , subq_0.largest_listing
+                  , subq_0.smallest_listing
                 FROM (
                   -- Read Elements From Semantic Model 'listings_latest'
                   SELECT
@@ -241,16 +241,16 @@ FROM (
                     , listings_latest_src_28000.user_id AS user
                     , listings_latest_src_28000.user_id AS listing__user
                   FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_6.user
-              , subq_6.home_state_latest
+              subq_4.user
+              , subq_4.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +280,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_6
-          ) subq_7
+            ) subq_4
+          ) subq_5
           ON
-            subq_5.user = subq_7.user
-        ) subq_8
-      ) subq_9
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.user__home_state_latest
-) subq_12
+    subq_9.user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_18.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_18.listing__capacity_latest AS listing__capacity_latest
+    subq_14.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_14.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_18.listings AS listings
+    , subq_14.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_16.user
+      subq_12.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_16
+    ) subq_12
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_18.user = users_latest_src_28000.user_id
-) subq_22
+    subq_14.user = users_latest_src_28000.user_id
+) subq_18
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,244 +1,244 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.listing__country_latest
-  , subq_13.bookings
+  subq_11.listing__country_latest
+  , subq_11.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.listing__country_latest
-    , SUM(subq_12.bookings) AS bookings
+    subq_10.listing__country_latest
+    , SUM(subq_10.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_11.listing__country_latest
-      , subq_11.bookings
+      subq_9.listing__country_latest
+      , subq_9.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_10.booking__is_instant
-        , subq_10.listing__country_latest
-        , subq_10.bookings
+        subq_8.booking__is_instant
+        , subq_8.listing__country_latest
+        , subq_8.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_9.booking__is_instant
-          , subq_9.listing__country_latest
-          , subq_9.bookings
+          subq_7.booking__is_instant
+          , subq_7.listing__country_latest
+          , subq_7.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.listing AS listing
-            , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
-            , subq_5.bookings AS bookings
+            subq_3.listing AS listing
+            , subq_3.booking__is_instant AS booking__is_instant
+            , subq_6.country_latest AS listing__country_latest
+            , subq_3.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_4.listing
-              , subq_4.booking__is_instant
-              , subq_4.bookings
+              subq_2.listing
+              , subq_2.booking__is_instant
+              , subq_2.bookings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -331,86 +331,86 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['country_latest', 'listing']
             SELECT
-              subq_7.listing
-              , subq_7.country_latest
+              subq_5.listing
+              , subq_5.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_6.ds__day
-                , subq_6.ds__week
-                , subq_6.ds__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.created_at__day
-                , subq_6.created_at__week
-                , subq_6.created_at__month
-                , subq_6.created_at__quarter
-                , subq_6.created_at__year
-                , subq_6.created_at__extract_year
-                , subq_6.created_at__extract_quarter
-                , subq_6.created_at__extract_month
-                , subq_6.created_at__extract_day
-                , subq_6.created_at__extract_dow
-                , subq_6.created_at__extract_doy
-                , subq_6.listing__ds__day
-                , subq_6.listing__ds__week
-                , subq_6.listing__ds__month
-                , subq_6.listing__ds__quarter
-                , subq_6.listing__ds__year
-                , subq_6.listing__ds__extract_year
-                , subq_6.listing__ds__extract_quarter
-                , subq_6.listing__ds__extract_month
-                , subq_6.listing__ds__extract_day
-                , subq_6.listing__ds__extract_dow
-                , subq_6.listing__ds__extract_doy
-                , subq_6.listing__created_at__day
-                , subq_6.listing__created_at__week
-                , subq_6.listing__created_at__month
-                , subq_6.listing__created_at__quarter
-                , subq_6.listing__created_at__year
-                , subq_6.listing__created_at__extract_year
-                , subq_6.listing__created_at__extract_quarter
-                , subq_6.listing__created_at__extract_month
-                , subq_6.listing__created_at__extract_day
-                , subq_6.listing__created_at__extract_dow
-                , subq_6.listing__created_at__extract_doy
-                , subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week AS metric_time__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter AS metric_time__quarter
-                , subq_6.ds__year AS metric_time__year
-                , subq_6.ds__extract_year AS metric_time__extract_year
-                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_6.ds__extract_month AS metric_time__extract_month
-                , subq_6.ds__extract_day AS metric_time__extract_day
-                , subq_6.ds__extract_dow AS metric_time__extract_dow
-                , subq_6.ds__extract_doy AS metric_time__extract_doy
-                , subq_6.listing
-                , subq_6.user
-                , subq_6.listing__user
-                , subq_6.country_latest
-                , subq_6.is_lux_latest
-                , subq_6.capacity_latest
-                , subq_6.listing__country_latest
-                , subq_6.listing__is_lux_latest
-                , subq_6.listing__capacity_latest
-                , subq_6.listings
-                , subq_6.largest_listing
-                , subq_6.smallest_listing
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.created_at__day
+                , subq_4.created_at__week
+                , subq_4.created_at__month
+                , subq_4.created_at__quarter
+                , subq_4.created_at__year
+                , subq_4.created_at__extract_year
+                , subq_4.created_at__extract_quarter
+                , subq_4.created_at__extract_month
+                , subq_4.created_at__extract_day
+                , subq_4.created_at__extract_dow
+                , subq_4.created_at__extract_doy
+                , subq_4.listing__ds__day
+                , subq_4.listing__ds__week
+                , subq_4.listing__ds__month
+                , subq_4.listing__ds__quarter
+                , subq_4.listing__ds__year
+                , subq_4.listing__ds__extract_year
+                , subq_4.listing__ds__extract_quarter
+                , subq_4.listing__ds__extract_month
+                , subq_4.listing__ds__extract_day
+                , subq_4.listing__ds__extract_dow
+                , subq_4.listing__ds__extract_doy
+                , subq_4.listing__created_at__day
+                , subq_4.listing__created_at__week
+                , subq_4.listing__created_at__month
+                , subq_4.listing__created_at__quarter
+                , subq_4.listing__created_at__year
+                , subq_4.listing__created_at__extract_year
+                , subq_4.listing__created_at__extract_quarter
+                , subq_4.listing__created_at__extract_month
+                , subq_4.listing__created_at__extract_day
+                , subq_4.listing__created_at__extract_dow
+                , subq_4.listing__created_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.user
+                , subq_4.listing__user
+                , subq_4.country_latest
+                , subq_4.is_lux_latest
+                , subq_4.capacity_latest
+                , subq_4.listing__country_latest
+                , subq_4.listing__is_lux_latest
+                , subq_4.listing__capacity_latest
+                , subq_4.listings
+                , subq_4.largest_listing
+                , subq_4.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +471,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_4
+            ) subq_5
+          ) subq_6
           ON
-            subq_5.listing = subq_8.listing
-        ) subq_9
-      ) subq_10
+            subq_3.listing = subq_6.listing
+        ) subq_7
+      ) subq_8
       WHERE booking__is_instant
-    ) subq_11
-  ) subq_12
+    ) subq_9
+  ) subq_10
   GROUP BY
-    subq_12.listing__country_latest
-) subq_13
+    subq_10.listing__country_latest
+) subq_11

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_19.booking__is_instant AS booking__is_instant
+    subq_15.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_19.bookings AS bookings
+    , subq_15.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
-  ) subq_19
+  ) subq_15
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_19.listing = listings_latest_src_28000.listing_id
-) subq_24
+    subq_15.listing = listings_latest_src_28000.listing_id
+) subq_20
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_15.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
+  subq_13.metric_time__day
+  , CAST(subq_13.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.average_booking_value) AS average_booking_value
-    , MAX(subq_14.max_booking_value) AS max_booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.average_booking_value) AS average_booking_value
+    , MAX(subq_12.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.average_booking_value
+      subq_6.metric_time__day
+      , subq_6.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , AVG(subq_7.average_booking_value) AS average_booking_value
+        subq_5.metric_time__day
+        , AVG(subq_5.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.average_booking_value
+          subq_4.metric_time__day
+          , subq_4.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.average_booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.average_booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.average_booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.max_booking_value
+      subq_11.metric_time__day
+      , subq_11.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , MAX(subq_12.max_booking_value) AS max_booking_value
+        subq_10.metric_time__day
+        , MAX(subq_10.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.max_booking_value
+          subq_9.metric_time__day
+          , subq_9.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.average_booking_value) AS average_booking_value
-    , MAX(subq_30.max_booking_value) AS max_booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.average_booking_value) AS average_booking_value
+    , MAX(subq_26.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,186 +1,186 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user__home_state_latest
-  , subq_12.listings
+  subq_10.user__home_state_latest
+  , subq_10.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.user__home_state_latest
-    , SUM(subq_11.listings) AS listings
+    subq_9.user__home_state_latest
+    , SUM(subq_9.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_10.user__home_state_latest
-      , subq_10.listings
+      subq_8.user__home_state_latest
+      , subq_8.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.listing__is_lux_latest
-        , subq_9.listing__capacity_latest
-        , subq_9.user__home_state_latest
-        , subq_9.listings
+        subq_7.listing__is_lux_latest
+        , subq_7.listing__capacity_latest
+        , subq_7.user__home_state_latest
+        , subq_7.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_8.listing__is_lux_latest
-          , subq_8.listing__capacity_latest
-          , subq_8.user__home_state_latest
-          , subq_8.listings
+          subq_6.listing__is_lux_latest
+          , subq_6.listing__capacity_latest
+          , subq_6.user__home_state_latest
+          , subq_6.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.user AS user
-            , subq_5.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_5.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state_latest AS user__home_state_latest
-            , subq_5.listings AS listings
+            subq_3.user AS user
+            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_3.listing__capacity_latest AS listing__capacity_latest
+            , subq_5.home_state_latest AS user__home_state_latest
+            , subq_3.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.listing__is_lux_latest
-              , subq_4.listing__capacity_latest
-              , subq_4.listings
+              subq_2.user
+              , subq_2.listing__is_lux_latest
+              , subq_2.listing__capacity_latest
+              , subq_2.listings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.created_at__day
-                , subq_3.created_at__week
-                , subq_3.created_at__month
-                , subq_3.created_at__quarter
-                , subq_3.created_at__year
-                , subq_3.created_at__extract_year
-                , subq_3.created_at__extract_quarter
-                , subq_3.created_at__extract_month
-                , subq_3.created_at__extract_day
-                , subq_3.created_at__extract_dow
-                , subq_3.created_at__extract_doy
-                , subq_3.listing__ds__day
-                , subq_3.listing__ds__week
-                , subq_3.listing__ds__month
-                , subq_3.listing__ds__quarter
-                , subq_3.listing__ds__year
-                , subq_3.listing__ds__extract_year
-                , subq_3.listing__ds__extract_quarter
-                , subq_3.listing__ds__extract_month
-                , subq_3.listing__ds__extract_day
-                , subq_3.listing__ds__extract_dow
-                , subq_3.listing__ds__extract_doy
-                , subq_3.listing__created_at__day
-                , subq_3.listing__created_at__week
-                , subq_3.listing__created_at__month
-                , subq_3.listing__created_at__quarter
-                , subq_3.listing__created_at__year
-                , subq_3.listing__created_at__extract_year
-                , subq_3.listing__created_at__extract_quarter
-                , subq_3.listing__created_at__extract_month
-                , subq_3.listing__created_at__extract_day
-                , subq_3.listing__created_at__extract_dow
-                , subq_3.listing__created_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.user
-                , subq_3.listing__user
-                , subq_3.country_latest
-                , subq_3.is_lux_latest
-                , subq_3.capacity_latest
-                , subq_3.listing__country_latest
-                , subq_3.listing__is_lux_latest
-                , subq_3.listing__capacity_latest
-                , subq_3.listings
-                , subq_3.largest_listing
-                , subq_3.smallest_listing
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.created_at__day
+                , subq_1.created_at__week
+                , subq_1.created_at__month
+                , subq_1.created_at__quarter
+                , subq_1.created_at__year
+                , subq_1.created_at__extract_year
+                , subq_1.created_at__extract_quarter
+                , subq_1.created_at__extract_month
+                , subq_1.created_at__extract_day
+                , subq_1.created_at__extract_dow
+                , subq_1.created_at__extract_doy
+                , subq_1.listing__ds__day
+                , subq_1.listing__ds__week
+                , subq_1.listing__ds__month
+                , subq_1.listing__ds__quarter
+                , subq_1.listing__ds__year
+                , subq_1.listing__ds__extract_year
+                , subq_1.listing__ds__extract_quarter
+                , subq_1.listing__ds__extract_month
+                , subq_1.listing__ds__extract_day
+                , subq_1.listing__ds__extract_dow
+                , subq_1.listing__ds__extract_doy
+                , subq_1.listing__created_at__day
+                , subq_1.listing__created_at__week
+                , subq_1.listing__created_at__month
+                , subq_1.listing__created_at__quarter
+                , subq_1.listing__created_at__year
+                , subq_1.listing__created_at__extract_year
+                , subq_1.listing__created_at__extract_quarter
+                , subq_1.listing__created_at__extract_month
+                , subq_1.listing__created_at__extract_day
+                , subq_1.listing__created_at__extract_dow
+                , subq_1.listing__created_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.user
+                , subq_1.listing__user
+                , subq_1.country_latest
+                , subq_1.is_lux_latest
+                , subq_1.capacity_latest
+                , subq_1.listing__country_latest
+                , subq_1.listing__is_lux_latest
+                , subq_1.listing__capacity_latest
+                , subq_1.listings
+                , subq_1.largest_listing
+                , subq_1.smallest_listing
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.created_at__day
-                  , subq_2.created_at__week
-                  , subq_2.created_at__month
-                  , subq_2.created_at__quarter
-                  , subq_2.created_at__year
-                  , subq_2.created_at__extract_year
-                  , subq_2.created_at__extract_quarter
-                  , subq_2.created_at__extract_month
-                  , subq_2.created_at__extract_day
-                  , subq_2.created_at__extract_dow
-                  , subq_2.created_at__extract_doy
-                  , subq_2.listing__ds__day
-                  , subq_2.listing__ds__week
-                  , subq_2.listing__ds__month
-                  , subq_2.listing__ds__quarter
-                  , subq_2.listing__ds__year
-                  , subq_2.listing__ds__extract_year
-                  , subq_2.listing__ds__extract_quarter
-                  , subq_2.listing__ds__extract_month
-                  , subq_2.listing__ds__extract_day
-                  , subq_2.listing__ds__extract_dow
-                  , subq_2.listing__ds__extract_doy
-                  , subq_2.listing__created_at__day
-                  , subq_2.listing__created_at__week
-                  , subq_2.listing__created_at__month
-                  , subq_2.listing__created_at__quarter
-                  , subq_2.listing__created_at__year
-                  , subq_2.listing__created_at__extract_year
-                  , subq_2.listing__created_at__extract_quarter
-                  , subq_2.listing__created_at__extract_month
-                  , subq_2.listing__created_at__extract_day
-                  , subq_2.listing__created_at__extract_dow
-                  , subq_2.listing__created_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.user
-                  , subq_2.listing__user
-                  , subq_2.country_latest
-                  , subq_2.is_lux_latest
-                  , subq_2.capacity_latest
-                  , subq_2.listing__country_latest
-                  , subq_2.listing__is_lux_latest
-                  , subq_2.listing__capacity_latest
-                  , subq_2.listings
-                  , subq_2.largest_listing
-                  , subq_2.smallest_listing
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.created_at__day
+                  , subq_0.created_at__week
+                  , subq_0.created_at__month
+                  , subq_0.created_at__quarter
+                  , subq_0.created_at__year
+                  , subq_0.created_at__extract_year
+                  , subq_0.created_at__extract_quarter
+                  , subq_0.created_at__extract_month
+                  , subq_0.created_at__extract_day
+                  , subq_0.created_at__extract_dow
+                  , subq_0.created_at__extract_doy
+                  , subq_0.listing__ds__day
+                  , subq_0.listing__ds__week
+                  , subq_0.listing__ds__month
+                  , subq_0.listing__ds__quarter
+                  , subq_0.listing__ds__year
+                  , subq_0.listing__ds__extract_year
+                  , subq_0.listing__ds__extract_quarter
+                  , subq_0.listing__ds__extract_month
+                  , subq_0.listing__ds__extract_day
+                  , subq_0.listing__ds__extract_dow
+                  , subq_0.listing__ds__extract_doy
+                  , subq_0.listing__created_at__day
+                  , subq_0.listing__created_at__week
+                  , subq_0.listing__created_at__month
+                  , subq_0.listing__created_at__quarter
+                  , subq_0.listing__created_at__year
+                  , subq_0.listing__created_at__extract_year
+                  , subq_0.listing__created_at__extract_quarter
+                  , subq_0.listing__created_at__extract_month
+                  , subq_0.listing__created_at__extract_day
+                  , subq_0.listing__created_at__extract_dow
+                  , subq_0.listing__created_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.user
+                  , subq_0.listing__user
+                  , subq_0.country_latest
+                  , subq_0.is_lux_latest
+                  , subq_0.capacity_latest
+                  , subq_0.listing__country_latest
+                  , subq_0.listing__is_lux_latest
+                  , subq_0.listing__capacity_latest
+                  , subq_0.listings
+                  , subq_0.largest_listing
+                  , subq_0.smallest_listing
                 FROM (
                   -- Read Elements From Semantic Model 'listings_latest'
                   SELECT
@@ -241,16 +241,16 @@ FROM (
                     , listings_latest_src_28000.user_id AS user
                     , listings_latest_src_28000.user_id AS listing__user
                   FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_6.user
-              , subq_6.home_state_latest
+              subq_4.user
+              , subq_4.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +280,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_6
-          ) subq_7
+            ) subq_4
+          ) subq_5
           ON
-            subq_5.user = subq_7.user
-        ) subq_8
-      ) subq_9
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.user__home_state_latest
-) subq_12
+    subq_9.user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_18.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_18.listing__capacity_latest AS listing__capacity_latest
+    subq_14.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_14.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_18.listings AS listings
+    , subq_14.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_16.user
+      subq_12.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_16
+    ) subq_12
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_18.user = users_latest_src_28000.user_id
-) subq_22
+    subq_14.user = users_latest_src_28000.user_id
+) subq_18
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,244 +1,244 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.listing__country_latest
-  , subq_13.bookings
+  subq_11.listing__country_latest
+  , subq_11.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.listing__country_latest
-    , SUM(subq_12.bookings) AS bookings
+    subq_10.listing__country_latest
+    , SUM(subq_10.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_11.listing__country_latest
-      , subq_11.bookings
+      subq_9.listing__country_latest
+      , subq_9.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_10.booking__is_instant
-        , subq_10.listing__country_latest
-        , subq_10.bookings
+        subq_8.booking__is_instant
+        , subq_8.listing__country_latest
+        , subq_8.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_9.booking__is_instant
-          , subq_9.listing__country_latest
-          , subq_9.bookings
+          subq_7.booking__is_instant
+          , subq_7.listing__country_latest
+          , subq_7.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.listing AS listing
-            , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
-            , subq_5.bookings AS bookings
+            subq_3.listing AS listing
+            , subq_3.booking__is_instant AS booking__is_instant
+            , subq_6.country_latest AS listing__country_latest
+            , subq_3.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_4.listing
-              , subq_4.booking__is_instant
-              , subq_4.bookings
+              subq_2.listing
+              , subq_2.booking__is_instant
+              , subq_2.bookings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -331,86 +331,86 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['country_latest', 'listing']
             SELECT
-              subq_7.listing
-              , subq_7.country_latest
+              subq_5.listing
+              , subq_5.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_6.ds__day
-                , subq_6.ds__week
-                , subq_6.ds__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.created_at__day
-                , subq_6.created_at__week
-                , subq_6.created_at__month
-                , subq_6.created_at__quarter
-                , subq_6.created_at__year
-                , subq_6.created_at__extract_year
-                , subq_6.created_at__extract_quarter
-                , subq_6.created_at__extract_month
-                , subq_6.created_at__extract_day
-                , subq_6.created_at__extract_dow
-                , subq_6.created_at__extract_doy
-                , subq_6.listing__ds__day
-                , subq_6.listing__ds__week
-                , subq_6.listing__ds__month
-                , subq_6.listing__ds__quarter
-                , subq_6.listing__ds__year
-                , subq_6.listing__ds__extract_year
-                , subq_6.listing__ds__extract_quarter
-                , subq_6.listing__ds__extract_month
-                , subq_6.listing__ds__extract_day
-                , subq_6.listing__ds__extract_dow
-                , subq_6.listing__ds__extract_doy
-                , subq_6.listing__created_at__day
-                , subq_6.listing__created_at__week
-                , subq_6.listing__created_at__month
-                , subq_6.listing__created_at__quarter
-                , subq_6.listing__created_at__year
-                , subq_6.listing__created_at__extract_year
-                , subq_6.listing__created_at__extract_quarter
-                , subq_6.listing__created_at__extract_month
-                , subq_6.listing__created_at__extract_day
-                , subq_6.listing__created_at__extract_dow
-                , subq_6.listing__created_at__extract_doy
-                , subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week AS metric_time__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter AS metric_time__quarter
-                , subq_6.ds__year AS metric_time__year
-                , subq_6.ds__extract_year AS metric_time__extract_year
-                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_6.ds__extract_month AS metric_time__extract_month
-                , subq_6.ds__extract_day AS metric_time__extract_day
-                , subq_6.ds__extract_dow AS metric_time__extract_dow
-                , subq_6.ds__extract_doy AS metric_time__extract_doy
-                , subq_6.listing
-                , subq_6.user
-                , subq_6.listing__user
-                , subq_6.country_latest
-                , subq_6.is_lux_latest
-                , subq_6.capacity_latest
-                , subq_6.listing__country_latest
-                , subq_6.listing__is_lux_latest
-                , subq_6.listing__capacity_latest
-                , subq_6.listings
-                , subq_6.largest_listing
-                , subq_6.smallest_listing
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.created_at__day
+                , subq_4.created_at__week
+                , subq_4.created_at__month
+                , subq_4.created_at__quarter
+                , subq_4.created_at__year
+                , subq_4.created_at__extract_year
+                , subq_4.created_at__extract_quarter
+                , subq_4.created_at__extract_month
+                , subq_4.created_at__extract_day
+                , subq_4.created_at__extract_dow
+                , subq_4.created_at__extract_doy
+                , subq_4.listing__ds__day
+                , subq_4.listing__ds__week
+                , subq_4.listing__ds__month
+                , subq_4.listing__ds__quarter
+                , subq_4.listing__ds__year
+                , subq_4.listing__ds__extract_year
+                , subq_4.listing__ds__extract_quarter
+                , subq_4.listing__ds__extract_month
+                , subq_4.listing__ds__extract_day
+                , subq_4.listing__ds__extract_dow
+                , subq_4.listing__ds__extract_doy
+                , subq_4.listing__created_at__day
+                , subq_4.listing__created_at__week
+                , subq_4.listing__created_at__month
+                , subq_4.listing__created_at__quarter
+                , subq_4.listing__created_at__year
+                , subq_4.listing__created_at__extract_year
+                , subq_4.listing__created_at__extract_quarter
+                , subq_4.listing__created_at__extract_month
+                , subq_4.listing__created_at__extract_day
+                , subq_4.listing__created_at__extract_dow
+                , subq_4.listing__created_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.user
+                , subq_4.listing__user
+                , subq_4.country_latest
+                , subq_4.is_lux_latest
+                , subq_4.capacity_latest
+                , subq_4.listing__country_latest
+                , subq_4.listing__is_lux_latest
+                , subq_4.listing__capacity_latest
+                , subq_4.listings
+                , subq_4.largest_listing
+                , subq_4.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +471,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_4
+            ) subq_5
+          ) subq_6
           ON
-            subq_5.listing = subq_8.listing
-        ) subq_9
-      ) subq_10
+            subq_3.listing = subq_6.listing
+        ) subq_7
+      ) subq_8
       WHERE booking__is_instant
-    ) subq_11
-  ) subq_12
+    ) subq_9
+  ) subq_10
   GROUP BY
-    subq_12.listing__country_latest
-) subq_13
+    subq_10.listing__country_latest
+) subq_11

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_19.booking__is_instant AS booking__is_instant
+    subq_15.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_19.bookings AS bookings
+    , subq_15.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
-  ) subq_19
+  ) subq_15
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_19.listing = listings_latest_src_28000.listing_id
-) subq_24
+    subq_15.listing = listings_latest_src_28000.listing_id
+) subq_20
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_15.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
+  subq_13.metric_time__day
+  , CAST(subq_13.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.average_booking_value) AS average_booking_value
-    , MAX(subq_14.max_booking_value) AS max_booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.average_booking_value) AS average_booking_value
+    , MAX(subq_12.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.average_booking_value
+      subq_6.metric_time__day
+      , subq_6.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , AVG(subq_7.average_booking_value) AS average_booking_value
+        subq_5.metric_time__day
+        , AVG(subq_5.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.average_booking_value
+          subq_4.metric_time__day
+          , subq_4.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.average_booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.average_booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.average_booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.max_booking_value
+      subq_11.metric_time__day
+      , subq_11.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , MAX(subq_12.max_booking_value) AS max_booking_value
+        subq_10.metric_time__day
+        , MAX(subq_10.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.max_booking_value
+          subq_9.metric_time__day
+          , subq_9.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.average_booking_value) AS average_booking_value
-    , MAX(subq_30.max_booking_value) AS max_booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.average_booking_value) AS average_booking_value
+    , MAX(subq_26.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,186 +1,186 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user__home_state_latest
-  , subq_12.listings
+  subq_10.user__home_state_latest
+  , subq_10.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.user__home_state_latest
-    , SUM(subq_11.listings) AS listings
+    subq_9.user__home_state_latest
+    , SUM(subq_9.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_10.user__home_state_latest
-      , subq_10.listings
+      subq_8.user__home_state_latest
+      , subq_8.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.listing__is_lux_latest
-        , subq_9.listing__capacity_latest
-        , subq_9.user__home_state_latest
-        , subq_9.listings
+        subq_7.listing__is_lux_latest
+        , subq_7.listing__capacity_latest
+        , subq_7.user__home_state_latest
+        , subq_7.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_8.listing__is_lux_latest
-          , subq_8.listing__capacity_latest
-          , subq_8.user__home_state_latest
-          , subq_8.listings
+          subq_6.listing__is_lux_latest
+          , subq_6.listing__capacity_latest
+          , subq_6.user__home_state_latest
+          , subq_6.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.user AS user
-            , subq_5.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_5.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state_latest AS user__home_state_latest
-            , subq_5.listings AS listings
+            subq_3.user AS user
+            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_3.listing__capacity_latest AS listing__capacity_latest
+            , subq_5.home_state_latest AS user__home_state_latest
+            , subq_3.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.listing__is_lux_latest
-              , subq_4.listing__capacity_latest
-              , subq_4.listings
+              subq_2.user
+              , subq_2.listing__is_lux_latest
+              , subq_2.listing__capacity_latest
+              , subq_2.listings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.created_at__day
-                , subq_3.created_at__week
-                , subq_3.created_at__month
-                , subq_3.created_at__quarter
-                , subq_3.created_at__year
-                , subq_3.created_at__extract_year
-                , subq_3.created_at__extract_quarter
-                , subq_3.created_at__extract_month
-                , subq_3.created_at__extract_day
-                , subq_3.created_at__extract_dow
-                , subq_3.created_at__extract_doy
-                , subq_3.listing__ds__day
-                , subq_3.listing__ds__week
-                , subq_3.listing__ds__month
-                , subq_3.listing__ds__quarter
-                , subq_3.listing__ds__year
-                , subq_3.listing__ds__extract_year
-                , subq_3.listing__ds__extract_quarter
-                , subq_3.listing__ds__extract_month
-                , subq_3.listing__ds__extract_day
-                , subq_3.listing__ds__extract_dow
-                , subq_3.listing__ds__extract_doy
-                , subq_3.listing__created_at__day
-                , subq_3.listing__created_at__week
-                , subq_3.listing__created_at__month
-                , subq_3.listing__created_at__quarter
-                , subq_3.listing__created_at__year
-                , subq_3.listing__created_at__extract_year
-                , subq_3.listing__created_at__extract_quarter
-                , subq_3.listing__created_at__extract_month
-                , subq_3.listing__created_at__extract_day
-                , subq_3.listing__created_at__extract_dow
-                , subq_3.listing__created_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.user
-                , subq_3.listing__user
-                , subq_3.country_latest
-                , subq_3.is_lux_latest
-                , subq_3.capacity_latest
-                , subq_3.listing__country_latest
-                , subq_3.listing__is_lux_latest
-                , subq_3.listing__capacity_latest
-                , subq_3.listings
-                , subq_3.largest_listing
-                , subq_3.smallest_listing
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.created_at__day
+                , subq_1.created_at__week
+                , subq_1.created_at__month
+                , subq_1.created_at__quarter
+                , subq_1.created_at__year
+                , subq_1.created_at__extract_year
+                , subq_1.created_at__extract_quarter
+                , subq_1.created_at__extract_month
+                , subq_1.created_at__extract_day
+                , subq_1.created_at__extract_dow
+                , subq_1.created_at__extract_doy
+                , subq_1.listing__ds__day
+                , subq_1.listing__ds__week
+                , subq_1.listing__ds__month
+                , subq_1.listing__ds__quarter
+                , subq_1.listing__ds__year
+                , subq_1.listing__ds__extract_year
+                , subq_1.listing__ds__extract_quarter
+                , subq_1.listing__ds__extract_month
+                , subq_1.listing__ds__extract_day
+                , subq_1.listing__ds__extract_dow
+                , subq_1.listing__ds__extract_doy
+                , subq_1.listing__created_at__day
+                , subq_1.listing__created_at__week
+                , subq_1.listing__created_at__month
+                , subq_1.listing__created_at__quarter
+                , subq_1.listing__created_at__year
+                , subq_1.listing__created_at__extract_year
+                , subq_1.listing__created_at__extract_quarter
+                , subq_1.listing__created_at__extract_month
+                , subq_1.listing__created_at__extract_day
+                , subq_1.listing__created_at__extract_dow
+                , subq_1.listing__created_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.user
+                , subq_1.listing__user
+                , subq_1.country_latest
+                , subq_1.is_lux_latest
+                , subq_1.capacity_latest
+                , subq_1.listing__country_latest
+                , subq_1.listing__is_lux_latest
+                , subq_1.listing__capacity_latest
+                , subq_1.listings
+                , subq_1.largest_listing
+                , subq_1.smallest_listing
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.created_at__day
-                  , subq_2.created_at__week
-                  , subq_2.created_at__month
-                  , subq_2.created_at__quarter
-                  , subq_2.created_at__year
-                  , subq_2.created_at__extract_year
-                  , subq_2.created_at__extract_quarter
-                  , subq_2.created_at__extract_month
-                  , subq_2.created_at__extract_day
-                  , subq_2.created_at__extract_dow
-                  , subq_2.created_at__extract_doy
-                  , subq_2.listing__ds__day
-                  , subq_2.listing__ds__week
-                  , subq_2.listing__ds__month
-                  , subq_2.listing__ds__quarter
-                  , subq_2.listing__ds__year
-                  , subq_2.listing__ds__extract_year
-                  , subq_2.listing__ds__extract_quarter
-                  , subq_2.listing__ds__extract_month
-                  , subq_2.listing__ds__extract_day
-                  , subq_2.listing__ds__extract_dow
-                  , subq_2.listing__ds__extract_doy
-                  , subq_2.listing__created_at__day
-                  , subq_2.listing__created_at__week
-                  , subq_2.listing__created_at__month
-                  , subq_2.listing__created_at__quarter
-                  , subq_2.listing__created_at__year
-                  , subq_2.listing__created_at__extract_year
-                  , subq_2.listing__created_at__extract_quarter
-                  , subq_2.listing__created_at__extract_month
-                  , subq_2.listing__created_at__extract_day
-                  , subq_2.listing__created_at__extract_dow
-                  , subq_2.listing__created_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.user
-                  , subq_2.listing__user
-                  , subq_2.country_latest
-                  , subq_2.is_lux_latest
-                  , subq_2.capacity_latest
-                  , subq_2.listing__country_latest
-                  , subq_2.listing__is_lux_latest
-                  , subq_2.listing__capacity_latest
-                  , subq_2.listings
-                  , subq_2.largest_listing
-                  , subq_2.smallest_listing
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.created_at__day
+                  , subq_0.created_at__week
+                  , subq_0.created_at__month
+                  , subq_0.created_at__quarter
+                  , subq_0.created_at__year
+                  , subq_0.created_at__extract_year
+                  , subq_0.created_at__extract_quarter
+                  , subq_0.created_at__extract_month
+                  , subq_0.created_at__extract_day
+                  , subq_0.created_at__extract_dow
+                  , subq_0.created_at__extract_doy
+                  , subq_0.listing__ds__day
+                  , subq_0.listing__ds__week
+                  , subq_0.listing__ds__month
+                  , subq_0.listing__ds__quarter
+                  , subq_0.listing__ds__year
+                  , subq_0.listing__ds__extract_year
+                  , subq_0.listing__ds__extract_quarter
+                  , subq_0.listing__ds__extract_month
+                  , subq_0.listing__ds__extract_day
+                  , subq_0.listing__ds__extract_dow
+                  , subq_0.listing__ds__extract_doy
+                  , subq_0.listing__created_at__day
+                  , subq_0.listing__created_at__week
+                  , subq_0.listing__created_at__month
+                  , subq_0.listing__created_at__quarter
+                  , subq_0.listing__created_at__year
+                  , subq_0.listing__created_at__extract_year
+                  , subq_0.listing__created_at__extract_quarter
+                  , subq_0.listing__created_at__extract_month
+                  , subq_0.listing__created_at__extract_day
+                  , subq_0.listing__created_at__extract_dow
+                  , subq_0.listing__created_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.user
+                  , subq_0.listing__user
+                  , subq_0.country_latest
+                  , subq_0.is_lux_latest
+                  , subq_0.capacity_latest
+                  , subq_0.listing__country_latest
+                  , subq_0.listing__is_lux_latest
+                  , subq_0.listing__capacity_latest
+                  , subq_0.listings
+                  , subq_0.largest_listing
+                  , subq_0.smallest_listing
                 FROM (
                   -- Read Elements From Semantic Model 'listings_latest'
                   SELECT
@@ -241,16 +241,16 @@ FROM (
                     , listings_latest_src_28000.user_id AS user
                     , listings_latest_src_28000.user_id AS listing__user
                   FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_6.user
-              , subq_6.home_state_latest
+              subq_4.user
+              , subq_4.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +280,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_6
-          ) subq_7
+            ) subq_4
+          ) subq_5
           ON
-            subq_5.user = subq_7.user
-        ) subq_8
-      ) subq_9
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.user__home_state_latest
-) subq_12
+    subq_9.user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_18.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_18.listing__capacity_latest AS listing__capacity_latest
+    subq_14.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_14.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_18.listings AS listings
+    , subq_14.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_16.user
+      subq_12.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_16
+    ) subq_12
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_18.user = users_latest_src_28000.user_id
-) subq_22
+    subq_14.user = users_latest_src_28000.user_id
+) subq_18
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,244 +1,244 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.listing__country_latest
-  , subq_13.bookings
+  subq_11.listing__country_latest
+  , subq_11.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.listing__country_latest
-    , SUM(subq_12.bookings) AS bookings
+    subq_10.listing__country_latest
+    , SUM(subq_10.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_11.listing__country_latest
-      , subq_11.bookings
+      subq_9.listing__country_latest
+      , subq_9.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_10.booking__is_instant
-        , subq_10.listing__country_latest
-        , subq_10.bookings
+        subq_8.booking__is_instant
+        , subq_8.listing__country_latest
+        , subq_8.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_9.booking__is_instant
-          , subq_9.listing__country_latest
-          , subq_9.bookings
+          subq_7.booking__is_instant
+          , subq_7.listing__country_latest
+          , subq_7.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.listing AS listing
-            , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
-            , subq_5.bookings AS bookings
+            subq_3.listing AS listing
+            , subq_3.booking__is_instant AS booking__is_instant
+            , subq_6.country_latest AS listing__country_latest
+            , subq_3.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_4.listing
-              , subq_4.booking__is_instant
-              , subq_4.bookings
+              subq_2.listing
+              , subq_2.booking__is_instant
+              , subq_2.bookings
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -331,86 +331,86 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['country_latest', 'listing']
             SELECT
-              subq_7.listing
-              , subq_7.country_latest
+              subq_5.listing
+              , subq_5.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_6.ds__day
-                , subq_6.ds__week
-                , subq_6.ds__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.created_at__day
-                , subq_6.created_at__week
-                , subq_6.created_at__month
-                , subq_6.created_at__quarter
-                , subq_6.created_at__year
-                , subq_6.created_at__extract_year
-                , subq_6.created_at__extract_quarter
-                , subq_6.created_at__extract_month
-                , subq_6.created_at__extract_day
-                , subq_6.created_at__extract_dow
-                , subq_6.created_at__extract_doy
-                , subq_6.listing__ds__day
-                , subq_6.listing__ds__week
-                , subq_6.listing__ds__month
-                , subq_6.listing__ds__quarter
-                , subq_6.listing__ds__year
-                , subq_6.listing__ds__extract_year
-                , subq_6.listing__ds__extract_quarter
-                , subq_6.listing__ds__extract_month
-                , subq_6.listing__ds__extract_day
-                , subq_6.listing__ds__extract_dow
-                , subq_6.listing__ds__extract_doy
-                , subq_6.listing__created_at__day
-                , subq_6.listing__created_at__week
-                , subq_6.listing__created_at__month
-                , subq_6.listing__created_at__quarter
-                , subq_6.listing__created_at__year
-                , subq_6.listing__created_at__extract_year
-                , subq_6.listing__created_at__extract_quarter
-                , subq_6.listing__created_at__extract_month
-                , subq_6.listing__created_at__extract_day
-                , subq_6.listing__created_at__extract_dow
-                , subq_6.listing__created_at__extract_doy
-                , subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week AS metric_time__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter AS metric_time__quarter
-                , subq_6.ds__year AS metric_time__year
-                , subq_6.ds__extract_year AS metric_time__extract_year
-                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_6.ds__extract_month AS metric_time__extract_month
-                , subq_6.ds__extract_day AS metric_time__extract_day
-                , subq_6.ds__extract_dow AS metric_time__extract_dow
-                , subq_6.ds__extract_doy AS metric_time__extract_doy
-                , subq_6.listing
-                , subq_6.user
-                , subq_6.listing__user
-                , subq_6.country_latest
-                , subq_6.is_lux_latest
-                , subq_6.capacity_latest
-                , subq_6.listing__country_latest
-                , subq_6.listing__is_lux_latest
-                , subq_6.listing__capacity_latest
-                , subq_6.listings
-                , subq_6.largest_listing
-                , subq_6.smallest_listing
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.created_at__day
+                , subq_4.created_at__week
+                , subq_4.created_at__month
+                , subq_4.created_at__quarter
+                , subq_4.created_at__year
+                , subq_4.created_at__extract_year
+                , subq_4.created_at__extract_quarter
+                , subq_4.created_at__extract_month
+                , subq_4.created_at__extract_day
+                , subq_4.created_at__extract_dow
+                , subq_4.created_at__extract_doy
+                , subq_4.listing__ds__day
+                , subq_4.listing__ds__week
+                , subq_4.listing__ds__month
+                , subq_4.listing__ds__quarter
+                , subq_4.listing__ds__year
+                , subq_4.listing__ds__extract_year
+                , subq_4.listing__ds__extract_quarter
+                , subq_4.listing__ds__extract_month
+                , subq_4.listing__ds__extract_day
+                , subq_4.listing__ds__extract_dow
+                , subq_4.listing__ds__extract_doy
+                , subq_4.listing__created_at__day
+                , subq_4.listing__created_at__week
+                , subq_4.listing__created_at__month
+                , subq_4.listing__created_at__quarter
+                , subq_4.listing__created_at__year
+                , subq_4.listing__created_at__extract_year
+                , subq_4.listing__created_at__extract_quarter
+                , subq_4.listing__created_at__extract_month
+                , subq_4.listing__created_at__extract_day
+                , subq_4.listing__created_at__extract_dow
+                , subq_4.listing__created_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.user
+                , subq_4.listing__user
+                , subq_4.country_latest
+                , subq_4.is_lux_latest
+                , subq_4.capacity_latest
+                , subq_4.listing__country_latest
+                , subq_4.listing__is_lux_latest
+                , subq_4.listing__capacity_latest
+                , subq_4.listings
+                , subq_4.largest_listing
+                , subq_4.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +471,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_4
+            ) subq_5
+          ) subq_6
           ON
-            subq_5.listing = subq_8.listing
-        ) subq_9
-      ) subq_10
+            subq_3.listing = subq_6.listing
+        ) subq_7
+      ) subq_8
       WHERE booking__is_instant
-    ) subq_11
-  ) subq_12
+    ) subq_9
+  ) subq_10
   GROUP BY
-    subq_12.listing__country_latest
-) subq_13
+    subq_10.listing__country_latest
+) subq_11

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_19.booking__is_instant AS booking__is_instant
+    subq_15.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_19.bookings AS bookings
+    , subq_15.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
-  ) subq_19
+  ) subq_15
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_19.listing = listings_latest_src_28000.listing_id
-) subq_24
+    subq_15.listing = listings_latest_src_28000.listing_id
+) subq_20
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_15.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
+  subq_13.metric_time__day
+  , CAST(subq_13.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_13.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_14.booking_value) AS booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_12.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.booking_value AS booking_value_with_is_instant_constraint
+      subq_6.metric_time__day
+      , subq_6.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , SUM(subq_7.booking_value) AS booking_value
+        subq_5.metric_time__day
+        , SUM(subq_5.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.booking_value
+          subq_4.metric_time__day
+          , subq_4.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
         metric_time__day
-    ) subq_8
-  ) subq_9
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.booking_value
+      subq_11.metric_time__day
+      , subq_11.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , SUM(subq_12.booking_value) AS booking_value
+        subq_10.metric_time__day
+        , SUM(subq_10.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.booking_value
+          subq_9.metric_time__day
+          , subq_9.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
         metric_time__day
-    ) subq_13
-  ) subq_14
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
     metric_time__day
-) subq_15
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_30.booking_value) AS booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_26.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       metric_time__day
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
     metric_time__day
-) subq_31
+) subq_27

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
+  subq_7.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.metric_time__day
-    , subq_8.bookings AS delayed_bookings
+    subq_6.metric_time__day
+    , subq_6.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -323,15 +323,15 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE NOT booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE NOT booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
       metric_time__day
-  ) subq_8
-) subq_9
+  ) subq_6
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_9
     WHERE NOT booking__is_instant
-  ) subq_15
+  ) subq_11
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_19
+) subq_15

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.listing__user__home_state_latest
-  , subq_21.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__user__home_state_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-    , SUM(subq_20.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__user__home_state_latest', 'metric_time__day']
     SELECT
-      subq_19.metric_time__day
-      , subq_19.listing__user__home_state_latest
-      , subq_19.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__user__home_state_latest
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_13.metric_time__day AS metric_time__day
-        , subq_18.window_start__day AS listing__window_start__day
-        , subq_18.window_end__day AS listing__window_end__day
-        , subq_13.listing AS listing
-        , subq_18.user__home_state_latest AS listing__user__home_state_latest
-        , subq_13.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.window_start__day AS listing__window_start__day
+        , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.user__home_state_latest AS listing__user__home_state_latest
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_12.metric_time__day
-          , subq_12.listing
-          , subq_12.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds__day
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds__extract_year
-            , subq_11.ds__extract_quarter
-            , subq_11.ds__extract_month
-            , subq_11.ds__extract_day
-            , subq_11.ds__extract_dow
-            , subq_11.ds__extract_doy
-            , subq_11.ds_partitioned__day
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.ds_partitioned__extract_year
-            , subq_11.ds_partitioned__extract_quarter
-            , subq_11.ds_partitioned__extract_month
-            , subq_11.ds_partitioned__extract_day
-            , subq_11.ds_partitioned__extract_dow
-            , subq_11.ds_partitioned__extract_doy
-            , subq_11.paid_at__day
-            , subq_11.paid_at__week
-            , subq_11.paid_at__month
-            , subq_11.paid_at__quarter
-            , subq_11.paid_at__year
-            , subq_11.paid_at__extract_year
-            , subq_11.paid_at__extract_quarter
-            , subq_11.paid_at__extract_month
-            , subq_11.paid_at__extract_day
-            , subq_11.paid_at__extract_dow
-            , subq_11.paid_at__extract_doy
-            , subq_11.booking__ds__day
-            , subq_11.booking__ds__week
-            , subq_11.booking__ds__month
-            , subq_11.booking__ds__quarter
-            , subq_11.booking__ds__year
-            , subq_11.booking__ds__extract_year
-            , subq_11.booking__ds__extract_quarter
-            , subq_11.booking__ds__extract_month
-            , subq_11.booking__ds__extract_day
-            , subq_11.booking__ds__extract_dow
-            , subq_11.booking__ds__extract_doy
-            , subq_11.booking__ds_partitioned__day
-            , subq_11.booking__ds_partitioned__week
-            , subq_11.booking__ds_partitioned__month
-            , subq_11.booking__ds_partitioned__quarter
-            , subq_11.booking__ds_partitioned__year
-            , subq_11.booking__ds_partitioned__extract_year
-            , subq_11.booking__ds_partitioned__extract_quarter
-            , subq_11.booking__ds_partitioned__extract_month
-            , subq_11.booking__ds_partitioned__extract_day
-            , subq_11.booking__ds_partitioned__extract_dow
-            , subq_11.booking__ds_partitioned__extract_doy
-            , subq_11.booking__paid_at__day
-            , subq_11.booking__paid_at__week
-            , subq_11.booking__paid_at__month
-            , subq_11.booking__paid_at__quarter
-            , subq_11.booking__paid_at__year
-            , subq_11.booking__paid_at__extract_year
-            , subq_11.booking__paid_at__extract_quarter
-            , subq_11.booking__paid_at__extract_month
-            , subq_11.booking__paid_at__extract_day
-            , subq_11.booking__paid_at__extract_dow
-            , subq_11.booking__paid_at__extract_doy
-            , subq_11.ds__day AS metric_time__day
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.ds__extract_year AS metric_time__extract_year
-            , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_11.ds__extract_month AS metric_time__extract_month
-            , subq_11.ds__extract_day AS metric_time__extract_day
-            , subq_11.ds__extract_dow AS metric_time__extract_dow
-            , subq_11.ds__extract_doy AS metric_time__extract_doy
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.user
-            , subq_11.booking__listing
-            , subq_11.booking__guest
-            , subq_11.booking__host
-            , subq_11.booking__user
-            , subq_11.is_instant
-            , subq_11.booking__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,84 +211,84 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
         SELECT
-          subq_17.window_start__day
-          , subq_17.window_end__day
-          , subq_17.listing
-          , subq_17.user__home_state_latest
+          subq_6.window_start__day
+          , subq_6.window_end__day
+          , subq_6.listing
+          , subq_6.user__home_state_latest
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.window_start__day AS window_start__day
-            , subq_14.window_start__week AS window_start__week
-            , subq_14.window_start__month AS window_start__month
-            , subq_14.window_start__quarter AS window_start__quarter
-            , subq_14.window_start__year AS window_start__year
-            , subq_14.window_start__extract_year AS window_start__extract_year
-            , subq_14.window_start__extract_quarter AS window_start__extract_quarter
-            , subq_14.window_start__extract_month AS window_start__extract_month
-            , subq_14.window_start__extract_day AS window_start__extract_day
-            , subq_14.window_start__extract_dow AS window_start__extract_dow
-            , subq_14.window_start__extract_doy AS window_start__extract_doy
-            , subq_14.window_end__day AS window_end__day
-            , subq_14.window_end__week AS window_end__week
-            , subq_14.window_end__month AS window_end__month
-            , subq_14.window_end__quarter AS window_end__quarter
-            , subq_14.window_end__year AS window_end__year
-            , subq_14.window_end__extract_year AS window_end__extract_year
-            , subq_14.window_end__extract_quarter AS window_end__extract_quarter
-            , subq_14.window_end__extract_month AS window_end__extract_month
-            , subq_14.window_end__extract_day AS window_end__extract_day
-            , subq_14.window_end__extract_dow AS window_end__extract_dow
-            , subq_14.window_end__extract_doy AS window_end__extract_doy
-            , subq_14.listing__window_start__day AS listing__window_start__day
-            , subq_14.listing__window_start__week AS listing__window_start__week
-            , subq_14.listing__window_start__month AS listing__window_start__month
-            , subq_14.listing__window_start__quarter AS listing__window_start__quarter
-            , subq_14.listing__window_start__year AS listing__window_start__year
-            , subq_14.listing__window_start__extract_year AS listing__window_start__extract_year
-            , subq_14.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
-            , subq_14.listing__window_start__extract_month AS listing__window_start__extract_month
-            , subq_14.listing__window_start__extract_day AS listing__window_start__extract_day
-            , subq_14.listing__window_start__extract_dow AS listing__window_start__extract_dow
-            , subq_14.listing__window_start__extract_doy AS listing__window_start__extract_doy
-            , subq_14.listing__window_end__day AS listing__window_end__day
-            , subq_14.listing__window_end__week AS listing__window_end__week
-            , subq_14.listing__window_end__month AS listing__window_end__month
-            , subq_14.listing__window_end__quarter AS listing__window_end__quarter
-            , subq_14.listing__window_end__year AS listing__window_end__year
-            , subq_14.listing__window_end__extract_year AS listing__window_end__extract_year
-            , subq_14.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
-            , subq_14.listing__window_end__extract_month AS listing__window_end__extract_month
-            , subq_14.listing__window_end__extract_day AS listing__window_end__extract_day
-            , subq_14.listing__window_end__extract_dow AS listing__window_end__extract_dow
-            , subq_14.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_16.ds__day AS user__ds__day
-            , subq_16.ds__week AS user__ds__week
-            , subq_16.ds__month AS user__ds__month
-            , subq_16.ds__quarter AS user__ds__quarter
-            , subq_16.ds__year AS user__ds__year
-            , subq_16.ds__extract_year AS user__ds__extract_year
-            , subq_16.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_16.ds__extract_month AS user__ds__extract_month
-            , subq_16.ds__extract_day AS user__ds__extract_day
-            , subq_16.ds__extract_dow AS user__ds__extract_dow
-            , subq_16.ds__extract_doy AS user__ds__extract_doy
-            , subq_14.listing AS listing
-            , subq_14.user AS user
-            , subq_14.listing__user AS listing__user
-            , subq_14.country AS country
-            , subq_14.is_lux AS is_lux
-            , subq_14.capacity AS capacity
-            , subq_14.listing__country AS listing__country
-            , subq_14.listing__is_lux AS listing__is_lux
-            , subq_14.listing__capacity AS listing__capacity
-            , subq_16.home_state_latest AS user__home_state_latest
+            subq_3.window_start__day AS window_start__day
+            , subq_3.window_start__week AS window_start__week
+            , subq_3.window_start__month AS window_start__month
+            , subq_3.window_start__quarter AS window_start__quarter
+            , subq_3.window_start__year AS window_start__year
+            , subq_3.window_start__extract_year AS window_start__extract_year
+            , subq_3.window_start__extract_quarter AS window_start__extract_quarter
+            , subq_3.window_start__extract_month AS window_start__extract_month
+            , subq_3.window_start__extract_day AS window_start__extract_day
+            , subq_3.window_start__extract_dow AS window_start__extract_dow
+            , subq_3.window_start__extract_doy AS window_start__extract_doy
+            , subq_3.window_end__day AS window_end__day
+            , subq_3.window_end__week AS window_end__week
+            , subq_3.window_end__month AS window_end__month
+            , subq_3.window_end__quarter AS window_end__quarter
+            , subq_3.window_end__year AS window_end__year
+            , subq_3.window_end__extract_year AS window_end__extract_year
+            , subq_3.window_end__extract_quarter AS window_end__extract_quarter
+            , subq_3.window_end__extract_month AS window_end__extract_month
+            , subq_3.window_end__extract_day AS window_end__extract_day
+            , subq_3.window_end__extract_dow AS window_end__extract_dow
+            , subq_3.window_end__extract_doy AS window_end__extract_doy
+            , subq_3.listing__window_start__day AS listing__window_start__day
+            , subq_3.listing__window_start__week AS listing__window_start__week
+            , subq_3.listing__window_start__month AS listing__window_start__month
+            , subq_3.listing__window_start__quarter AS listing__window_start__quarter
+            , subq_3.listing__window_start__year AS listing__window_start__year
+            , subq_3.listing__window_start__extract_year AS listing__window_start__extract_year
+            , subq_3.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+            , subq_3.listing__window_start__extract_month AS listing__window_start__extract_month
+            , subq_3.listing__window_start__extract_day AS listing__window_start__extract_day
+            , subq_3.listing__window_start__extract_dow AS listing__window_start__extract_dow
+            , subq_3.listing__window_start__extract_doy AS listing__window_start__extract_doy
+            , subq_3.listing__window_end__day AS listing__window_end__day
+            , subq_3.listing__window_end__week AS listing__window_end__week
+            , subq_3.listing__window_end__month AS listing__window_end__month
+            , subq_3.listing__window_end__quarter AS listing__window_end__quarter
+            , subq_3.listing__window_end__year AS listing__window_end__year
+            , subq_3.listing__window_end__extract_year AS listing__window_end__extract_year
+            , subq_3.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+            , subq_3.listing__window_end__extract_month AS listing__window_end__extract_month
+            , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
+            , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
+            , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.user AS user
+            , subq_3.listing__user AS listing__user
+            , subq_3.country AS country
+            , subq_3.is_lux AS is_lux
+            , subq_3.capacity AS capacity
+            , subq_3.listing__country AS listing__country
+            , subq_3.listing__is_lux AS listing__is_lux
+            , subq_3.listing__capacity AS listing__capacity
+            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT
@@ -346,7 +346,7 @@ FROM (
               , listings_src_26000.user_id AS user
               , listings_src_26000.user_id AS listing__user
             FROM ***************************.dim_listings listings_src_26000
-          ) subq_14
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'home_state_latest',
@@ -376,31 +376,31 @@ FROM (
             --   'user',
             -- ]
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.user__ds__day
-              , subq_15.user__ds__week
-              , subq_15.user__ds__month
-              , subq_15.user__ds__quarter
-              , subq_15.user__ds__year
-              , subq_15.user__ds__extract_year
-              , subq_15.user__ds__extract_quarter
-              , subq_15.user__ds__extract_month
-              , subq_15.user__ds__extract_day
-              , subq_15.user__ds__extract_dow
-              , subq_15.user__ds__extract_doy
-              , subq_15.user
-              , subq_15.home_state_latest
-              , subq_15.user__home_state_latest
+              subq_4.ds__day
+              , subq_4.ds__week
+              , subq_4.ds__month
+              , subq_4.ds__quarter
+              , subq_4.ds__year
+              , subq_4.ds__extract_year
+              , subq_4.ds__extract_quarter
+              , subq_4.ds__extract_month
+              , subq_4.ds__extract_day
+              , subq_4.ds__extract_dow
+              , subq_4.ds__extract_doy
+              , subq_4.user__ds__day
+              , subq_4.user__ds__week
+              , subq_4.user__ds__month
+              , subq_4.user__ds__quarter
+              , subq_4.user__ds__year
+              , subq_4.user__ds__extract_year
+              , subq_4.user__ds__extract_quarter
+              , subq_4.user__ds__extract_month
+              , subq_4.user__ds__extract_day
+              , subq_4.user__ds__extract_dow
+              , subq_4.user__ds__extract_doy
+              , subq_4.user
+              , subq_4.home_state_latest
+              , subq_4.user__home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -430,29 +430,29 @@ FROM (
                 , users_latest_src_26000.home_state_latest AS user__home_state_latest
                 , users_latest_src_26000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_26000
-            ) subq_15
-          ) subq_16
+            ) subq_4
+          ) subq_5
           ON
-            subq_14.user = subq_16.user
-        ) subq_17
-      ) subq_18
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_13.listing = subq_18.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_13.metric_time__day >= subq_18.window_start__day
+            subq_2.metric_time__day >= subq_7.window_start__day
           ) AND (
             (
-              subq_13.metric_time__day < subq_18.window_end__day
+              subq_2.metric_time__day < subq_7.window_end__day
             ) OR (
-              subq_18.window_end__day IS NULL
+              subq_7.window_end__day IS NULL
             )
           )
         )
-    ) subq_19
-  ) subq_20
+    ) subq_8
+  ) subq_9
   GROUP BY
     metric_time__day
     , listing__user__home_state_latest
-) subq_21
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_35.metric_time__day AS metric_time__day
-  , subq_40.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_35.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_35
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,18 +29,18 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_40
+) subq_18
 ON
   (
-    subq_35.listing = subq_40.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_35.metric_time__day >= subq_40.window_start__day
+      subq_13.metric_time__day >= subq_18.window_start__day
     ) AND (
       (
-        subq_35.metric_time__day < subq_40.window_end__day
+        subq_13.metric_time__day < subq_18.window_end__day
       ) OR (
-        subq_40.window_end__day IS NULL
+        subq_18.window_end__day IS NULL
       )
     )
   )

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , subq_13.listing__lux_listing__is_confirmed_lux
-  , subq_13.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__lux_listing__is_confirmed_lux
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-    , SUM(subq_12.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__lux_listing__is_confirmed_lux', 'metric_time__day']
     SELECT
-      subq_11.metric_time__day
-      , subq_11.listing__lux_listing__is_confirmed_lux
-      , subq_11.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__lux_listing__is_confirmed_lux
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_5.metric_time__day AS metric_time__day
-        , subq_10.lux_listing__window_start__day AS listing__lux_listing__window_start__day
-        , subq_10.lux_listing__window_end__day AS listing__lux_listing__window_end__day
-        , subq_5.listing AS listing
-        , subq_10.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-        , subq_5.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
+        , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.listing
-          , subq_4.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.ds__day AS metric_time__day
-            , subq_3.ds__week AS metric_time__week
-            , subq_3.ds__month AS metric_time__month
-            , subq_3.ds__quarter AS metric_time__quarter
-            , subq_3.ds__year AS metric_time__year
-            , subq_3.ds__extract_year AS metric_time__extract_year
-            , subq_3.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_3.ds__extract_month AS metric_time__extract_month
-            , subq_3.ds__extract_day AS metric_time__extract_day
-            , subq_3.ds__extract_dow AS metric_time__extract_dow
-            , subq_3.ds__extract_doy AS metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.user
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.booking__user
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,45 +211,45 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_3
-        ) subq_4
-      ) subq_5
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
         SELECT
-          subq_9.lux_listing__window_start__day
-          , subq_9.lux_listing__window_end__day
-          , subq_9.listing
-          , subq_9.lux_listing__is_confirmed_lux
+          subq_6.lux_listing__window_start__day
+          , subq_6.lux_listing__window_end__day
+          , subq_6.listing
+          , subq_6.lux_listing__is_confirmed_lux
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_8.window_start__day AS lux_listing__window_start__day
-            , subq_8.window_start__week AS lux_listing__window_start__week
-            , subq_8.window_start__month AS lux_listing__window_start__month
-            , subq_8.window_start__quarter AS lux_listing__window_start__quarter
-            , subq_8.window_start__year AS lux_listing__window_start__year
-            , subq_8.window_start__extract_year AS lux_listing__window_start__extract_year
-            , subq_8.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
-            , subq_8.window_start__extract_month AS lux_listing__window_start__extract_month
-            , subq_8.window_start__extract_day AS lux_listing__window_start__extract_day
-            , subq_8.window_start__extract_dow AS lux_listing__window_start__extract_dow
-            , subq_8.window_start__extract_doy AS lux_listing__window_start__extract_doy
-            , subq_8.window_end__day AS lux_listing__window_end__day
-            , subq_8.window_end__week AS lux_listing__window_end__week
-            , subq_8.window_end__month AS lux_listing__window_end__month
-            , subq_8.window_end__quarter AS lux_listing__window_end__quarter
-            , subq_8.window_end__year AS lux_listing__window_end__year
-            , subq_8.window_end__extract_year AS lux_listing__window_end__extract_year
-            , subq_8.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
-            , subq_8.window_end__extract_month AS lux_listing__window_end__extract_month
-            , subq_8.window_end__extract_day AS lux_listing__window_end__extract_day
-            , subq_8.window_end__extract_dow AS lux_listing__window_end__extract_dow
-            , subq_8.window_end__extract_doy AS lux_listing__window_end__extract_doy
-            , subq_6.listing AS listing
-            , subq_6.lux_listing AS lux_listing
-            , subq_6.listing__lux_listing AS listing__lux_listing
-            , subq_8.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            subq_5.window_start__day AS lux_listing__window_start__day
+            , subq_5.window_start__week AS lux_listing__window_start__week
+            , subq_5.window_start__month AS lux_listing__window_start__month
+            , subq_5.window_start__quarter AS lux_listing__window_start__quarter
+            , subq_5.window_start__year AS lux_listing__window_start__year
+            , subq_5.window_start__extract_year AS lux_listing__window_start__extract_year
+            , subq_5.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
+            , subq_5.window_start__extract_month AS lux_listing__window_start__extract_month
+            , subq_5.window_start__extract_day AS lux_listing__window_start__extract_day
+            , subq_5.window_start__extract_dow AS lux_listing__window_start__extract_dow
+            , subq_5.window_start__extract_doy AS lux_listing__window_start__extract_doy
+            , subq_5.window_end__day AS lux_listing__window_end__day
+            , subq_5.window_end__week AS lux_listing__window_end__week
+            , subq_5.window_end__month AS lux_listing__window_end__month
+            , subq_5.window_end__quarter AS lux_listing__window_end__quarter
+            , subq_5.window_end__year AS lux_listing__window_end__year
+            , subq_5.window_end__extract_year AS lux_listing__window_end__extract_year
+            , subq_5.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
+            , subq_5.window_end__extract_month AS lux_listing__window_end__extract_month
+            , subq_5.window_end__extract_day AS lux_listing__window_end__extract_day
+            , subq_5.window_end__extract_dow AS lux_listing__window_end__extract_dow
+            , subq_5.window_end__extract_doy AS lux_listing__window_end__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.lux_listing AS lux_listing
+            , subq_3.listing__lux_listing AS listing__lux_listing
+            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT
@@ -257,7 +257,7 @@ FROM (
               , lux_listing_mapping_src_26000.lux_listing_id AS lux_listing
               , lux_listing_mapping_src_26000.lux_listing_id AS listing__lux_listing
             FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_26000
-          ) subq_6
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'is_confirmed_lux',
@@ -309,53 +309,53 @@ FROM (
             --   'lux_listing',
             -- ]
             SELECT
-              subq_7.window_start__day
-              , subq_7.window_start__week
-              , subq_7.window_start__month
-              , subq_7.window_start__quarter
-              , subq_7.window_start__year
-              , subq_7.window_start__extract_year
-              , subq_7.window_start__extract_quarter
-              , subq_7.window_start__extract_month
-              , subq_7.window_start__extract_day
-              , subq_7.window_start__extract_dow
-              , subq_7.window_start__extract_doy
-              , subq_7.window_end__day
-              , subq_7.window_end__week
-              , subq_7.window_end__month
-              , subq_7.window_end__quarter
-              , subq_7.window_end__year
-              , subq_7.window_end__extract_year
-              , subq_7.window_end__extract_quarter
-              , subq_7.window_end__extract_month
-              , subq_7.window_end__extract_day
-              , subq_7.window_end__extract_dow
-              , subq_7.window_end__extract_doy
-              , subq_7.lux_listing__window_start__day
-              , subq_7.lux_listing__window_start__week
-              , subq_7.lux_listing__window_start__month
-              , subq_7.lux_listing__window_start__quarter
-              , subq_7.lux_listing__window_start__year
-              , subq_7.lux_listing__window_start__extract_year
-              , subq_7.lux_listing__window_start__extract_quarter
-              , subq_7.lux_listing__window_start__extract_month
-              , subq_7.lux_listing__window_start__extract_day
-              , subq_7.lux_listing__window_start__extract_dow
-              , subq_7.lux_listing__window_start__extract_doy
-              , subq_7.lux_listing__window_end__day
-              , subq_7.lux_listing__window_end__week
-              , subq_7.lux_listing__window_end__month
-              , subq_7.lux_listing__window_end__quarter
-              , subq_7.lux_listing__window_end__year
-              , subq_7.lux_listing__window_end__extract_year
-              , subq_7.lux_listing__window_end__extract_quarter
-              , subq_7.lux_listing__window_end__extract_month
-              , subq_7.lux_listing__window_end__extract_day
-              , subq_7.lux_listing__window_end__extract_dow
-              , subq_7.lux_listing__window_end__extract_doy
-              , subq_7.lux_listing
-              , subq_7.is_confirmed_lux
-              , subq_7.lux_listing__is_confirmed_lux
+              subq_4.window_start__day
+              , subq_4.window_start__week
+              , subq_4.window_start__month
+              , subq_4.window_start__quarter
+              , subq_4.window_start__year
+              , subq_4.window_start__extract_year
+              , subq_4.window_start__extract_quarter
+              , subq_4.window_start__extract_month
+              , subq_4.window_start__extract_day
+              , subq_4.window_start__extract_dow
+              , subq_4.window_start__extract_doy
+              , subq_4.window_end__day
+              , subq_4.window_end__week
+              , subq_4.window_end__month
+              , subq_4.window_end__quarter
+              , subq_4.window_end__year
+              , subq_4.window_end__extract_year
+              , subq_4.window_end__extract_quarter
+              , subq_4.window_end__extract_month
+              , subq_4.window_end__extract_day
+              , subq_4.window_end__extract_dow
+              , subq_4.window_end__extract_doy
+              , subq_4.lux_listing__window_start__day
+              , subq_4.lux_listing__window_start__week
+              , subq_4.lux_listing__window_start__month
+              , subq_4.lux_listing__window_start__quarter
+              , subq_4.lux_listing__window_start__year
+              , subq_4.lux_listing__window_start__extract_year
+              , subq_4.lux_listing__window_start__extract_quarter
+              , subq_4.lux_listing__window_start__extract_month
+              , subq_4.lux_listing__window_start__extract_day
+              , subq_4.lux_listing__window_start__extract_dow
+              , subq_4.lux_listing__window_start__extract_doy
+              , subq_4.lux_listing__window_end__day
+              , subq_4.lux_listing__window_end__week
+              , subq_4.lux_listing__window_end__month
+              , subq_4.lux_listing__window_end__quarter
+              , subq_4.lux_listing__window_end__year
+              , subq_4.lux_listing__window_end__extract_year
+              , subq_4.lux_listing__window_end__extract_quarter
+              , subq_4.lux_listing__window_end__extract_month
+              , subq_4.lux_listing__window_end__extract_day
+              , subq_4.lux_listing__window_end__extract_dow
+              , subq_4.lux_listing__window_end__extract_doy
+              , subq_4.lux_listing
+              , subq_4.is_confirmed_lux
+              , subq_4.lux_listing__is_confirmed_lux
             FROM (
               -- Read Elements From Semantic Model 'lux_listings'
               SELECT
@@ -407,29 +407,29 @@ FROM (
                 , lux_listings_src_26000.is_confirmed_lux AS lux_listing__is_confirmed_lux
                 , lux_listings_src_26000.lux_listing_id AS lux_listing
               FROM ***************************.dim_lux_listings lux_listings_src_26000
-            ) subq_7
-          ) subq_8
+            ) subq_4
+          ) subq_5
           ON
-            subq_6.lux_listing = subq_8.lux_listing
-        ) subq_9
-      ) subq_10
+            subq_3.lux_listing = subq_5.lux_listing
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_5.listing = subq_10.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_5.metric_time__day >= subq_10.lux_listing__window_start__day
+            subq_2.metric_time__day >= subq_7.lux_listing__window_start__day
           ) AND (
             (
-              subq_5.metric_time__day < subq_10.lux_listing__window_end__day
+              subq_2.metric_time__day < subq_7.lux_listing__window_end__day
             ) OR (
-              subq_10.lux_listing__window_end__day IS NULL
+              subq_7.lux_listing__window_end__day IS NULL
             )
           )
         )
-    ) subq_11
-  ) subq_12
+    ) subq_8
+  ) subq_9
   GROUP BY
     metric_time__day
     , listing__lux_listing__is_confirmed_lux
-) subq_13
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time__day AS metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_19.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_19
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,18 +29,18 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_24
+) subq_18
 ON
   (
-    subq_19.listing = subq_24.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
+      subq_13.metric_time__day >= subq_18.lux_listing__window_start__day
     ) AND (
       (
-        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
+        subq_13.metric_time__day < subq_18.lux_listing__window_end__day
       ) OR (
-        subq_24.lux_listing__window_end__day IS NULL
+        subq_18.lux_listing__window_end__day IS NULL
       )
     )
   )

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0.sql
@@ -1,93 +1,93 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.account_id__customer_id__customer_name
-  , subq_17.txn_count
+  subq_12.account_id__customer_id__customer_name
+  , subq_12.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.account_id__customer_id__customer_name
-    , SUM(subq_16.txn_count) AS txn_count
+    subq_11.account_id__customer_id__customer_name
+    , SUM(subq_11.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_15.account_id__customer_id__customer_name
-      , subq_15.txn_count
+      subq_10.account_id__customer_id__customer_name
+      , subq_10.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_7.ds_partitioned__day AS ds_partitioned__day
-        , subq_14.ds_partitioned__day AS account_id__ds_partitioned__day
-        , subq_7.account_id AS account_id
-        , subq_14.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_7.txn_count AS txn_count
+        subq_2.ds_partitioned__day AS ds_partitioned__day
+        , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.account_id AS account_id
+        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_6.ds_partitioned__day
-          , subq_6.account_id
-          , subq_6.txn_count
+          subq_1.ds_partitioned__day
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds_partitioned__day
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.ds_partitioned__extract_year
-            , subq_5.ds_partitioned__extract_quarter
-            , subq_5.ds_partitioned__extract_month
-            , subq_5.ds_partitioned__extract_day
-            , subq_5.ds_partitioned__extract_dow
-            , subq_5.ds_partitioned__extract_doy
-            , subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.account_id__ds_partitioned__day
-            , subq_5.account_id__ds_partitioned__week
-            , subq_5.account_id__ds_partitioned__month
-            , subq_5.account_id__ds_partitioned__quarter
-            , subq_5.account_id__ds_partitioned__year
-            , subq_5.account_id__ds_partitioned__extract_year
-            , subq_5.account_id__ds_partitioned__extract_quarter
-            , subq_5.account_id__ds_partitioned__extract_month
-            , subq_5.account_id__ds_partitioned__extract_day
-            , subq_5.account_id__ds_partitioned__extract_dow
-            , subq_5.account_id__ds_partitioned__extract_doy
-            , subq_5.account_id__ds__day
-            , subq_5.account_id__ds__week
-            , subq_5.account_id__ds__month
-            , subq_5.account_id__ds__quarter
-            , subq_5.account_id__ds__year
-            , subq_5.account_id__ds__extract_year
-            , subq_5.account_id__ds__extract_quarter
-            , subq_5.account_id__ds__extract_month
-            , subq_5.account_id__ds__extract_day
-            , subq_5.account_id__ds__extract_dow
-            , subq_5.account_id__ds__extract_doy
-            , subq_5.ds__day AS metric_time__day
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.ds__extract_year AS metric_time__extract_year
-            , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_5.ds__extract_month AS metric_time__extract_month
-            , subq_5.ds__extract_day AS metric_time__extract_day
-            , subq_5.ds__extract_dow AS metric_time__extract_dow
-            , subq_5.ds__extract_doy AS metric_time__extract_doy
-            , subq_5.account_id
-            , subq_5.account_month
-            , subq_5.account_id__account_month
-            , subq_5.txn_count
+            subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.account_id__ds_partitioned__day
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds_partitioned__extract_year
+            , subq_0.account_id__ds_partitioned__extract_quarter
+            , subq_0.account_id__ds_partitioned__extract_month
+            , subq_0.account_id__ds_partitioned__extract_day
+            , subq_0.account_id__ds_partitioned__extract_dow
+            , subq_0.account_id__ds_partitioned__extract_doy
+            , subq_0.account_id__ds__day
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.account_id__ds__extract_year
+            , subq_0.account_id__ds__extract_quarter
+            , subq_0.account_id__ds__extract_month
+            , subq_0.account_id__ds__extract_day
+            , subq_0.account_id__ds__extract_dow
+            , subq_0.account_id__ds__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
@@ -140,151 +140,151 @@ FROM (
               , account_month_txns_src_22000.account_month AS account_id__account_month
               , account_month_txns_src_22000.account_id
             FROM ***************************.account_month_txns account_month_txns_src_22000
-          ) subq_5
-        ) subq_6
-      ) subq_7
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_13.ds_partitioned__day
-          , subq_13.account_id
-          , subq_13.customer_id__customer_name
+          subq_8.ds_partitioned__day
+          , subq_8.account_id
+          , subq_8.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_9.ds_partitioned__day AS ds_partitioned__day
-            , subq_9.ds_partitioned__week AS ds_partitioned__week
-            , subq_9.ds_partitioned__month AS ds_partitioned__month
-            , subq_9.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_9.ds_partitioned__year AS ds_partitioned__year
-            , subq_9.ds_partitioned__extract_year AS ds_partitioned__extract_year
-            , subq_9.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-            , subq_9.ds_partitioned__extract_month AS ds_partitioned__extract_month
-            , subq_9.ds_partitioned__extract_day AS ds_partitioned__extract_day
-            , subq_9.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-            , subq_9.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-            , subq_9.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-            , subq_9.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_9.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_9.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_9.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_9.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-            , subq_9.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-            , subq_9.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-            , subq_9.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-            , subq_9.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-            , subq_9.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-            , subq_9.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-            , subq_9.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-            , subq_9.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-            , subq_9.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-            , subq_9.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-            , subq_9.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-            , subq_9.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-            , subq_9.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-            , subq_9.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-            , subq_9.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-            , subq_9.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
-            , subq_9.metric_time__month AS metric_time__month
-            , subq_9.metric_time__quarter AS metric_time__quarter
-            , subq_9.metric_time__year AS metric_time__year
-            , subq_9.metric_time__extract_year AS metric_time__extract_year
-            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_9.metric_time__extract_month AS metric_time__extract_month
-            , subq_9.metric_time__extract_day AS metric_time__extract_day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_12.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_12.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_12.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_12.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_12.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_12.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_12.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_12.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_12.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_12.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_12.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_12.metric_time__day AS customer_id__metric_time__day
-            , subq_12.metric_time__week AS customer_id__metric_time__week
-            , subq_12.metric_time__month AS customer_id__metric_time__month
-            , subq_12.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_12.metric_time__year AS customer_id__metric_time__year
-            , subq_12.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_12.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_12.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_12.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_12.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_12.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-            , subq_9.account_id AS account_id
-            , subq_9.customer_id AS customer_id
-            , subq_9.account_id__customer_id AS account_id__customer_id
-            , subq_9.bridge_account__account_id AS bridge_account__account_id
-            , subq_9.bridge_account__customer_id AS bridge_account__customer_id
-            , subq_9.extra_dim AS extra_dim
-            , subq_9.account_id__extra_dim AS account_id__extra_dim
-            , subq_9.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_12.customer_name AS customer_id__customer_name
-            , subq_12.customer_atomic_weight AS customer_id__customer_atomic_weight
-            , subq_9.account_customer_combos AS account_customer_combos
+            subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_4.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+            , subq_4.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+            , subq_4.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+            , subq_4.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+            , subq_4.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+            , subq_4.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+            , subq_4.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+            , subq_4.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+            , subq_4.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+            , subq_4.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+            , subq_4.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+            , subq_4.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+            , subq_4.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+            , subq_4.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+            , subq_4.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+            , subq_4.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+            , subq_4.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.account_id AS account_id
+            , subq_4.customer_id AS customer_id
+            , subq_4.account_id__customer_id AS account_id__customer_id
+            , subq_4.bridge_account__account_id AS bridge_account__account_id
+            , subq_4.bridge_account__customer_id AS bridge_account__customer_id
+            , subq_4.extra_dim AS extra_dim
+            , subq_4.account_id__extra_dim AS account_id__extra_dim
+            , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
+            , subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'
             SELECT
-              subq_8.ds_partitioned__day
-              , subq_8.ds_partitioned__week
-              , subq_8.ds_partitioned__month
-              , subq_8.ds_partitioned__quarter
-              , subq_8.ds_partitioned__year
-              , subq_8.ds_partitioned__extract_year
-              , subq_8.ds_partitioned__extract_quarter
-              , subq_8.ds_partitioned__extract_month
-              , subq_8.ds_partitioned__extract_day
-              , subq_8.ds_partitioned__extract_dow
-              , subq_8.ds_partitioned__extract_doy
-              , subq_8.account_id__ds_partitioned__day
-              , subq_8.account_id__ds_partitioned__week
-              , subq_8.account_id__ds_partitioned__month
-              , subq_8.account_id__ds_partitioned__quarter
-              , subq_8.account_id__ds_partitioned__year
-              , subq_8.account_id__ds_partitioned__extract_year
-              , subq_8.account_id__ds_partitioned__extract_quarter
-              , subq_8.account_id__ds_partitioned__extract_month
-              , subq_8.account_id__ds_partitioned__extract_day
-              , subq_8.account_id__ds_partitioned__extract_dow
-              , subq_8.account_id__ds_partitioned__extract_doy
-              , subq_8.bridge_account__ds_partitioned__day
-              , subq_8.bridge_account__ds_partitioned__week
-              , subq_8.bridge_account__ds_partitioned__month
-              , subq_8.bridge_account__ds_partitioned__quarter
-              , subq_8.bridge_account__ds_partitioned__year
-              , subq_8.bridge_account__ds_partitioned__extract_year
-              , subq_8.bridge_account__ds_partitioned__extract_quarter
-              , subq_8.bridge_account__ds_partitioned__extract_month
-              , subq_8.bridge_account__ds_partitioned__extract_day
-              , subq_8.bridge_account__ds_partitioned__extract_dow
-              , subq_8.bridge_account__ds_partitioned__extract_doy
-              , subq_8.ds_partitioned__day AS metric_time__day
-              , subq_8.ds_partitioned__week AS metric_time__week
-              , subq_8.ds_partitioned__month AS metric_time__month
-              , subq_8.ds_partitioned__quarter AS metric_time__quarter
-              , subq_8.ds_partitioned__year AS metric_time__year
-              , subq_8.ds_partitioned__extract_year AS metric_time__extract_year
-              , subq_8.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-              , subq_8.ds_partitioned__extract_month AS metric_time__extract_month
-              , subq_8.ds_partitioned__extract_day AS metric_time__extract_day
-              , subq_8.ds_partitioned__extract_dow AS metric_time__extract_dow
-              , subq_8.ds_partitioned__extract_doy AS metric_time__extract_doy
-              , subq_8.account_id
-              , subq_8.customer_id
-              , subq_8.account_id__customer_id
-              , subq_8.bridge_account__account_id
-              , subq_8.bridge_account__customer_id
-              , subq_8.extra_dim
-              , subq_8.account_id__extra_dim
-              , subq_8.bridge_account__extra_dim
-              , subq_8.account_customer_combos
+              subq_3.ds_partitioned__day
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.ds_partitioned__extract_year
+              , subq_3.ds_partitioned__extract_quarter
+              , subq_3.ds_partitioned__extract_month
+              , subq_3.ds_partitioned__extract_day
+              , subq_3.ds_partitioned__extract_dow
+              , subq_3.ds_partitioned__extract_doy
+              , subq_3.account_id__ds_partitioned__day
+              , subq_3.account_id__ds_partitioned__week
+              , subq_3.account_id__ds_partitioned__month
+              , subq_3.account_id__ds_partitioned__quarter
+              , subq_3.account_id__ds_partitioned__year
+              , subq_3.account_id__ds_partitioned__extract_year
+              , subq_3.account_id__ds_partitioned__extract_quarter
+              , subq_3.account_id__ds_partitioned__extract_month
+              , subq_3.account_id__ds_partitioned__extract_day
+              , subq_3.account_id__ds_partitioned__extract_dow
+              , subq_3.account_id__ds_partitioned__extract_doy
+              , subq_3.bridge_account__ds_partitioned__day
+              , subq_3.bridge_account__ds_partitioned__week
+              , subq_3.bridge_account__ds_partitioned__month
+              , subq_3.bridge_account__ds_partitioned__quarter
+              , subq_3.bridge_account__ds_partitioned__year
+              , subq_3.bridge_account__ds_partitioned__extract_year
+              , subq_3.bridge_account__ds_partitioned__extract_quarter
+              , subq_3.bridge_account__ds_partitioned__extract_month
+              , subq_3.bridge_account__ds_partitioned__extract_day
+              , subq_3.bridge_account__ds_partitioned__extract_dow
+              , subq_3.bridge_account__ds_partitioned__extract_doy
+              , subq_3.ds_partitioned__day AS metric_time__day
+              , subq_3.ds_partitioned__week AS metric_time__week
+              , subq_3.ds_partitioned__month AS metric_time__month
+              , subq_3.ds_partitioned__quarter AS metric_time__quarter
+              , subq_3.ds_partitioned__year AS metric_time__year
+              , subq_3.ds_partitioned__extract_year AS metric_time__extract_year
+              , subq_3.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+              , subq_3.ds_partitioned__extract_month AS metric_time__extract_month
+              , subq_3.ds_partitioned__extract_day AS metric_time__extract_day
+              , subq_3.ds_partitioned__extract_dow AS metric_time__extract_dow
+              , subq_3.ds_partitioned__extract_doy AS metric_time__extract_doy
+              , subq_3.account_id
+              , subq_3.customer_id
+              , subq_3.account_id__customer_id
+              , subq_3.bridge_account__account_id
+              , subq_3.bridge_account__customer_id
+              , subq_3.extra_dim
+              , subq_3.account_id__extra_dim
+              , subq_3.bridge_account__extra_dim
+              , subq_3.account_customer_combos
             FROM (
               -- Read Elements From Semantic Model 'bridge_table'
               SELECT
@@ -331,8 +331,8 @@ FROM (
                 , bridge_table_src_22000.account_id AS bridge_account__account_id
                 , bridge_table_src_22000.customer_id AS bridge_account__customer_id
               FROM ***************************.bridge_table bridge_table_src_22000
-            ) subq_8
-          ) subq_9
+            ) subq_3
+          ) subq_4
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'customer_name',
@@ -375,86 +375,86 @@ FROM (
             --   'customer_id',
             -- ]
             SELECT
-              subq_11.ds_partitioned__day
-              , subq_11.ds_partitioned__week
-              , subq_11.ds_partitioned__month
-              , subq_11.ds_partitioned__quarter
-              , subq_11.ds_partitioned__year
-              , subq_11.ds_partitioned__extract_year
-              , subq_11.ds_partitioned__extract_quarter
-              , subq_11.ds_partitioned__extract_month
-              , subq_11.ds_partitioned__extract_day
-              , subq_11.ds_partitioned__extract_dow
-              , subq_11.ds_partitioned__extract_doy
-              , subq_11.customer_id__ds_partitioned__day
-              , subq_11.customer_id__ds_partitioned__week
-              , subq_11.customer_id__ds_partitioned__month
-              , subq_11.customer_id__ds_partitioned__quarter
-              , subq_11.customer_id__ds_partitioned__year
-              , subq_11.customer_id__ds_partitioned__extract_year
-              , subq_11.customer_id__ds_partitioned__extract_quarter
-              , subq_11.customer_id__ds_partitioned__extract_month
-              , subq_11.customer_id__ds_partitioned__extract_day
-              , subq_11.customer_id__ds_partitioned__extract_dow
-              , subq_11.customer_id__ds_partitioned__extract_doy
-              , subq_11.metric_time__day
-              , subq_11.metric_time__week
-              , subq_11.metric_time__month
-              , subq_11.metric_time__quarter
-              , subq_11.metric_time__year
-              , subq_11.metric_time__extract_year
-              , subq_11.metric_time__extract_quarter
-              , subq_11.metric_time__extract_month
-              , subq_11.metric_time__extract_day
-              , subq_11.metric_time__extract_dow
-              , subq_11.metric_time__extract_doy
-              , subq_11.customer_id
-              , subq_11.customer_name
-              , subq_11.customer_atomic_weight
-              , subq_11.customer_id__customer_name
-              , subq_11.customer_id__customer_atomic_weight
+              subq_6.ds_partitioned__day
+              , subq_6.ds_partitioned__week
+              , subq_6.ds_partitioned__month
+              , subq_6.ds_partitioned__quarter
+              , subq_6.ds_partitioned__year
+              , subq_6.ds_partitioned__extract_year
+              , subq_6.ds_partitioned__extract_quarter
+              , subq_6.ds_partitioned__extract_month
+              , subq_6.ds_partitioned__extract_day
+              , subq_6.ds_partitioned__extract_dow
+              , subq_6.ds_partitioned__extract_doy
+              , subq_6.customer_id__ds_partitioned__day
+              , subq_6.customer_id__ds_partitioned__week
+              , subq_6.customer_id__ds_partitioned__month
+              , subq_6.customer_id__ds_partitioned__quarter
+              , subq_6.customer_id__ds_partitioned__year
+              , subq_6.customer_id__ds_partitioned__extract_year
+              , subq_6.customer_id__ds_partitioned__extract_quarter
+              , subq_6.customer_id__ds_partitioned__extract_month
+              , subq_6.customer_id__ds_partitioned__extract_day
+              , subq_6.customer_id__ds_partitioned__extract_dow
+              , subq_6.customer_id__ds_partitioned__extract_doy
+              , subq_6.metric_time__day
+              , subq_6.metric_time__week
+              , subq_6.metric_time__month
+              , subq_6.metric_time__quarter
+              , subq_6.metric_time__year
+              , subq_6.metric_time__extract_year
+              , subq_6.metric_time__extract_quarter
+              , subq_6.metric_time__extract_month
+              , subq_6.metric_time__extract_day
+              , subq_6.metric_time__extract_dow
+              , subq_6.metric_time__extract_doy
+              , subq_6.customer_id
+              , subq_6.customer_name
+              , subq_6.customer_atomic_weight
+              , subq_6.customer_id__customer_name
+              , subq_6.customer_id__customer_atomic_weight
             FROM (
               -- Metric Time Dimension 'ds_partitioned'
               SELECT
-                subq_10.ds_partitioned__day
-                , subq_10.ds_partitioned__week
-                , subq_10.ds_partitioned__month
-                , subq_10.ds_partitioned__quarter
-                , subq_10.ds_partitioned__year
-                , subq_10.ds_partitioned__extract_year
-                , subq_10.ds_partitioned__extract_quarter
-                , subq_10.ds_partitioned__extract_month
-                , subq_10.ds_partitioned__extract_day
-                , subq_10.ds_partitioned__extract_dow
-                , subq_10.ds_partitioned__extract_doy
-                , subq_10.customer_id__ds_partitioned__day
-                , subq_10.customer_id__ds_partitioned__week
-                , subq_10.customer_id__ds_partitioned__month
-                , subq_10.customer_id__ds_partitioned__quarter
-                , subq_10.customer_id__ds_partitioned__year
-                , subq_10.customer_id__ds_partitioned__extract_year
-                , subq_10.customer_id__ds_partitioned__extract_quarter
-                , subq_10.customer_id__ds_partitioned__extract_month
-                , subq_10.customer_id__ds_partitioned__extract_day
-                , subq_10.customer_id__ds_partitioned__extract_dow
-                , subq_10.customer_id__ds_partitioned__extract_doy
-                , subq_10.ds_partitioned__day AS metric_time__day
-                , subq_10.ds_partitioned__week AS metric_time__week
-                , subq_10.ds_partitioned__month AS metric_time__month
-                , subq_10.ds_partitioned__quarter AS metric_time__quarter
-                , subq_10.ds_partitioned__year AS metric_time__year
-                , subq_10.ds_partitioned__extract_year AS metric_time__extract_year
-                , subq_10.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                , subq_10.ds_partitioned__extract_month AS metric_time__extract_month
-                , subq_10.ds_partitioned__extract_day AS metric_time__extract_day
-                , subq_10.ds_partitioned__extract_dow AS metric_time__extract_dow
-                , subq_10.ds_partitioned__extract_doy AS metric_time__extract_doy
-                , subq_10.customer_id
-                , subq_10.customer_name
-                , subq_10.customer_atomic_weight
-                , subq_10.customer_id__customer_name
-                , subq_10.customer_id__customer_atomic_weight
-                , subq_10.customers
+                subq_5.ds_partitioned__day
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.ds_partitioned__extract_year
+                , subq_5.ds_partitioned__extract_quarter
+                , subq_5.ds_partitioned__extract_month
+                , subq_5.ds_partitioned__extract_day
+                , subq_5.ds_partitioned__extract_dow
+                , subq_5.ds_partitioned__extract_doy
+                , subq_5.customer_id__ds_partitioned__day
+                , subq_5.customer_id__ds_partitioned__week
+                , subq_5.customer_id__ds_partitioned__month
+                , subq_5.customer_id__ds_partitioned__quarter
+                , subq_5.customer_id__ds_partitioned__year
+                , subq_5.customer_id__ds_partitioned__extract_year
+                , subq_5.customer_id__ds_partitioned__extract_quarter
+                , subq_5.customer_id__ds_partitioned__extract_month
+                , subq_5.customer_id__ds_partitioned__extract_day
+                , subq_5.customer_id__ds_partitioned__extract_dow
+                , subq_5.customer_id__ds_partitioned__extract_doy
+                , subq_5.ds_partitioned__day AS metric_time__day
+                , subq_5.ds_partitioned__week AS metric_time__week
+                , subq_5.ds_partitioned__month AS metric_time__month
+                , subq_5.ds_partitioned__quarter AS metric_time__quarter
+                , subq_5.ds_partitioned__year AS metric_time__year
+                , subq_5.ds_partitioned__extract_year AS metric_time__extract_year
+                , subq_5.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                , subq_5.ds_partitioned__extract_month AS metric_time__extract_month
+                , subq_5.ds_partitioned__extract_day AS metric_time__extract_day
+                , subq_5.ds_partitioned__extract_dow AS metric_time__extract_dow
+                , subq_5.ds_partitioned__extract_doy AS metric_time__extract_doy
+                , subq_5.customer_id
+                , subq_5.customer_name
+                , subq_5.customer_atomic_weight
+                , subq_5.customer_id__customer_name
+                , subq_5.customer_id__customer_atomic_weight
+                , subq_5.customers
               FROM (
                 -- Read Elements From Semantic Model 'customer_table'
                 SELECT
@@ -487,25 +487,25 @@ FROM (
                   , EXTRACT(dayofyear FROM customer_table_src_22000.ds_partitioned) AS customer_id__ds_partitioned__extract_doy
                   , customer_table_src_22000.customer_id
                 FROM ***************************.customer_table customer_table_src_22000
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_5
+            ) subq_6
+          ) subq_7
           ON
             (
-              subq_9.customer_id = subq_12.customer_id
+              subq_4.customer_id = subq_7.customer_id
             ) AND (
-              subq_9.ds_partitioned__day = subq_12.ds_partitioned__day
+              subq_4.ds_partitioned__day = subq_7.ds_partitioned__day
             )
-        ) subq_13
-      ) subq_14
+        ) subq_8
+      ) subq_9
       ON
         (
-          subq_7.account_id = subq_14.account_id
+          subq_2.account_id = subq_9.account_id
         ) AND (
-          subq_7.ds_partitioned__day = subq_14.ds_partitioned__day
+          subq_2.ds_partitioned__day = subq_9.ds_partitioned__day
         )
-    ) subq_15
-  ) subq_16
+    ) subq_10
+  ) subq_11
   GROUP BY
     account_id__customer_id__customer_name
-) subq_17
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_22.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATETIME_TRUNC(bridge_table_src_22000.ds_partitioned, day) = DATETIME_TRUNC(customer_table_src_22000.ds_partitioned, day)
     )
-) subq_32
+) subq_22
 ON
   (
-    account_month_txns_src_22000.account_id = subq_32.account_id
+    account_month_txns_src_22000.account_id = subq_22.account_id
   ) AND (
-    DATETIME_TRUNC(account_month_txns_src_22000.ds_partitioned, day) = subq_32.ds_partitioned__day
+    DATETIME_TRUNC(account_month_txns_src_22000.ds_partitioned, day) = subq_22.ds_partitioned__day
   )
 GROUP BY
   account_id__customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,221 +1,221 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_9.bookings) AS bookings
-  , MAX(subq_15.listings) AS listings
+  MAX(subq_5.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.bookings
+    subq_4.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_7.bookings) AS bookings
+      SUM(subq_3.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings',]
       SELECT
-        subq_6.bookings
+        subq_2.bookings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_5.ds__day
-          , subq_5.ds__week
-          , subq_5.ds__month
-          , subq_5.ds__quarter
-          , subq_5.ds__year
-          , subq_5.ds__extract_year
-          , subq_5.ds__extract_quarter
-          , subq_5.ds__extract_month
-          , subq_5.ds__extract_day
-          , subq_5.ds__extract_dow
-          , subq_5.ds__extract_doy
-          , subq_5.ds_partitioned__day
-          , subq_5.ds_partitioned__week
-          , subq_5.ds_partitioned__month
-          , subq_5.ds_partitioned__quarter
-          , subq_5.ds_partitioned__year
-          , subq_5.ds_partitioned__extract_year
-          , subq_5.ds_partitioned__extract_quarter
-          , subq_5.ds_partitioned__extract_month
-          , subq_5.ds_partitioned__extract_day
-          , subq_5.ds_partitioned__extract_dow
-          , subq_5.ds_partitioned__extract_doy
-          , subq_5.paid_at__day
-          , subq_5.paid_at__week
-          , subq_5.paid_at__month
-          , subq_5.paid_at__quarter
-          , subq_5.paid_at__year
-          , subq_5.paid_at__extract_year
-          , subq_5.paid_at__extract_quarter
-          , subq_5.paid_at__extract_month
-          , subq_5.paid_at__extract_day
-          , subq_5.paid_at__extract_dow
-          , subq_5.paid_at__extract_doy
-          , subq_5.booking__ds__day
-          , subq_5.booking__ds__week
-          , subq_5.booking__ds__month
-          , subq_5.booking__ds__quarter
-          , subq_5.booking__ds__year
-          , subq_5.booking__ds__extract_year
-          , subq_5.booking__ds__extract_quarter
-          , subq_5.booking__ds__extract_month
-          , subq_5.booking__ds__extract_day
-          , subq_5.booking__ds__extract_dow
-          , subq_5.booking__ds__extract_doy
-          , subq_5.booking__ds_partitioned__day
-          , subq_5.booking__ds_partitioned__week
-          , subq_5.booking__ds_partitioned__month
-          , subq_5.booking__ds_partitioned__quarter
-          , subq_5.booking__ds_partitioned__year
-          , subq_5.booking__ds_partitioned__extract_year
-          , subq_5.booking__ds_partitioned__extract_quarter
-          , subq_5.booking__ds_partitioned__extract_month
-          , subq_5.booking__ds_partitioned__extract_day
-          , subq_5.booking__ds_partitioned__extract_dow
-          , subq_5.booking__ds_partitioned__extract_doy
-          , subq_5.booking__paid_at__day
-          , subq_5.booking__paid_at__week
-          , subq_5.booking__paid_at__month
-          , subq_5.booking__paid_at__quarter
-          , subq_5.booking__paid_at__year
-          , subq_5.booking__paid_at__extract_year
-          , subq_5.booking__paid_at__extract_quarter
-          , subq_5.booking__paid_at__extract_month
-          , subq_5.booking__paid_at__extract_day
-          , subq_5.booking__paid_at__extract_dow
-          , subq_5.booking__paid_at__extract_doy
-          , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
-          , subq_5.listing
-          , subq_5.guest
-          , subq_5.host
-          , subq_5.booking__listing
-          , subq_5.booking__guest
-          , subq_5.booking__host
-          , subq_5.is_instant
-          , subq_5.booking__is_instant
-          , subq_5.bookings
-          , subq_5.instant_bookings
-          , subq_5.booking_value
-          , subq_5.max_booking_value
-          , subq_5.min_booking_value
-          , subq_5.bookers
-          , subq_5.average_booking_value
-          , subq_5.referred_bookings
-          , subq_5.median_booking_value
-          , subq_5.booking_value_p99
-          , subq_5.discrete_booking_value_p99
-          , subq_5.approximate_continuous_booking_value_p99
-          , subq_5.approximate_discrete_booking_value_p99
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds_partitioned__day
+          , subq_1.ds_partitioned__week
+          , subq_1.ds_partitioned__month
+          , subq_1.ds_partitioned__quarter
+          , subq_1.ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy
+          , subq_1.paid_at__day
+          , subq_1.paid_at__week
+          , subq_1.paid_at__month
+          , subq_1.paid_at__quarter
+          , subq_1.paid_at__year
+          , subq_1.paid_at__extract_year
+          , subq_1.paid_at__extract_quarter
+          , subq_1.paid_at__extract_month
+          , subq_1.paid_at__extract_day
+          , subq_1.paid_at__extract_dow
+          , subq_1.paid_at__extract_doy
+          , subq_1.booking__ds__day
+          , subq_1.booking__ds__week
+          , subq_1.booking__ds__month
+          , subq_1.booking__ds__quarter
+          , subq_1.booking__ds__year
+          , subq_1.booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month
+          , subq_1.booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day
+          , subq_1.booking__paid_at__week
+          , subq_1.booking__paid_at__month
+          , subq_1.booking__paid_at__quarter
+          , subq_1.booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy
+          , subq_1.metric_time__day
+          , subq_1.metric_time__week
+          , subq_1.metric_time__month
+          , subq_1.metric_time__quarter
+          , subq_1.metric_time__year
+          , subq_1.metric_time__extract_year
+          , subq_1.metric_time__extract_quarter
+          , subq_1.metric_time__extract_month
+          , subq_1.metric_time__extract_day
+          , subq_1.metric_time__extract_dow
+          , subq_1.metric_time__extract_doy
+          , subq_1.listing
+          , subq_1.guest
+          , subq_1.host
+          , subq_1.booking__listing
+          , subq_1.booking__guest
+          , subq_1.booking__host
+          , subq_1.is_instant
+          , subq_1.booking__is_instant
+          , subq_1.bookings
+          , subq_1.instant_bookings
+          , subq_1.booking_value
+          , subq_1.max_booking_value
+          , subq_1.min_booking_value
+          , subq_1.bookers
+          , subq_1.average_booking_value
+          , subq_1.referred_bookings
+          , subq_1.median_booking_value
+          , subq_1.booking_value_p99
+          , subq_1.discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds__day
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds__extract_year
-            , subq_4.ds__extract_quarter
-            , subq_4.ds__extract_month
-            , subq_4.ds__extract_day
-            , subq_4.ds__extract_dow
-            , subq_4.ds__extract_doy
-            , subq_4.ds_partitioned__day
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.ds_partitioned__extract_year
-            , subq_4.ds_partitioned__extract_quarter
-            , subq_4.ds_partitioned__extract_month
-            , subq_4.ds_partitioned__extract_day
-            , subq_4.ds_partitioned__extract_dow
-            , subq_4.ds_partitioned__extract_doy
-            , subq_4.paid_at__day
-            , subq_4.paid_at__week
-            , subq_4.paid_at__month
-            , subq_4.paid_at__quarter
-            , subq_4.paid_at__year
-            , subq_4.paid_at__extract_year
-            , subq_4.paid_at__extract_quarter
-            , subq_4.paid_at__extract_month
-            , subq_4.paid_at__extract_day
-            , subq_4.paid_at__extract_dow
-            , subq_4.paid_at__extract_doy
-            , subq_4.booking__ds__day
-            , subq_4.booking__ds__week
-            , subq_4.booking__ds__month
-            , subq_4.booking__ds__quarter
-            , subq_4.booking__ds__year
-            , subq_4.booking__ds__extract_year
-            , subq_4.booking__ds__extract_quarter
-            , subq_4.booking__ds__extract_month
-            , subq_4.booking__ds__extract_day
-            , subq_4.booking__ds__extract_dow
-            , subq_4.booking__ds__extract_doy
-            , subq_4.booking__ds_partitioned__day
-            , subq_4.booking__ds_partitioned__week
-            , subq_4.booking__ds_partitioned__month
-            , subq_4.booking__ds_partitioned__quarter
-            , subq_4.booking__ds_partitioned__year
-            , subq_4.booking__ds_partitioned__extract_year
-            , subq_4.booking__ds_partitioned__extract_quarter
-            , subq_4.booking__ds_partitioned__extract_month
-            , subq_4.booking__ds_partitioned__extract_day
-            , subq_4.booking__ds_partitioned__extract_dow
-            , subq_4.booking__ds_partitioned__extract_doy
-            , subq_4.booking__paid_at__day
-            , subq_4.booking__paid_at__week
-            , subq_4.booking__paid_at__month
-            , subq_4.booking__paid_at__quarter
-            , subq_4.booking__paid_at__year
-            , subq_4.booking__paid_at__extract_year
-            , subq_4.booking__paid_at__extract_quarter
-            , subq_4.booking__paid_at__extract_month
-            , subq_4.booking__paid_at__extract_day
-            , subq_4.booking__paid_at__extract_dow
-            , subq_4.booking__paid_at__extract_doy
-            , subq_4.ds__day AS metric_time__day
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.ds__extract_year AS metric_time__extract_year
-            , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_4.ds__extract_month AS metric_time__extract_month
-            , subq_4.ds__extract_day AS metric_time__extract_day
-            , subq_4.ds__extract_dow AS metric_time__extract_dow
-            , subq_4.ds__extract_doy AS metric_time__extract_doy
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.booking__listing
-            , subq_4.booking__guest
-            , subq_4.booking__host
-            , subq_4.is_instant
-            , subq_4.booking__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
-            , subq_4.median_booking_value
-            , subq_4.booking_value_p99
-            , subq_4.discrete_booking_value_p99
-            , subq_4.approximate_continuous_booking_value_p99
-            , subq_4.approximate_discrete_booking_value_p99
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -308,165 +308,165 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_4
-        ) subq_5
-        WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_0
+        ) subq_1
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_2
+    ) subq_3
+  ) subq_4
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_14.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_13.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements: ['listings',]
       SELECT
-        subq_12.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_11.ds__day
-          , subq_11.ds__week
-          , subq_11.ds__month
-          , subq_11.ds__quarter
-          , subq_11.ds__year
-          , subq_11.ds__extract_year
-          , subq_11.ds__extract_quarter
-          , subq_11.ds__extract_month
-          , subq_11.ds__extract_day
-          , subq_11.ds__extract_dow
-          , subq_11.ds__extract_doy
-          , subq_11.created_at__day
-          , subq_11.created_at__week
-          , subq_11.created_at__month
-          , subq_11.created_at__quarter
-          , subq_11.created_at__year
-          , subq_11.created_at__extract_year
-          , subq_11.created_at__extract_quarter
-          , subq_11.created_at__extract_month
-          , subq_11.created_at__extract_day
-          , subq_11.created_at__extract_dow
-          , subq_11.created_at__extract_doy
-          , subq_11.listing__ds__day
-          , subq_11.listing__ds__week
-          , subq_11.listing__ds__month
-          , subq_11.listing__ds__quarter
-          , subq_11.listing__ds__year
-          , subq_11.listing__ds__extract_year
-          , subq_11.listing__ds__extract_quarter
-          , subq_11.listing__ds__extract_month
-          , subq_11.listing__ds__extract_day
-          , subq_11.listing__ds__extract_dow
-          , subq_11.listing__ds__extract_doy
-          , subq_11.listing__created_at__day
-          , subq_11.listing__created_at__week
-          , subq_11.listing__created_at__month
-          , subq_11.listing__created_at__quarter
-          , subq_11.listing__created_at__year
-          , subq_11.listing__created_at__extract_year
-          , subq_11.listing__created_at__extract_quarter
-          , subq_11.listing__created_at__extract_month
-          , subq_11.listing__created_at__extract_day
-          , subq_11.listing__created_at__extract_dow
-          , subq_11.listing__created_at__extract_doy
-          , subq_11.metric_time__day
-          , subq_11.metric_time__week
-          , subq_11.metric_time__month
-          , subq_11.metric_time__quarter
-          , subq_11.metric_time__year
-          , subq_11.metric_time__extract_year
-          , subq_11.metric_time__extract_quarter
-          , subq_11.metric_time__extract_month
-          , subq_11.metric_time__extract_day
-          , subq_11.metric_time__extract_dow
-          , subq_11.metric_time__extract_doy
-          , subq_11.listing
-          , subq_11.user
-          , subq_11.listing__user
-          , subq_11.country_latest
-          , subq_11.is_lux_latest
-          , subq_11.capacity_latest
-          , subq_11.listing__country_latest
-          , subq_11.listing__is_lux_latest
-          , subq_11.listing__capacity_latest
-          , subq_11.listings
-          , subq_11.largest_listing
-          , subq_11.smallest_listing
+          subq_7.ds__day
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.ds__extract_year
+          , subq_7.ds__extract_quarter
+          , subq_7.ds__extract_month
+          , subq_7.ds__extract_day
+          , subq_7.ds__extract_dow
+          , subq_7.ds__extract_doy
+          , subq_7.created_at__day
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.created_at__extract_year
+          , subq_7.created_at__extract_quarter
+          , subq_7.created_at__extract_month
+          , subq_7.created_at__extract_day
+          , subq_7.created_at__extract_dow
+          , subq_7.created_at__extract_doy
+          , subq_7.listing__ds__day
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__ds__extract_year
+          , subq_7.listing__ds__extract_quarter
+          , subq_7.listing__ds__extract_month
+          , subq_7.listing__ds__extract_day
+          , subq_7.listing__ds__extract_dow
+          , subq_7.listing__ds__extract_doy
+          , subq_7.listing__created_at__day
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.listing__created_at__extract_year
+          , subq_7.listing__created_at__extract_quarter
+          , subq_7.listing__created_at__extract_month
+          , subq_7.listing__created_at__extract_day
+          , subq_7.listing__created_at__extract_dow
+          , subq_7.listing__created_at__extract_doy
+          , subq_7.metric_time__day
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.created_at__day
-            , subq_10.created_at__week
-            , subq_10.created_at__month
-            , subq_10.created_at__quarter
-            , subq_10.created_at__year
-            , subq_10.created_at__extract_year
-            , subq_10.created_at__extract_quarter
-            , subq_10.created_at__extract_month
-            , subq_10.created_at__extract_day
-            , subq_10.created_at__extract_dow
-            , subq_10.created_at__extract_doy
-            , subq_10.listing__ds__day
-            , subq_10.listing__ds__week
-            , subq_10.listing__ds__month
-            , subq_10.listing__ds__quarter
-            , subq_10.listing__ds__year
-            , subq_10.listing__ds__extract_year
-            , subq_10.listing__ds__extract_quarter
-            , subq_10.listing__ds__extract_month
-            , subq_10.listing__ds__extract_day
-            , subq_10.listing__ds__extract_dow
-            , subq_10.listing__ds__extract_doy
-            , subq_10.listing__created_at__day
-            , subq_10.listing__created_at__week
-            , subq_10.listing__created_at__month
-            , subq_10.listing__created_at__quarter
-            , subq_10.listing__created_at__year
-            , subq_10.listing__created_at__extract_year
-            , subq_10.listing__created_at__extract_quarter
-            , subq_10.listing__created_at__extract_month
-            , subq_10.listing__created_at__extract_day
-            , subq_10.listing__created_at__extract_dow
-            , subq_10.listing__created_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.user
-            , subq_10.listing__user
-            , subq_10.country_latest
-            , subq_10.is_lux_latest
-            , subq_10.capacity_latest
-            , subq_10.listing__country_latest
-            , subq_10.listing__is_lux_latest
-            , subq_10.listing__capacity_latest
-            , subq_10.listings
-            , subq_10.largest_listing
-            , subq_10.smallest_listing
+            subq_6.ds__day
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds__extract_year
+            , subq_6.ds__extract_quarter
+            , subq_6.ds__extract_month
+            , subq_6.ds__extract_day
+            , subq_6.ds__extract_dow
+            , subq_6.ds__extract_doy
+            , subq_6.created_at__day
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.created_at__extract_year
+            , subq_6.created_at__extract_quarter
+            , subq_6.created_at__extract_month
+            , subq_6.created_at__extract_day
+            , subq_6.created_at__extract_dow
+            , subq_6.created_at__extract_doy
+            , subq_6.listing__ds__day
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__ds__extract_year
+            , subq_6.listing__ds__extract_quarter
+            , subq_6.listing__ds__extract_month
+            , subq_6.listing__ds__extract_day
+            , subq_6.listing__ds__extract_dow
+            , subq_6.listing__ds__extract_doy
+            , subq_6.listing__created_at__day
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.listing__created_at__extract_year
+            , subq_6.listing__created_at__extract_quarter
+            , subq_6.listing__created_at__extract_month
+            , subq_6.listing__created_at__extract_day
+            , subq_6.listing__created_at__extract_dow
+            , subq_6.listing__created_at__extract_doy
+            , subq_6.ds__day AS metric_time__day
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.ds__extract_year AS metric_time__extract_year
+            , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_6.ds__extract_month AS metric_time__extract_month
+            , subq_6.ds__extract_day AS metric_time__extract_day
+            , subq_6.ds__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__extract_doy AS metric_time__extract_doy
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -527,10 +527,10 @@ CROSS JOIN (
               , listings_latest_src_28000.user_id AS user
               , listings_latest_src_28000.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_28000
-          ) subq_10
-        ) subq_11
-        WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_12
-    ) subq_13
-  ) subq_14
-) subq_15
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_8
+    ) subq_9
+  ) subq_10
+) subq_11

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_25.bookings) AS bookings
-  , MAX(subq_31.listings) AS listings
+  MAX(subq_17.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_25
+) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATETIME_TRUNC(created_at, day) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_31
+) subq_23

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_15.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_13.metric_time__day
+  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_14.booking_value) AS booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_12.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.booking_value AS booking_value_with_is_instant_constraint
+      subq_6.metric_time__day
+      , subq_6.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , SUM(subq_7.booking_value) AS booking_value
+        subq_5.metric_time__day
+        , SUM(subq_5.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.booking_value
+          subq_4.metric_time__day
+          , subq_4.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.booking_value
+      subq_11.metric_time__day
+      , subq_11.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , SUM(subq_12.booking_value) AS booking_value
+        subq_10.metric_time__day
+        , SUM(subq_10.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.booking_value
+          subq_9.metric_time__day
+          , subq_9.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_30.booking_value) AS booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_26.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
+  subq_7.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.metric_time__day
-    , subq_8.bookings AS delayed_bookings
+    subq_6.metric_time__day
+    , subq_6.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -323,15 +323,15 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE NOT booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE NOT booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
-) subq_9
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_9
     WHERE NOT booking__is_instant
-  ) subq_15
+  ) subq_11
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_19
+) subq_15

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.listing__user__home_state_latest
-  , subq_21.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__user__home_state_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-    , SUM(subq_20.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__user__home_state_latest', 'metric_time__day']
     SELECT
-      subq_19.metric_time__day
-      , subq_19.listing__user__home_state_latest
-      , subq_19.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__user__home_state_latest
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_13.metric_time__day AS metric_time__day
-        , subq_18.window_start__day AS listing__window_start__day
-        , subq_18.window_end__day AS listing__window_end__day
-        , subq_13.listing AS listing
-        , subq_18.user__home_state_latest AS listing__user__home_state_latest
-        , subq_13.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.window_start__day AS listing__window_start__day
+        , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.user__home_state_latest AS listing__user__home_state_latest
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_12.metric_time__day
-          , subq_12.listing
-          , subq_12.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds__day
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds__extract_year
-            , subq_11.ds__extract_quarter
-            , subq_11.ds__extract_month
-            , subq_11.ds__extract_day
-            , subq_11.ds__extract_dow
-            , subq_11.ds__extract_doy
-            , subq_11.ds_partitioned__day
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.ds_partitioned__extract_year
-            , subq_11.ds_partitioned__extract_quarter
-            , subq_11.ds_partitioned__extract_month
-            , subq_11.ds_partitioned__extract_day
-            , subq_11.ds_partitioned__extract_dow
-            , subq_11.ds_partitioned__extract_doy
-            , subq_11.paid_at__day
-            , subq_11.paid_at__week
-            , subq_11.paid_at__month
-            , subq_11.paid_at__quarter
-            , subq_11.paid_at__year
-            , subq_11.paid_at__extract_year
-            , subq_11.paid_at__extract_quarter
-            , subq_11.paid_at__extract_month
-            , subq_11.paid_at__extract_day
-            , subq_11.paid_at__extract_dow
-            , subq_11.paid_at__extract_doy
-            , subq_11.booking__ds__day
-            , subq_11.booking__ds__week
-            , subq_11.booking__ds__month
-            , subq_11.booking__ds__quarter
-            , subq_11.booking__ds__year
-            , subq_11.booking__ds__extract_year
-            , subq_11.booking__ds__extract_quarter
-            , subq_11.booking__ds__extract_month
-            , subq_11.booking__ds__extract_day
-            , subq_11.booking__ds__extract_dow
-            , subq_11.booking__ds__extract_doy
-            , subq_11.booking__ds_partitioned__day
-            , subq_11.booking__ds_partitioned__week
-            , subq_11.booking__ds_partitioned__month
-            , subq_11.booking__ds_partitioned__quarter
-            , subq_11.booking__ds_partitioned__year
-            , subq_11.booking__ds_partitioned__extract_year
-            , subq_11.booking__ds_partitioned__extract_quarter
-            , subq_11.booking__ds_partitioned__extract_month
-            , subq_11.booking__ds_partitioned__extract_day
-            , subq_11.booking__ds_partitioned__extract_dow
-            , subq_11.booking__ds_partitioned__extract_doy
-            , subq_11.booking__paid_at__day
-            , subq_11.booking__paid_at__week
-            , subq_11.booking__paid_at__month
-            , subq_11.booking__paid_at__quarter
-            , subq_11.booking__paid_at__year
-            , subq_11.booking__paid_at__extract_year
-            , subq_11.booking__paid_at__extract_quarter
-            , subq_11.booking__paid_at__extract_month
-            , subq_11.booking__paid_at__extract_day
-            , subq_11.booking__paid_at__extract_dow
-            , subq_11.booking__paid_at__extract_doy
-            , subq_11.ds__day AS metric_time__day
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.ds__extract_year AS metric_time__extract_year
-            , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_11.ds__extract_month AS metric_time__extract_month
-            , subq_11.ds__extract_day AS metric_time__extract_day
-            , subq_11.ds__extract_dow AS metric_time__extract_dow
-            , subq_11.ds__extract_doy AS metric_time__extract_doy
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.user
-            , subq_11.booking__listing
-            , subq_11.booking__guest
-            , subq_11.booking__host
-            , subq_11.booking__user
-            , subq_11.is_instant
-            , subq_11.booking__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,84 +211,84 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
         SELECT
-          subq_17.window_start__day
-          , subq_17.window_end__day
-          , subq_17.listing
-          , subq_17.user__home_state_latest
+          subq_6.window_start__day
+          , subq_6.window_end__day
+          , subq_6.listing
+          , subq_6.user__home_state_latest
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.window_start__day AS window_start__day
-            , subq_14.window_start__week AS window_start__week
-            , subq_14.window_start__month AS window_start__month
-            , subq_14.window_start__quarter AS window_start__quarter
-            , subq_14.window_start__year AS window_start__year
-            , subq_14.window_start__extract_year AS window_start__extract_year
-            , subq_14.window_start__extract_quarter AS window_start__extract_quarter
-            , subq_14.window_start__extract_month AS window_start__extract_month
-            , subq_14.window_start__extract_day AS window_start__extract_day
-            , subq_14.window_start__extract_dow AS window_start__extract_dow
-            , subq_14.window_start__extract_doy AS window_start__extract_doy
-            , subq_14.window_end__day AS window_end__day
-            , subq_14.window_end__week AS window_end__week
-            , subq_14.window_end__month AS window_end__month
-            , subq_14.window_end__quarter AS window_end__quarter
-            , subq_14.window_end__year AS window_end__year
-            , subq_14.window_end__extract_year AS window_end__extract_year
-            , subq_14.window_end__extract_quarter AS window_end__extract_quarter
-            , subq_14.window_end__extract_month AS window_end__extract_month
-            , subq_14.window_end__extract_day AS window_end__extract_day
-            , subq_14.window_end__extract_dow AS window_end__extract_dow
-            , subq_14.window_end__extract_doy AS window_end__extract_doy
-            , subq_14.listing__window_start__day AS listing__window_start__day
-            , subq_14.listing__window_start__week AS listing__window_start__week
-            , subq_14.listing__window_start__month AS listing__window_start__month
-            , subq_14.listing__window_start__quarter AS listing__window_start__quarter
-            , subq_14.listing__window_start__year AS listing__window_start__year
-            , subq_14.listing__window_start__extract_year AS listing__window_start__extract_year
-            , subq_14.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
-            , subq_14.listing__window_start__extract_month AS listing__window_start__extract_month
-            , subq_14.listing__window_start__extract_day AS listing__window_start__extract_day
-            , subq_14.listing__window_start__extract_dow AS listing__window_start__extract_dow
-            , subq_14.listing__window_start__extract_doy AS listing__window_start__extract_doy
-            , subq_14.listing__window_end__day AS listing__window_end__day
-            , subq_14.listing__window_end__week AS listing__window_end__week
-            , subq_14.listing__window_end__month AS listing__window_end__month
-            , subq_14.listing__window_end__quarter AS listing__window_end__quarter
-            , subq_14.listing__window_end__year AS listing__window_end__year
-            , subq_14.listing__window_end__extract_year AS listing__window_end__extract_year
-            , subq_14.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
-            , subq_14.listing__window_end__extract_month AS listing__window_end__extract_month
-            , subq_14.listing__window_end__extract_day AS listing__window_end__extract_day
-            , subq_14.listing__window_end__extract_dow AS listing__window_end__extract_dow
-            , subq_14.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_16.ds__day AS user__ds__day
-            , subq_16.ds__week AS user__ds__week
-            , subq_16.ds__month AS user__ds__month
-            , subq_16.ds__quarter AS user__ds__quarter
-            , subq_16.ds__year AS user__ds__year
-            , subq_16.ds__extract_year AS user__ds__extract_year
-            , subq_16.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_16.ds__extract_month AS user__ds__extract_month
-            , subq_16.ds__extract_day AS user__ds__extract_day
-            , subq_16.ds__extract_dow AS user__ds__extract_dow
-            , subq_16.ds__extract_doy AS user__ds__extract_doy
-            , subq_14.listing AS listing
-            , subq_14.user AS user
-            , subq_14.listing__user AS listing__user
-            , subq_14.country AS country
-            , subq_14.is_lux AS is_lux
-            , subq_14.capacity AS capacity
-            , subq_14.listing__country AS listing__country
-            , subq_14.listing__is_lux AS listing__is_lux
-            , subq_14.listing__capacity AS listing__capacity
-            , subq_16.home_state_latest AS user__home_state_latest
+            subq_3.window_start__day AS window_start__day
+            , subq_3.window_start__week AS window_start__week
+            , subq_3.window_start__month AS window_start__month
+            , subq_3.window_start__quarter AS window_start__quarter
+            , subq_3.window_start__year AS window_start__year
+            , subq_3.window_start__extract_year AS window_start__extract_year
+            , subq_3.window_start__extract_quarter AS window_start__extract_quarter
+            , subq_3.window_start__extract_month AS window_start__extract_month
+            , subq_3.window_start__extract_day AS window_start__extract_day
+            , subq_3.window_start__extract_dow AS window_start__extract_dow
+            , subq_3.window_start__extract_doy AS window_start__extract_doy
+            , subq_3.window_end__day AS window_end__day
+            , subq_3.window_end__week AS window_end__week
+            , subq_3.window_end__month AS window_end__month
+            , subq_3.window_end__quarter AS window_end__quarter
+            , subq_3.window_end__year AS window_end__year
+            , subq_3.window_end__extract_year AS window_end__extract_year
+            , subq_3.window_end__extract_quarter AS window_end__extract_quarter
+            , subq_3.window_end__extract_month AS window_end__extract_month
+            , subq_3.window_end__extract_day AS window_end__extract_day
+            , subq_3.window_end__extract_dow AS window_end__extract_dow
+            , subq_3.window_end__extract_doy AS window_end__extract_doy
+            , subq_3.listing__window_start__day AS listing__window_start__day
+            , subq_3.listing__window_start__week AS listing__window_start__week
+            , subq_3.listing__window_start__month AS listing__window_start__month
+            , subq_3.listing__window_start__quarter AS listing__window_start__quarter
+            , subq_3.listing__window_start__year AS listing__window_start__year
+            , subq_3.listing__window_start__extract_year AS listing__window_start__extract_year
+            , subq_3.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+            , subq_3.listing__window_start__extract_month AS listing__window_start__extract_month
+            , subq_3.listing__window_start__extract_day AS listing__window_start__extract_day
+            , subq_3.listing__window_start__extract_dow AS listing__window_start__extract_dow
+            , subq_3.listing__window_start__extract_doy AS listing__window_start__extract_doy
+            , subq_3.listing__window_end__day AS listing__window_end__day
+            , subq_3.listing__window_end__week AS listing__window_end__week
+            , subq_3.listing__window_end__month AS listing__window_end__month
+            , subq_3.listing__window_end__quarter AS listing__window_end__quarter
+            , subq_3.listing__window_end__year AS listing__window_end__year
+            , subq_3.listing__window_end__extract_year AS listing__window_end__extract_year
+            , subq_3.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+            , subq_3.listing__window_end__extract_month AS listing__window_end__extract_month
+            , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
+            , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
+            , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.user AS user
+            , subq_3.listing__user AS listing__user
+            , subq_3.country AS country
+            , subq_3.is_lux AS is_lux
+            , subq_3.capacity AS capacity
+            , subq_3.listing__country AS listing__country
+            , subq_3.listing__is_lux AS listing__is_lux
+            , subq_3.listing__capacity AS listing__capacity
+            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT
@@ -346,7 +346,7 @@ FROM (
               , listings_src_26000.user_id AS user
               , listings_src_26000.user_id AS listing__user
             FROM ***************************.dim_listings listings_src_26000
-          ) subq_14
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'home_state_latest',
@@ -376,31 +376,31 @@ FROM (
             --   'user',
             -- ]
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.user__ds__day
-              , subq_15.user__ds__week
-              , subq_15.user__ds__month
-              , subq_15.user__ds__quarter
-              , subq_15.user__ds__year
-              , subq_15.user__ds__extract_year
-              , subq_15.user__ds__extract_quarter
-              , subq_15.user__ds__extract_month
-              , subq_15.user__ds__extract_day
-              , subq_15.user__ds__extract_dow
-              , subq_15.user__ds__extract_doy
-              , subq_15.user
-              , subq_15.home_state_latest
-              , subq_15.user__home_state_latest
+              subq_4.ds__day
+              , subq_4.ds__week
+              , subq_4.ds__month
+              , subq_4.ds__quarter
+              , subq_4.ds__year
+              , subq_4.ds__extract_year
+              , subq_4.ds__extract_quarter
+              , subq_4.ds__extract_month
+              , subq_4.ds__extract_day
+              , subq_4.ds__extract_dow
+              , subq_4.ds__extract_doy
+              , subq_4.user__ds__day
+              , subq_4.user__ds__week
+              , subq_4.user__ds__month
+              , subq_4.user__ds__quarter
+              , subq_4.user__ds__year
+              , subq_4.user__ds__extract_year
+              , subq_4.user__ds__extract_quarter
+              , subq_4.user__ds__extract_month
+              , subq_4.user__ds__extract_day
+              , subq_4.user__ds__extract_dow
+              , subq_4.user__ds__extract_doy
+              , subq_4.user
+              , subq_4.home_state_latest
+              , subq_4.user__home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -430,29 +430,29 @@ FROM (
                 , users_latest_src_26000.home_state_latest AS user__home_state_latest
                 , users_latest_src_26000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_26000
-            ) subq_15
-          ) subq_16
+            ) subq_4
+          ) subq_5
           ON
-            subq_14.user = subq_16.user
-        ) subq_17
-      ) subq_18
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_13.listing = subq_18.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_13.metric_time__day >= subq_18.window_start__day
+            subq_2.metric_time__day >= subq_7.window_start__day
           ) AND (
             (
-              subq_13.metric_time__day < subq_18.window_end__day
+              subq_2.metric_time__day < subq_7.window_end__day
             ) OR (
-              subq_18.window_end__day IS NULL
+              subq_7.window_end__day IS NULL
             )
           )
         )
-    ) subq_19
-  ) subq_20
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-) subq_21
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_35.metric_time__day AS metric_time__day
-  , subq_40.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_35.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_35
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_40
+) subq_18
 ON
   (
-    subq_35.listing = subq_40.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_35.metric_time__day >= subq_40.window_start__day
+      subq_13.metric_time__day >= subq_18.window_start__day
     ) AND (
       (
-        subq_35.metric_time__day < subq_40.window_end__day
+        subq_13.metric_time__day < subq_18.window_end__day
       ) OR (
-        subq_40.window_end__day IS NULL
+        subq_18.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_35.metric_time__day
-  , subq_40.user__home_state_latest
+  subq_13.metric_time__day
+  , subq_18.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , subq_13.listing__lux_listing__is_confirmed_lux
-  , subq_13.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__lux_listing__is_confirmed_lux
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-    , SUM(subq_12.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__lux_listing__is_confirmed_lux', 'metric_time__day']
     SELECT
-      subq_11.metric_time__day
-      , subq_11.listing__lux_listing__is_confirmed_lux
-      , subq_11.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__lux_listing__is_confirmed_lux
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_5.metric_time__day AS metric_time__day
-        , subq_10.lux_listing__window_start__day AS listing__lux_listing__window_start__day
-        , subq_10.lux_listing__window_end__day AS listing__lux_listing__window_end__day
-        , subq_5.listing AS listing
-        , subq_10.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-        , subq_5.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
+        , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.listing
-          , subq_4.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.ds__day AS metric_time__day
-            , subq_3.ds__week AS metric_time__week
-            , subq_3.ds__month AS metric_time__month
-            , subq_3.ds__quarter AS metric_time__quarter
-            , subq_3.ds__year AS metric_time__year
-            , subq_3.ds__extract_year AS metric_time__extract_year
-            , subq_3.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_3.ds__extract_month AS metric_time__extract_month
-            , subq_3.ds__extract_day AS metric_time__extract_day
-            , subq_3.ds__extract_dow AS metric_time__extract_dow
-            , subq_3.ds__extract_doy AS metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.user
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.booking__user
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,45 +211,45 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_3
-        ) subq_4
-      ) subq_5
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
         SELECT
-          subq_9.lux_listing__window_start__day
-          , subq_9.lux_listing__window_end__day
-          , subq_9.listing
-          , subq_9.lux_listing__is_confirmed_lux
+          subq_6.lux_listing__window_start__day
+          , subq_6.lux_listing__window_end__day
+          , subq_6.listing
+          , subq_6.lux_listing__is_confirmed_lux
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_8.window_start__day AS lux_listing__window_start__day
-            , subq_8.window_start__week AS lux_listing__window_start__week
-            , subq_8.window_start__month AS lux_listing__window_start__month
-            , subq_8.window_start__quarter AS lux_listing__window_start__quarter
-            , subq_8.window_start__year AS lux_listing__window_start__year
-            , subq_8.window_start__extract_year AS lux_listing__window_start__extract_year
-            , subq_8.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
-            , subq_8.window_start__extract_month AS lux_listing__window_start__extract_month
-            , subq_8.window_start__extract_day AS lux_listing__window_start__extract_day
-            , subq_8.window_start__extract_dow AS lux_listing__window_start__extract_dow
-            , subq_8.window_start__extract_doy AS lux_listing__window_start__extract_doy
-            , subq_8.window_end__day AS lux_listing__window_end__day
-            , subq_8.window_end__week AS lux_listing__window_end__week
-            , subq_8.window_end__month AS lux_listing__window_end__month
-            , subq_8.window_end__quarter AS lux_listing__window_end__quarter
-            , subq_8.window_end__year AS lux_listing__window_end__year
-            , subq_8.window_end__extract_year AS lux_listing__window_end__extract_year
-            , subq_8.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
-            , subq_8.window_end__extract_month AS lux_listing__window_end__extract_month
-            , subq_8.window_end__extract_day AS lux_listing__window_end__extract_day
-            , subq_8.window_end__extract_dow AS lux_listing__window_end__extract_dow
-            , subq_8.window_end__extract_doy AS lux_listing__window_end__extract_doy
-            , subq_6.listing AS listing
-            , subq_6.lux_listing AS lux_listing
-            , subq_6.listing__lux_listing AS listing__lux_listing
-            , subq_8.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            subq_5.window_start__day AS lux_listing__window_start__day
+            , subq_5.window_start__week AS lux_listing__window_start__week
+            , subq_5.window_start__month AS lux_listing__window_start__month
+            , subq_5.window_start__quarter AS lux_listing__window_start__quarter
+            , subq_5.window_start__year AS lux_listing__window_start__year
+            , subq_5.window_start__extract_year AS lux_listing__window_start__extract_year
+            , subq_5.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
+            , subq_5.window_start__extract_month AS lux_listing__window_start__extract_month
+            , subq_5.window_start__extract_day AS lux_listing__window_start__extract_day
+            , subq_5.window_start__extract_dow AS lux_listing__window_start__extract_dow
+            , subq_5.window_start__extract_doy AS lux_listing__window_start__extract_doy
+            , subq_5.window_end__day AS lux_listing__window_end__day
+            , subq_5.window_end__week AS lux_listing__window_end__week
+            , subq_5.window_end__month AS lux_listing__window_end__month
+            , subq_5.window_end__quarter AS lux_listing__window_end__quarter
+            , subq_5.window_end__year AS lux_listing__window_end__year
+            , subq_5.window_end__extract_year AS lux_listing__window_end__extract_year
+            , subq_5.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
+            , subq_5.window_end__extract_month AS lux_listing__window_end__extract_month
+            , subq_5.window_end__extract_day AS lux_listing__window_end__extract_day
+            , subq_5.window_end__extract_dow AS lux_listing__window_end__extract_dow
+            , subq_5.window_end__extract_doy AS lux_listing__window_end__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.lux_listing AS lux_listing
+            , subq_3.listing__lux_listing AS listing__lux_listing
+            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT
@@ -257,7 +257,7 @@ FROM (
               , lux_listing_mapping_src_26000.lux_listing_id AS lux_listing
               , lux_listing_mapping_src_26000.lux_listing_id AS listing__lux_listing
             FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_26000
-          ) subq_6
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'is_confirmed_lux',
@@ -309,53 +309,53 @@ FROM (
             --   'lux_listing',
             -- ]
             SELECT
-              subq_7.window_start__day
-              , subq_7.window_start__week
-              , subq_7.window_start__month
-              , subq_7.window_start__quarter
-              , subq_7.window_start__year
-              , subq_7.window_start__extract_year
-              , subq_7.window_start__extract_quarter
-              , subq_7.window_start__extract_month
-              , subq_7.window_start__extract_day
-              , subq_7.window_start__extract_dow
-              , subq_7.window_start__extract_doy
-              , subq_7.window_end__day
-              , subq_7.window_end__week
-              , subq_7.window_end__month
-              , subq_7.window_end__quarter
-              , subq_7.window_end__year
-              , subq_7.window_end__extract_year
-              , subq_7.window_end__extract_quarter
-              , subq_7.window_end__extract_month
-              , subq_7.window_end__extract_day
-              , subq_7.window_end__extract_dow
-              , subq_7.window_end__extract_doy
-              , subq_7.lux_listing__window_start__day
-              , subq_7.lux_listing__window_start__week
-              , subq_7.lux_listing__window_start__month
-              , subq_7.lux_listing__window_start__quarter
-              , subq_7.lux_listing__window_start__year
-              , subq_7.lux_listing__window_start__extract_year
-              , subq_7.lux_listing__window_start__extract_quarter
-              , subq_7.lux_listing__window_start__extract_month
-              , subq_7.lux_listing__window_start__extract_day
-              , subq_7.lux_listing__window_start__extract_dow
-              , subq_7.lux_listing__window_start__extract_doy
-              , subq_7.lux_listing__window_end__day
-              , subq_7.lux_listing__window_end__week
-              , subq_7.lux_listing__window_end__month
-              , subq_7.lux_listing__window_end__quarter
-              , subq_7.lux_listing__window_end__year
-              , subq_7.lux_listing__window_end__extract_year
-              , subq_7.lux_listing__window_end__extract_quarter
-              , subq_7.lux_listing__window_end__extract_month
-              , subq_7.lux_listing__window_end__extract_day
-              , subq_7.lux_listing__window_end__extract_dow
-              , subq_7.lux_listing__window_end__extract_doy
-              , subq_7.lux_listing
-              , subq_7.is_confirmed_lux
-              , subq_7.lux_listing__is_confirmed_lux
+              subq_4.window_start__day
+              , subq_4.window_start__week
+              , subq_4.window_start__month
+              , subq_4.window_start__quarter
+              , subq_4.window_start__year
+              , subq_4.window_start__extract_year
+              , subq_4.window_start__extract_quarter
+              , subq_4.window_start__extract_month
+              , subq_4.window_start__extract_day
+              , subq_4.window_start__extract_dow
+              , subq_4.window_start__extract_doy
+              , subq_4.window_end__day
+              , subq_4.window_end__week
+              , subq_4.window_end__month
+              , subq_4.window_end__quarter
+              , subq_4.window_end__year
+              , subq_4.window_end__extract_year
+              , subq_4.window_end__extract_quarter
+              , subq_4.window_end__extract_month
+              , subq_4.window_end__extract_day
+              , subq_4.window_end__extract_dow
+              , subq_4.window_end__extract_doy
+              , subq_4.lux_listing__window_start__day
+              , subq_4.lux_listing__window_start__week
+              , subq_4.lux_listing__window_start__month
+              , subq_4.lux_listing__window_start__quarter
+              , subq_4.lux_listing__window_start__year
+              , subq_4.lux_listing__window_start__extract_year
+              , subq_4.lux_listing__window_start__extract_quarter
+              , subq_4.lux_listing__window_start__extract_month
+              , subq_4.lux_listing__window_start__extract_day
+              , subq_4.lux_listing__window_start__extract_dow
+              , subq_4.lux_listing__window_start__extract_doy
+              , subq_4.lux_listing__window_end__day
+              , subq_4.lux_listing__window_end__week
+              , subq_4.lux_listing__window_end__month
+              , subq_4.lux_listing__window_end__quarter
+              , subq_4.lux_listing__window_end__year
+              , subq_4.lux_listing__window_end__extract_year
+              , subq_4.lux_listing__window_end__extract_quarter
+              , subq_4.lux_listing__window_end__extract_month
+              , subq_4.lux_listing__window_end__extract_day
+              , subq_4.lux_listing__window_end__extract_dow
+              , subq_4.lux_listing__window_end__extract_doy
+              , subq_4.lux_listing
+              , subq_4.is_confirmed_lux
+              , subq_4.lux_listing__is_confirmed_lux
             FROM (
               -- Read Elements From Semantic Model 'lux_listings'
               SELECT
@@ -407,29 +407,29 @@ FROM (
                 , lux_listings_src_26000.is_confirmed_lux AS lux_listing__is_confirmed_lux
                 , lux_listings_src_26000.lux_listing_id AS lux_listing
               FROM ***************************.dim_lux_listings lux_listings_src_26000
-            ) subq_7
-          ) subq_8
+            ) subq_4
+          ) subq_5
           ON
-            subq_6.lux_listing = subq_8.lux_listing
-        ) subq_9
-      ) subq_10
+            subq_3.lux_listing = subq_5.lux_listing
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_5.listing = subq_10.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_5.metric_time__day >= subq_10.lux_listing__window_start__day
+            subq_2.metric_time__day >= subq_7.lux_listing__window_start__day
           ) AND (
             (
-              subq_5.metric_time__day < subq_10.lux_listing__window_end__day
+              subq_2.metric_time__day < subq_7.lux_listing__window_end__day
             ) OR (
-              subq_10.lux_listing__window_end__day IS NULL
+              subq_7.lux_listing__window_end__day IS NULL
             )
           )
         )
-    ) subq_11
-  ) subq_12
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-) subq_13
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time__day AS metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_19.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_19
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_24
+) subq_18
 ON
   (
-    subq_19.listing = subq_24.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
+      subq_13.metric_time__day >= subq_18.lux_listing__window_start__day
     ) AND (
       (
-        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
+        subq_13.metric_time__day < subq_18.lux_listing__window_end__day
       ) OR (
-        subq_24.lux_listing__window_end__day IS NULL
+        subq_18.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_19.metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux
+  subq_13.metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multihop_node__plan0.sql
@@ -1,93 +1,93 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.account_id__customer_id__customer_name
-  , subq_17.txn_count
+  subq_12.account_id__customer_id__customer_name
+  , subq_12.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.account_id__customer_id__customer_name
-    , SUM(subq_16.txn_count) AS txn_count
+    subq_11.account_id__customer_id__customer_name
+    , SUM(subq_11.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_15.account_id__customer_id__customer_name
-      , subq_15.txn_count
+      subq_10.account_id__customer_id__customer_name
+      , subq_10.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_7.ds_partitioned__day AS ds_partitioned__day
-        , subq_14.ds_partitioned__day AS account_id__ds_partitioned__day
-        , subq_7.account_id AS account_id
-        , subq_14.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_7.txn_count AS txn_count
+        subq_2.ds_partitioned__day AS ds_partitioned__day
+        , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.account_id AS account_id
+        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_6.ds_partitioned__day
-          , subq_6.account_id
-          , subq_6.txn_count
+          subq_1.ds_partitioned__day
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds_partitioned__day
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.ds_partitioned__extract_year
-            , subq_5.ds_partitioned__extract_quarter
-            , subq_5.ds_partitioned__extract_month
-            , subq_5.ds_partitioned__extract_day
-            , subq_5.ds_partitioned__extract_dow
-            , subq_5.ds_partitioned__extract_doy
-            , subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.account_id__ds_partitioned__day
-            , subq_5.account_id__ds_partitioned__week
-            , subq_5.account_id__ds_partitioned__month
-            , subq_5.account_id__ds_partitioned__quarter
-            , subq_5.account_id__ds_partitioned__year
-            , subq_5.account_id__ds_partitioned__extract_year
-            , subq_5.account_id__ds_partitioned__extract_quarter
-            , subq_5.account_id__ds_partitioned__extract_month
-            , subq_5.account_id__ds_partitioned__extract_day
-            , subq_5.account_id__ds_partitioned__extract_dow
-            , subq_5.account_id__ds_partitioned__extract_doy
-            , subq_5.account_id__ds__day
-            , subq_5.account_id__ds__week
-            , subq_5.account_id__ds__month
-            , subq_5.account_id__ds__quarter
-            , subq_5.account_id__ds__year
-            , subq_5.account_id__ds__extract_year
-            , subq_5.account_id__ds__extract_quarter
-            , subq_5.account_id__ds__extract_month
-            , subq_5.account_id__ds__extract_day
-            , subq_5.account_id__ds__extract_dow
-            , subq_5.account_id__ds__extract_doy
-            , subq_5.ds__day AS metric_time__day
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.ds__extract_year AS metric_time__extract_year
-            , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_5.ds__extract_month AS metric_time__extract_month
-            , subq_5.ds__extract_day AS metric_time__extract_day
-            , subq_5.ds__extract_dow AS metric_time__extract_dow
-            , subq_5.ds__extract_doy AS metric_time__extract_doy
-            , subq_5.account_id
-            , subq_5.account_month
-            , subq_5.account_id__account_month
-            , subq_5.txn_count
+            subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.account_id__ds_partitioned__day
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds_partitioned__extract_year
+            , subq_0.account_id__ds_partitioned__extract_quarter
+            , subq_0.account_id__ds_partitioned__extract_month
+            , subq_0.account_id__ds_partitioned__extract_day
+            , subq_0.account_id__ds_partitioned__extract_dow
+            , subq_0.account_id__ds_partitioned__extract_doy
+            , subq_0.account_id__ds__day
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.account_id__ds__extract_year
+            , subq_0.account_id__ds__extract_quarter
+            , subq_0.account_id__ds__extract_month
+            , subq_0.account_id__ds__extract_day
+            , subq_0.account_id__ds__extract_dow
+            , subq_0.account_id__ds__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
@@ -140,151 +140,151 @@ FROM (
               , account_month_txns_src_22000.account_month AS account_id__account_month
               , account_month_txns_src_22000.account_id
             FROM ***************************.account_month_txns account_month_txns_src_22000
-          ) subq_5
-        ) subq_6
-      ) subq_7
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_13.ds_partitioned__day
-          , subq_13.account_id
-          , subq_13.customer_id__customer_name
+          subq_8.ds_partitioned__day
+          , subq_8.account_id
+          , subq_8.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_9.ds_partitioned__day AS ds_partitioned__day
-            , subq_9.ds_partitioned__week AS ds_partitioned__week
-            , subq_9.ds_partitioned__month AS ds_partitioned__month
-            , subq_9.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_9.ds_partitioned__year AS ds_partitioned__year
-            , subq_9.ds_partitioned__extract_year AS ds_partitioned__extract_year
-            , subq_9.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-            , subq_9.ds_partitioned__extract_month AS ds_partitioned__extract_month
-            , subq_9.ds_partitioned__extract_day AS ds_partitioned__extract_day
-            , subq_9.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-            , subq_9.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-            , subq_9.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-            , subq_9.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_9.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_9.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_9.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_9.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-            , subq_9.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-            , subq_9.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-            , subq_9.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-            , subq_9.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-            , subq_9.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-            , subq_9.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-            , subq_9.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-            , subq_9.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-            , subq_9.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-            , subq_9.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-            , subq_9.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-            , subq_9.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-            , subq_9.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-            , subq_9.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-            , subq_9.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-            , subq_9.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
-            , subq_9.metric_time__month AS metric_time__month
-            , subq_9.metric_time__quarter AS metric_time__quarter
-            , subq_9.metric_time__year AS metric_time__year
-            , subq_9.metric_time__extract_year AS metric_time__extract_year
-            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_9.metric_time__extract_month AS metric_time__extract_month
-            , subq_9.metric_time__extract_day AS metric_time__extract_day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_12.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_12.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_12.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_12.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_12.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_12.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_12.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_12.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_12.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_12.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_12.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_12.metric_time__day AS customer_id__metric_time__day
-            , subq_12.metric_time__week AS customer_id__metric_time__week
-            , subq_12.metric_time__month AS customer_id__metric_time__month
-            , subq_12.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_12.metric_time__year AS customer_id__metric_time__year
-            , subq_12.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_12.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_12.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_12.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_12.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_12.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-            , subq_9.account_id AS account_id
-            , subq_9.customer_id AS customer_id
-            , subq_9.account_id__customer_id AS account_id__customer_id
-            , subq_9.bridge_account__account_id AS bridge_account__account_id
-            , subq_9.bridge_account__customer_id AS bridge_account__customer_id
-            , subq_9.extra_dim AS extra_dim
-            , subq_9.account_id__extra_dim AS account_id__extra_dim
-            , subq_9.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_12.customer_name AS customer_id__customer_name
-            , subq_12.customer_atomic_weight AS customer_id__customer_atomic_weight
-            , subq_9.account_customer_combos AS account_customer_combos
+            subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_4.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+            , subq_4.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+            , subq_4.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+            , subq_4.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+            , subq_4.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+            , subq_4.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+            , subq_4.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+            , subq_4.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+            , subq_4.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+            , subq_4.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+            , subq_4.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+            , subq_4.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+            , subq_4.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+            , subq_4.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+            , subq_4.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+            , subq_4.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+            , subq_4.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.account_id AS account_id
+            , subq_4.customer_id AS customer_id
+            , subq_4.account_id__customer_id AS account_id__customer_id
+            , subq_4.bridge_account__account_id AS bridge_account__account_id
+            , subq_4.bridge_account__customer_id AS bridge_account__customer_id
+            , subq_4.extra_dim AS extra_dim
+            , subq_4.account_id__extra_dim AS account_id__extra_dim
+            , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
+            , subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'
             SELECT
-              subq_8.ds_partitioned__day
-              , subq_8.ds_partitioned__week
-              , subq_8.ds_partitioned__month
-              , subq_8.ds_partitioned__quarter
-              , subq_8.ds_partitioned__year
-              , subq_8.ds_partitioned__extract_year
-              , subq_8.ds_partitioned__extract_quarter
-              , subq_8.ds_partitioned__extract_month
-              , subq_8.ds_partitioned__extract_day
-              , subq_8.ds_partitioned__extract_dow
-              , subq_8.ds_partitioned__extract_doy
-              , subq_8.account_id__ds_partitioned__day
-              , subq_8.account_id__ds_partitioned__week
-              , subq_8.account_id__ds_partitioned__month
-              , subq_8.account_id__ds_partitioned__quarter
-              , subq_8.account_id__ds_partitioned__year
-              , subq_8.account_id__ds_partitioned__extract_year
-              , subq_8.account_id__ds_partitioned__extract_quarter
-              , subq_8.account_id__ds_partitioned__extract_month
-              , subq_8.account_id__ds_partitioned__extract_day
-              , subq_8.account_id__ds_partitioned__extract_dow
-              , subq_8.account_id__ds_partitioned__extract_doy
-              , subq_8.bridge_account__ds_partitioned__day
-              , subq_8.bridge_account__ds_partitioned__week
-              , subq_8.bridge_account__ds_partitioned__month
-              , subq_8.bridge_account__ds_partitioned__quarter
-              , subq_8.bridge_account__ds_partitioned__year
-              , subq_8.bridge_account__ds_partitioned__extract_year
-              , subq_8.bridge_account__ds_partitioned__extract_quarter
-              , subq_8.bridge_account__ds_partitioned__extract_month
-              , subq_8.bridge_account__ds_partitioned__extract_day
-              , subq_8.bridge_account__ds_partitioned__extract_dow
-              , subq_8.bridge_account__ds_partitioned__extract_doy
-              , subq_8.ds_partitioned__day AS metric_time__day
-              , subq_8.ds_partitioned__week AS metric_time__week
-              , subq_8.ds_partitioned__month AS metric_time__month
-              , subq_8.ds_partitioned__quarter AS metric_time__quarter
-              , subq_8.ds_partitioned__year AS metric_time__year
-              , subq_8.ds_partitioned__extract_year AS metric_time__extract_year
-              , subq_8.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-              , subq_8.ds_partitioned__extract_month AS metric_time__extract_month
-              , subq_8.ds_partitioned__extract_day AS metric_time__extract_day
-              , subq_8.ds_partitioned__extract_dow AS metric_time__extract_dow
-              , subq_8.ds_partitioned__extract_doy AS metric_time__extract_doy
-              , subq_8.account_id
-              , subq_8.customer_id
-              , subq_8.account_id__customer_id
-              , subq_8.bridge_account__account_id
-              , subq_8.bridge_account__customer_id
-              , subq_8.extra_dim
-              , subq_8.account_id__extra_dim
-              , subq_8.bridge_account__extra_dim
-              , subq_8.account_customer_combos
+              subq_3.ds_partitioned__day
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.ds_partitioned__extract_year
+              , subq_3.ds_partitioned__extract_quarter
+              , subq_3.ds_partitioned__extract_month
+              , subq_3.ds_partitioned__extract_day
+              , subq_3.ds_partitioned__extract_dow
+              , subq_3.ds_partitioned__extract_doy
+              , subq_3.account_id__ds_partitioned__day
+              , subq_3.account_id__ds_partitioned__week
+              , subq_3.account_id__ds_partitioned__month
+              , subq_3.account_id__ds_partitioned__quarter
+              , subq_3.account_id__ds_partitioned__year
+              , subq_3.account_id__ds_partitioned__extract_year
+              , subq_3.account_id__ds_partitioned__extract_quarter
+              , subq_3.account_id__ds_partitioned__extract_month
+              , subq_3.account_id__ds_partitioned__extract_day
+              , subq_3.account_id__ds_partitioned__extract_dow
+              , subq_3.account_id__ds_partitioned__extract_doy
+              , subq_3.bridge_account__ds_partitioned__day
+              , subq_3.bridge_account__ds_partitioned__week
+              , subq_3.bridge_account__ds_partitioned__month
+              , subq_3.bridge_account__ds_partitioned__quarter
+              , subq_3.bridge_account__ds_partitioned__year
+              , subq_3.bridge_account__ds_partitioned__extract_year
+              , subq_3.bridge_account__ds_partitioned__extract_quarter
+              , subq_3.bridge_account__ds_partitioned__extract_month
+              , subq_3.bridge_account__ds_partitioned__extract_day
+              , subq_3.bridge_account__ds_partitioned__extract_dow
+              , subq_3.bridge_account__ds_partitioned__extract_doy
+              , subq_3.ds_partitioned__day AS metric_time__day
+              , subq_3.ds_partitioned__week AS metric_time__week
+              , subq_3.ds_partitioned__month AS metric_time__month
+              , subq_3.ds_partitioned__quarter AS metric_time__quarter
+              , subq_3.ds_partitioned__year AS metric_time__year
+              , subq_3.ds_partitioned__extract_year AS metric_time__extract_year
+              , subq_3.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+              , subq_3.ds_partitioned__extract_month AS metric_time__extract_month
+              , subq_3.ds_partitioned__extract_day AS metric_time__extract_day
+              , subq_3.ds_partitioned__extract_dow AS metric_time__extract_dow
+              , subq_3.ds_partitioned__extract_doy AS metric_time__extract_doy
+              , subq_3.account_id
+              , subq_3.customer_id
+              , subq_3.account_id__customer_id
+              , subq_3.bridge_account__account_id
+              , subq_3.bridge_account__customer_id
+              , subq_3.extra_dim
+              , subq_3.account_id__extra_dim
+              , subq_3.bridge_account__extra_dim
+              , subq_3.account_customer_combos
             FROM (
               -- Read Elements From Semantic Model 'bridge_table'
               SELECT
@@ -331,8 +331,8 @@ FROM (
                 , bridge_table_src_22000.account_id AS bridge_account__account_id
                 , bridge_table_src_22000.customer_id AS bridge_account__customer_id
               FROM ***************************.bridge_table bridge_table_src_22000
-            ) subq_8
-          ) subq_9
+            ) subq_3
+          ) subq_4
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'customer_name',
@@ -375,86 +375,86 @@ FROM (
             --   'customer_id',
             -- ]
             SELECT
-              subq_11.ds_partitioned__day
-              , subq_11.ds_partitioned__week
-              , subq_11.ds_partitioned__month
-              , subq_11.ds_partitioned__quarter
-              , subq_11.ds_partitioned__year
-              , subq_11.ds_partitioned__extract_year
-              , subq_11.ds_partitioned__extract_quarter
-              , subq_11.ds_partitioned__extract_month
-              , subq_11.ds_partitioned__extract_day
-              , subq_11.ds_partitioned__extract_dow
-              , subq_11.ds_partitioned__extract_doy
-              , subq_11.customer_id__ds_partitioned__day
-              , subq_11.customer_id__ds_partitioned__week
-              , subq_11.customer_id__ds_partitioned__month
-              , subq_11.customer_id__ds_partitioned__quarter
-              , subq_11.customer_id__ds_partitioned__year
-              , subq_11.customer_id__ds_partitioned__extract_year
-              , subq_11.customer_id__ds_partitioned__extract_quarter
-              , subq_11.customer_id__ds_partitioned__extract_month
-              , subq_11.customer_id__ds_partitioned__extract_day
-              , subq_11.customer_id__ds_partitioned__extract_dow
-              , subq_11.customer_id__ds_partitioned__extract_doy
-              , subq_11.metric_time__day
-              , subq_11.metric_time__week
-              , subq_11.metric_time__month
-              , subq_11.metric_time__quarter
-              , subq_11.metric_time__year
-              , subq_11.metric_time__extract_year
-              , subq_11.metric_time__extract_quarter
-              , subq_11.metric_time__extract_month
-              , subq_11.metric_time__extract_day
-              , subq_11.metric_time__extract_dow
-              , subq_11.metric_time__extract_doy
-              , subq_11.customer_id
-              , subq_11.customer_name
-              , subq_11.customer_atomic_weight
-              , subq_11.customer_id__customer_name
-              , subq_11.customer_id__customer_atomic_weight
+              subq_6.ds_partitioned__day
+              , subq_6.ds_partitioned__week
+              , subq_6.ds_partitioned__month
+              , subq_6.ds_partitioned__quarter
+              , subq_6.ds_partitioned__year
+              , subq_6.ds_partitioned__extract_year
+              , subq_6.ds_partitioned__extract_quarter
+              , subq_6.ds_partitioned__extract_month
+              , subq_6.ds_partitioned__extract_day
+              , subq_6.ds_partitioned__extract_dow
+              , subq_6.ds_partitioned__extract_doy
+              , subq_6.customer_id__ds_partitioned__day
+              , subq_6.customer_id__ds_partitioned__week
+              , subq_6.customer_id__ds_partitioned__month
+              , subq_6.customer_id__ds_partitioned__quarter
+              , subq_6.customer_id__ds_partitioned__year
+              , subq_6.customer_id__ds_partitioned__extract_year
+              , subq_6.customer_id__ds_partitioned__extract_quarter
+              , subq_6.customer_id__ds_partitioned__extract_month
+              , subq_6.customer_id__ds_partitioned__extract_day
+              , subq_6.customer_id__ds_partitioned__extract_dow
+              , subq_6.customer_id__ds_partitioned__extract_doy
+              , subq_6.metric_time__day
+              , subq_6.metric_time__week
+              , subq_6.metric_time__month
+              , subq_6.metric_time__quarter
+              , subq_6.metric_time__year
+              , subq_6.metric_time__extract_year
+              , subq_6.metric_time__extract_quarter
+              , subq_6.metric_time__extract_month
+              , subq_6.metric_time__extract_day
+              , subq_6.metric_time__extract_dow
+              , subq_6.metric_time__extract_doy
+              , subq_6.customer_id
+              , subq_6.customer_name
+              , subq_6.customer_atomic_weight
+              , subq_6.customer_id__customer_name
+              , subq_6.customer_id__customer_atomic_weight
             FROM (
               -- Metric Time Dimension 'ds_partitioned'
               SELECT
-                subq_10.ds_partitioned__day
-                , subq_10.ds_partitioned__week
-                , subq_10.ds_partitioned__month
-                , subq_10.ds_partitioned__quarter
-                , subq_10.ds_partitioned__year
-                , subq_10.ds_partitioned__extract_year
-                , subq_10.ds_partitioned__extract_quarter
-                , subq_10.ds_partitioned__extract_month
-                , subq_10.ds_partitioned__extract_day
-                , subq_10.ds_partitioned__extract_dow
-                , subq_10.ds_partitioned__extract_doy
-                , subq_10.customer_id__ds_partitioned__day
-                , subq_10.customer_id__ds_partitioned__week
-                , subq_10.customer_id__ds_partitioned__month
-                , subq_10.customer_id__ds_partitioned__quarter
-                , subq_10.customer_id__ds_partitioned__year
-                , subq_10.customer_id__ds_partitioned__extract_year
-                , subq_10.customer_id__ds_partitioned__extract_quarter
-                , subq_10.customer_id__ds_partitioned__extract_month
-                , subq_10.customer_id__ds_partitioned__extract_day
-                , subq_10.customer_id__ds_partitioned__extract_dow
-                , subq_10.customer_id__ds_partitioned__extract_doy
-                , subq_10.ds_partitioned__day AS metric_time__day
-                , subq_10.ds_partitioned__week AS metric_time__week
-                , subq_10.ds_partitioned__month AS metric_time__month
-                , subq_10.ds_partitioned__quarter AS metric_time__quarter
-                , subq_10.ds_partitioned__year AS metric_time__year
-                , subq_10.ds_partitioned__extract_year AS metric_time__extract_year
-                , subq_10.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                , subq_10.ds_partitioned__extract_month AS metric_time__extract_month
-                , subq_10.ds_partitioned__extract_day AS metric_time__extract_day
-                , subq_10.ds_partitioned__extract_dow AS metric_time__extract_dow
-                , subq_10.ds_partitioned__extract_doy AS metric_time__extract_doy
-                , subq_10.customer_id
-                , subq_10.customer_name
-                , subq_10.customer_atomic_weight
-                , subq_10.customer_id__customer_name
-                , subq_10.customer_id__customer_atomic_weight
-                , subq_10.customers
+                subq_5.ds_partitioned__day
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.ds_partitioned__extract_year
+                , subq_5.ds_partitioned__extract_quarter
+                , subq_5.ds_partitioned__extract_month
+                , subq_5.ds_partitioned__extract_day
+                , subq_5.ds_partitioned__extract_dow
+                , subq_5.ds_partitioned__extract_doy
+                , subq_5.customer_id__ds_partitioned__day
+                , subq_5.customer_id__ds_partitioned__week
+                , subq_5.customer_id__ds_partitioned__month
+                , subq_5.customer_id__ds_partitioned__quarter
+                , subq_5.customer_id__ds_partitioned__year
+                , subq_5.customer_id__ds_partitioned__extract_year
+                , subq_5.customer_id__ds_partitioned__extract_quarter
+                , subq_5.customer_id__ds_partitioned__extract_month
+                , subq_5.customer_id__ds_partitioned__extract_day
+                , subq_5.customer_id__ds_partitioned__extract_dow
+                , subq_5.customer_id__ds_partitioned__extract_doy
+                , subq_5.ds_partitioned__day AS metric_time__day
+                , subq_5.ds_partitioned__week AS metric_time__week
+                , subq_5.ds_partitioned__month AS metric_time__month
+                , subq_5.ds_partitioned__quarter AS metric_time__quarter
+                , subq_5.ds_partitioned__year AS metric_time__year
+                , subq_5.ds_partitioned__extract_year AS metric_time__extract_year
+                , subq_5.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                , subq_5.ds_partitioned__extract_month AS metric_time__extract_month
+                , subq_5.ds_partitioned__extract_day AS metric_time__extract_day
+                , subq_5.ds_partitioned__extract_dow AS metric_time__extract_dow
+                , subq_5.ds_partitioned__extract_doy AS metric_time__extract_doy
+                , subq_5.customer_id
+                , subq_5.customer_name
+                , subq_5.customer_atomic_weight
+                , subq_5.customer_id__customer_name
+                , subq_5.customer_id__customer_atomic_weight
+                , subq_5.customers
               FROM (
                 -- Read Elements From Semantic Model 'customer_table'
                 SELECT
@@ -487,25 +487,25 @@ FROM (
                   , EXTRACT(doy FROM customer_table_src_22000.ds_partitioned) AS customer_id__ds_partitioned__extract_doy
                   , customer_table_src_22000.customer_id
                 FROM ***************************.customer_table customer_table_src_22000
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_5
+            ) subq_6
+          ) subq_7
           ON
             (
-              subq_9.customer_id = subq_12.customer_id
+              subq_4.customer_id = subq_7.customer_id
             ) AND (
-              subq_9.ds_partitioned__day = subq_12.ds_partitioned__day
+              subq_4.ds_partitioned__day = subq_7.ds_partitioned__day
             )
-        ) subq_13
-      ) subq_14
+        ) subq_8
+      ) subq_9
       ON
         (
-          subq_7.account_id = subq_14.account_id
+          subq_2.account_id = subq_9.account_id
         ) AND (
-          subq_7.ds_partitioned__day = subq_14.ds_partitioned__day
+          subq_2.ds_partitioned__day = subq_9.ds_partitioned__day
         )
-    ) subq_15
-  ) subq_16
+    ) subq_10
+  ) subq_11
   GROUP BY
-    subq_16.account_id__customer_id__customer_name
-) subq_17
+    subq_11.account_id__customer_id__customer_name
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_22.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_32
+) subq_22
 ON
   (
-    account_month_txns_src_22000.account_id = subq_32.account_id
+    account_month_txns_src_22000.account_id = subq_22.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_22.ds_partitioned__day
   )
 GROUP BY
-  subq_32.customer_id__customer_name
+  subq_22.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,221 +1,221 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_9.bookings) AS bookings
-  , MAX(subq_15.listings) AS listings
+  MAX(subq_5.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.bookings
+    subq_4.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_7.bookings) AS bookings
+      SUM(subq_3.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings',]
       SELECT
-        subq_6.bookings
+        subq_2.bookings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_5.ds__day
-          , subq_5.ds__week
-          , subq_5.ds__month
-          , subq_5.ds__quarter
-          , subq_5.ds__year
-          , subq_5.ds__extract_year
-          , subq_5.ds__extract_quarter
-          , subq_5.ds__extract_month
-          , subq_5.ds__extract_day
-          , subq_5.ds__extract_dow
-          , subq_5.ds__extract_doy
-          , subq_5.ds_partitioned__day
-          , subq_5.ds_partitioned__week
-          , subq_5.ds_partitioned__month
-          , subq_5.ds_partitioned__quarter
-          , subq_5.ds_partitioned__year
-          , subq_5.ds_partitioned__extract_year
-          , subq_5.ds_partitioned__extract_quarter
-          , subq_5.ds_partitioned__extract_month
-          , subq_5.ds_partitioned__extract_day
-          , subq_5.ds_partitioned__extract_dow
-          , subq_5.ds_partitioned__extract_doy
-          , subq_5.paid_at__day
-          , subq_5.paid_at__week
-          , subq_5.paid_at__month
-          , subq_5.paid_at__quarter
-          , subq_5.paid_at__year
-          , subq_5.paid_at__extract_year
-          , subq_5.paid_at__extract_quarter
-          , subq_5.paid_at__extract_month
-          , subq_5.paid_at__extract_day
-          , subq_5.paid_at__extract_dow
-          , subq_5.paid_at__extract_doy
-          , subq_5.booking__ds__day
-          , subq_5.booking__ds__week
-          , subq_5.booking__ds__month
-          , subq_5.booking__ds__quarter
-          , subq_5.booking__ds__year
-          , subq_5.booking__ds__extract_year
-          , subq_5.booking__ds__extract_quarter
-          , subq_5.booking__ds__extract_month
-          , subq_5.booking__ds__extract_day
-          , subq_5.booking__ds__extract_dow
-          , subq_5.booking__ds__extract_doy
-          , subq_5.booking__ds_partitioned__day
-          , subq_5.booking__ds_partitioned__week
-          , subq_5.booking__ds_partitioned__month
-          , subq_5.booking__ds_partitioned__quarter
-          , subq_5.booking__ds_partitioned__year
-          , subq_5.booking__ds_partitioned__extract_year
-          , subq_5.booking__ds_partitioned__extract_quarter
-          , subq_5.booking__ds_partitioned__extract_month
-          , subq_5.booking__ds_partitioned__extract_day
-          , subq_5.booking__ds_partitioned__extract_dow
-          , subq_5.booking__ds_partitioned__extract_doy
-          , subq_5.booking__paid_at__day
-          , subq_5.booking__paid_at__week
-          , subq_5.booking__paid_at__month
-          , subq_5.booking__paid_at__quarter
-          , subq_5.booking__paid_at__year
-          , subq_5.booking__paid_at__extract_year
-          , subq_5.booking__paid_at__extract_quarter
-          , subq_5.booking__paid_at__extract_month
-          , subq_5.booking__paid_at__extract_day
-          , subq_5.booking__paid_at__extract_dow
-          , subq_5.booking__paid_at__extract_doy
-          , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
-          , subq_5.listing
-          , subq_5.guest
-          , subq_5.host
-          , subq_5.booking__listing
-          , subq_5.booking__guest
-          , subq_5.booking__host
-          , subq_5.is_instant
-          , subq_5.booking__is_instant
-          , subq_5.bookings
-          , subq_5.instant_bookings
-          , subq_5.booking_value
-          , subq_5.max_booking_value
-          , subq_5.min_booking_value
-          , subq_5.bookers
-          , subq_5.average_booking_value
-          , subq_5.referred_bookings
-          , subq_5.median_booking_value
-          , subq_5.booking_value_p99
-          , subq_5.discrete_booking_value_p99
-          , subq_5.approximate_continuous_booking_value_p99
-          , subq_5.approximate_discrete_booking_value_p99
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds_partitioned__day
+          , subq_1.ds_partitioned__week
+          , subq_1.ds_partitioned__month
+          , subq_1.ds_partitioned__quarter
+          , subq_1.ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy
+          , subq_1.paid_at__day
+          , subq_1.paid_at__week
+          , subq_1.paid_at__month
+          , subq_1.paid_at__quarter
+          , subq_1.paid_at__year
+          , subq_1.paid_at__extract_year
+          , subq_1.paid_at__extract_quarter
+          , subq_1.paid_at__extract_month
+          , subq_1.paid_at__extract_day
+          , subq_1.paid_at__extract_dow
+          , subq_1.paid_at__extract_doy
+          , subq_1.booking__ds__day
+          , subq_1.booking__ds__week
+          , subq_1.booking__ds__month
+          , subq_1.booking__ds__quarter
+          , subq_1.booking__ds__year
+          , subq_1.booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month
+          , subq_1.booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day
+          , subq_1.booking__paid_at__week
+          , subq_1.booking__paid_at__month
+          , subq_1.booking__paid_at__quarter
+          , subq_1.booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy
+          , subq_1.metric_time__day
+          , subq_1.metric_time__week
+          , subq_1.metric_time__month
+          , subq_1.metric_time__quarter
+          , subq_1.metric_time__year
+          , subq_1.metric_time__extract_year
+          , subq_1.metric_time__extract_quarter
+          , subq_1.metric_time__extract_month
+          , subq_1.metric_time__extract_day
+          , subq_1.metric_time__extract_dow
+          , subq_1.metric_time__extract_doy
+          , subq_1.listing
+          , subq_1.guest
+          , subq_1.host
+          , subq_1.booking__listing
+          , subq_1.booking__guest
+          , subq_1.booking__host
+          , subq_1.is_instant
+          , subq_1.booking__is_instant
+          , subq_1.bookings
+          , subq_1.instant_bookings
+          , subq_1.booking_value
+          , subq_1.max_booking_value
+          , subq_1.min_booking_value
+          , subq_1.bookers
+          , subq_1.average_booking_value
+          , subq_1.referred_bookings
+          , subq_1.median_booking_value
+          , subq_1.booking_value_p99
+          , subq_1.discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds__day
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds__extract_year
-            , subq_4.ds__extract_quarter
-            , subq_4.ds__extract_month
-            , subq_4.ds__extract_day
-            , subq_4.ds__extract_dow
-            , subq_4.ds__extract_doy
-            , subq_4.ds_partitioned__day
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.ds_partitioned__extract_year
-            , subq_4.ds_partitioned__extract_quarter
-            , subq_4.ds_partitioned__extract_month
-            , subq_4.ds_partitioned__extract_day
-            , subq_4.ds_partitioned__extract_dow
-            , subq_4.ds_partitioned__extract_doy
-            , subq_4.paid_at__day
-            , subq_4.paid_at__week
-            , subq_4.paid_at__month
-            , subq_4.paid_at__quarter
-            , subq_4.paid_at__year
-            , subq_4.paid_at__extract_year
-            , subq_4.paid_at__extract_quarter
-            , subq_4.paid_at__extract_month
-            , subq_4.paid_at__extract_day
-            , subq_4.paid_at__extract_dow
-            , subq_4.paid_at__extract_doy
-            , subq_4.booking__ds__day
-            , subq_4.booking__ds__week
-            , subq_4.booking__ds__month
-            , subq_4.booking__ds__quarter
-            , subq_4.booking__ds__year
-            , subq_4.booking__ds__extract_year
-            , subq_4.booking__ds__extract_quarter
-            , subq_4.booking__ds__extract_month
-            , subq_4.booking__ds__extract_day
-            , subq_4.booking__ds__extract_dow
-            , subq_4.booking__ds__extract_doy
-            , subq_4.booking__ds_partitioned__day
-            , subq_4.booking__ds_partitioned__week
-            , subq_4.booking__ds_partitioned__month
-            , subq_4.booking__ds_partitioned__quarter
-            , subq_4.booking__ds_partitioned__year
-            , subq_4.booking__ds_partitioned__extract_year
-            , subq_4.booking__ds_partitioned__extract_quarter
-            , subq_4.booking__ds_partitioned__extract_month
-            , subq_4.booking__ds_partitioned__extract_day
-            , subq_4.booking__ds_partitioned__extract_dow
-            , subq_4.booking__ds_partitioned__extract_doy
-            , subq_4.booking__paid_at__day
-            , subq_4.booking__paid_at__week
-            , subq_4.booking__paid_at__month
-            , subq_4.booking__paid_at__quarter
-            , subq_4.booking__paid_at__year
-            , subq_4.booking__paid_at__extract_year
-            , subq_4.booking__paid_at__extract_quarter
-            , subq_4.booking__paid_at__extract_month
-            , subq_4.booking__paid_at__extract_day
-            , subq_4.booking__paid_at__extract_dow
-            , subq_4.booking__paid_at__extract_doy
-            , subq_4.ds__day AS metric_time__day
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.ds__extract_year AS metric_time__extract_year
-            , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_4.ds__extract_month AS metric_time__extract_month
-            , subq_4.ds__extract_day AS metric_time__extract_day
-            , subq_4.ds__extract_dow AS metric_time__extract_dow
-            , subq_4.ds__extract_doy AS metric_time__extract_doy
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.booking__listing
-            , subq_4.booking__guest
-            , subq_4.booking__host
-            , subq_4.is_instant
-            , subq_4.booking__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
-            , subq_4.median_booking_value
-            , subq_4.booking_value_p99
-            , subq_4.discrete_booking_value_p99
-            , subq_4.approximate_continuous_booking_value_p99
-            , subq_4.approximate_discrete_booking_value_p99
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -308,165 +308,165 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_4
-        ) subq_5
-        WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_0
+        ) subq_1
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_2
+    ) subq_3
+  ) subq_4
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_14.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_13.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements: ['listings',]
       SELECT
-        subq_12.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_11.ds__day
-          , subq_11.ds__week
-          , subq_11.ds__month
-          , subq_11.ds__quarter
-          , subq_11.ds__year
-          , subq_11.ds__extract_year
-          , subq_11.ds__extract_quarter
-          , subq_11.ds__extract_month
-          , subq_11.ds__extract_day
-          , subq_11.ds__extract_dow
-          , subq_11.ds__extract_doy
-          , subq_11.created_at__day
-          , subq_11.created_at__week
-          , subq_11.created_at__month
-          , subq_11.created_at__quarter
-          , subq_11.created_at__year
-          , subq_11.created_at__extract_year
-          , subq_11.created_at__extract_quarter
-          , subq_11.created_at__extract_month
-          , subq_11.created_at__extract_day
-          , subq_11.created_at__extract_dow
-          , subq_11.created_at__extract_doy
-          , subq_11.listing__ds__day
-          , subq_11.listing__ds__week
-          , subq_11.listing__ds__month
-          , subq_11.listing__ds__quarter
-          , subq_11.listing__ds__year
-          , subq_11.listing__ds__extract_year
-          , subq_11.listing__ds__extract_quarter
-          , subq_11.listing__ds__extract_month
-          , subq_11.listing__ds__extract_day
-          , subq_11.listing__ds__extract_dow
-          , subq_11.listing__ds__extract_doy
-          , subq_11.listing__created_at__day
-          , subq_11.listing__created_at__week
-          , subq_11.listing__created_at__month
-          , subq_11.listing__created_at__quarter
-          , subq_11.listing__created_at__year
-          , subq_11.listing__created_at__extract_year
-          , subq_11.listing__created_at__extract_quarter
-          , subq_11.listing__created_at__extract_month
-          , subq_11.listing__created_at__extract_day
-          , subq_11.listing__created_at__extract_dow
-          , subq_11.listing__created_at__extract_doy
-          , subq_11.metric_time__day
-          , subq_11.metric_time__week
-          , subq_11.metric_time__month
-          , subq_11.metric_time__quarter
-          , subq_11.metric_time__year
-          , subq_11.metric_time__extract_year
-          , subq_11.metric_time__extract_quarter
-          , subq_11.metric_time__extract_month
-          , subq_11.metric_time__extract_day
-          , subq_11.metric_time__extract_dow
-          , subq_11.metric_time__extract_doy
-          , subq_11.listing
-          , subq_11.user
-          , subq_11.listing__user
-          , subq_11.country_latest
-          , subq_11.is_lux_latest
-          , subq_11.capacity_latest
-          , subq_11.listing__country_latest
-          , subq_11.listing__is_lux_latest
-          , subq_11.listing__capacity_latest
-          , subq_11.listings
-          , subq_11.largest_listing
-          , subq_11.smallest_listing
+          subq_7.ds__day
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.ds__extract_year
+          , subq_7.ds__extract_quarter
+          , subq_7.ds__extract_month
+          , subq_7.ds__extract_day
+          , subq_7.ds__extract_dow
+          , subq_7.ds__extract_doy
+          , subq_7.created_at__day
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.created_at__extract_year
+          , subq_7.created_at__extract_quarter
+          , subq_7.created_at__extract_month
+          , subq_7.created_at__extract_day
+          , subq_7.created_at__extract_dow
+          , subq_7.created_at__extract_doy
+          , subq_7.listing__ds__day
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__ds__extract_year
+          , subq_7.listing__ds__extract_quarter
+          , subq_7.listing__ds__extract_month
+          , subq_7.listing__ds__extract_day
+          , subq_7.listing__ds__extract_dow
+          , subq_7.listing__ds__extract_doy
+          , subq_7.listing__created_at__day
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.listing__created_at__extract_year
+          , subq_7.listing__created_at__extract_quarter
+          , subq_7.listing__created_at__extract_month
+          , subq_7.listing__created_at__extract_day
+          , subq_7.listing__created_at__extract_dow
+          , subq_7.listing__created_at__extract_doy
+          , subq_7.metric_time__day
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.created_at__day
-            , subq_10.created_at__week
-            , subq_10.created_at__month
-            , subq_10.created_at__quarter
-            , subq_10.created_at__year
-            , subq_10.created_at__extract_year
-            , subq_10.created_at__extract_quarter
-            , subq_10.created_at__extract_month
-            , subq_10.created_at__extract_day
-            , subq_10.created_at__extract_dow
-            , subq_10.created_at__extract_doy
-            , subq_10.listing__ds__day
-            , subq_10.listing__ds__week
-            , subq_10.listing__ds__month
-            , subq_10.listing__ds__quarter
-            , subq_10.listing__ds__year
-            , subq_10.listing__ds__extract_year
-            , subq_10.listing__ds__extract_quarter
-            , subq_10.listing__ds__extract_month
-            , subq_10.listing__ds__extract_day
-            , subq_10.listing__ds__extract_dow
-            , subq_10.listing__ds__extract_doy
-            , subq_10.listing__created_at__day
-            , subq_10.listing__created_at__week
-            , subq_10.listing__created_at__month
-            , subq_10.listing__created_at__quarter
-            , subq_10.listing__created_at__year
-            , subq_10.listing__created_at__extract_year
-            , subq_10.listing__created_at__extract_quarter
-            , subq_10.listing__created_at__extract_month
-            , subq_10.listing__created_at__extract_day
-            , subq_10.listing__created_at__extract_dow
-            , subq_10.listing__created_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.user
-            , subq_10.listing__user
-            , subq_10.country_latest
-            , subq_10.is_lux_latest
-            , subq_10.capacity_latest
-            , subq_10.listing__country_latest
-            , subq_10.listing__is_lux_latest
-            , subq_10.listing__capacity_latest
-            , subq_10.listings
-            , subq_10.largest_listing
-            , subq_10.smallest_listing
+            subq_6.ds__day
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds__extract_year
+            , subq_6.ds__extract_quarter
+            , subq_6.ds__extract_month
+            , subq_6.ds__extract_day
+            , subq_6.ds__extract_dow
+            , subq_6.ds__extract_doy
+            , subq_6.created_at__day
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.created_at__extract_year
+            , subq_6.created_at__extract_quarter
+            , subq_6.created_at__extract_month
+            , subq_6.created_at__extract_day
+            , subq_6.created_at__extract_dow
+            , subq_6.created_at__extract_doy
+            , subq_6.listing__ds__day
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__ds__extract_year
+            , subq_6.listing__ds__extract_quarter
+            , subq_6.listing__ds__extract_month
+            , subq_6.listing__ds__extract_day
+            , subq_6.listing__ds__extract_dow
+            , subq_6.listing__ds__extract_doy
+            , subq_6.listing__created_at__day
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.listing__created_at__extract_year
+            , subq_6.listing__created_at__extract_quarter
+            , subq_6.listing__created_at__extract_month
+            , subq_6.listing__created_at__extract_day
+            , subq_6.listing__created_at__extract_dow
+            , subq_6.listing__created_at__extract_doy
+            , subq_6.ds__day AS metric_time__day
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.ds__extract_year AS metric_time__extract_year
+            , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_6.ds__extract_month AS metric_time__extract_month
+            , subq_6.ds__extract_day AS metric_time__extract_day
+            , subq_6.ds__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__extract_doy AS metric_time__extract_doy
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -527,10 +527,10 @@ CROSS JOIN (
               , listings_latest_src_28000.user_id AS user
               , listings_latest_src_28000.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_28000
-          ) subq_10
-        ) subq_11
-        WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_12
-    ) subq_13
-  ) subq_14
-) subq_15
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_8
+    ) subq_9
+  ) subq_10
+) subq_11

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_25.bookings) AS bookings
-  , MAX(subq_31.listings) AS listings
+  MAX(subq_17.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_25
+) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_31
+) subq_23

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_15.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_13.metric_time__day
+  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_14.booking_value) AS booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_12.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.booking_value AS booking_value_with_is_instant_constraint
+      subq_6.metric_time__day
+      , subq_6.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , SUM(subq_7.booking_value) AS booking_value
+        subq_5.metric_time__day
+        , SUM(subq_5.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.booking_value
+          subq_4.metric_time__day
+          , subq_4.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.booking_value
+      subq_11.metric_time__day
+      , subq_11.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , SUM(subq_12.booking_value) AS booking_value
+        subq_10.metric_time__day
+        , SUM(subq_10.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.booking_value
+          subq_9.metric_time__day
+          , subq_9.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_30.booking_value) AS booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_26.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
+  subq_7.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.metric_time__day
-    , subq_8.bookings AS delayed_bookings
+    subq_6.metric_time__day
+    , subq_6.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -323,15 +323,15 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE NOT booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE NOT booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
-) subq_9
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_9
     WHERE NOT booking__is_instant
-  ) subq_15
+  ) subq_11
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_19
+) subq_15

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.listing__user__home_state_latest
-  , subq_21.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__user__home_state_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-    , SUM(subq_20.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__user__home_state_latest', 'metric_time__day']
     SELECT
-      subq_19.metric_time__day
-      , subq_19.listing__user__home_state_latest
-      , subq_19.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__user__home_state_latest
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_13.metric_time__day AS metric_time__day
-        , subq_18.window_start__day AS listing__window_start__day
-        , subq_18.window_end__day AS listing__window_end__day
-        , subq_13.listing AS listing
-        , subq_18.user__home_state_latest AS listing__user__home_state_latest
-        , subq_13.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.window_start__day AS listing__window_start__day
+        , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.user__home_state_latest AS listing__user__home_state_latest
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_12.metric_time__day
-          , subq_12.listing
-          , subq_12.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds__day
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds__extract_year
-            , subq_11.ds__extract_quarter
-            , subq_11.ds__extract_month
-            , subq_11.ds__extract_day
-            , subq_11.ds__extract_dow
-            , subq_11.ds__extract_doy
-            , subq_11.ds_partitioned__day
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.ds_partitioned__extract_year
-            , subq_11.ds_partitioned__extract_quarter
-            , subq_11.ds_partitioned__extract_month
-            , subq_11.ds_partitioned__extract_day
-            , subq_11.ds_partitioned__extract_dow
-            , subq_11.ds_partitioned__extract_doy
-            , subq_11.paid_at__day
-            , subq_11.paid_at__week
-            , subq_11.paid_at__month
-            , subq_11.paid_at__quarter
-            , subq_11.paid_at__year
-            , subq_11.paid_at__extract_year
-            , subq_11.paid_at__extract_quarter
-            , subq_11.paid_at__extract_month
-            , subq_11.paid_at__extract_day
-            , subq_11.paid_at__extract_dow
-            , subq_11.paid_at__extract_doy
-            , subq_11.booking__ds__day
-            , subq_11.booking__ds__week
-            , subq_11.booking__ds__month
-            , subq_11.booking__ds__quarter
-            , subq_11.booking__ds__year
-            , subq_11.booking__ds__extract_year
-            , subq_11.booking__ds__extract_quarter
-            , subq_11.booking__ds__extract_month
-            , subq_11.booking__ds__extract_day
-            , subq_11.booking__ds__extract_dow
-            , subq_11.booking__ds__extract_doy
-            , subq_11.booking__ds_partitioned__day
-            , subq_11.booking__ds_partitioned__week
-            , subq_11.booking__ds_partitioned__month
-            , subq_11.booking__ds_partitioned__quarter
-            , subq_11.booking__ds_partitioned__year
-            , subq_11.booking__ds_partitioned__extract_year
-            , subq_11.booking__ds_partitioned__extract_quarter
-            , subq_11.booking__ds_partitioned__extract_month
-            , subq_11.booking__ds_partitioned__extract_day
-            , subq_11.booking__ds_partitioned__extract_dow
-            , subq_11.booking__ds_partitioned__extract_doy
-            , subq_11.booking__paid_at__day
-            , subq_11.booking__paid_at__week
-            , subq_11.booking__paid_at__month
-            , subq_11.booking__paid_at__quarter
-            , subq_11.booking__paid_at__year
-            , subq_11.booking__paid_at__extract_year
-            , subq_11.booking__paid_at__extract_quarter
-            , subq_11.booking__paid_at__extract_month
-            , subq_11.booking__paid_at__extract_day
-            , subq_11.booking__paid_at__extract_dow
-            , subq_11.booking__paid_at__extract_doy
-            , subq_11.ds__day AS metric_time__day
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.ds__extract_year AS metric_time__extract_year
-            , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_11.ds__extract_month AS metric_time__extract_month
-            , subq_11.ds__extract_day AS metric_time__extract_day
-            , subq_11.ds__extract_dow AS metric_time__extract_dow
-            , subq_11.ds__extract_doy AS metric_time__extract_doy
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.user
-            , subq_11.booking__listing
-            , subq_11.booking__guest
-            , subq_11.booking__host
-            , subq_11.booking__user
-            , subq_11.is_instant
-            , subq_11.booking__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,84 +211,84 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
         SELECT
-          subq_17.window_start__day
-          , subq_17.window_end__day
-          , subq_17.listing
-          , subq_17.user__home_state_latest
+          subq_6.window_start__day
+          , subq_6.window_end__day
+          , subq_6.listing
+          , subq_6.user__home_state_latest
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.window_start__day AS window_start__day
-            , subq_14.window_start__week AS window_start__week
-            , subq_14.window_start__month AS window_start__month
-            , subq_14.window_start__quarter AS window_start__quarter
-            , subq_14.window_start__year AS window_start__year
-            , subq_14.window_start__extract_year AS window_start__extract_year
-            , subq_14.window_start__extract_quarter AS window_start__extract_quarter
-            , subq_14.window_start__extract_month AS window_start__extract_month
-            , subq_14.window_start__extract_day AS window_start__extract_day
-            , subq_14.window_start__extract_dow AS window_start__extract_dow
-            , subq_14.window_start__extract_doy AS window_start__extract_doy
-            , subq_14.window_end__day AS window_end__day
-            , subq_14.window_end__week AS window_end__week
-            , subq_14.window_end__month AS window_end__month
-            , subq_14.window_end__quarter AS window_end__quarter
-            , subq_14.window_end__year AS window_end__year
-            , subq_14.window_end__extract_year AS window_end__extract_year
-            , subq_14.window_end__extract_quarter AS window_end__extract_quarter
-            , subq_14.window_end__extract_month AS window_end__extract_month
-            , subq_14.window_end__extract_day AS window_end__extract_day
-            , subq_14.window_end__extract_dow AS window_end__extract_dow
-            , subq_14.window_end__extract_doy AS window_end__extract_doy
-            , subq_14.listing__window_start__day AS listing__window_start__day
-            , subq_14.listing__window_start__week AS listing__window_start__week
-            , subq_14.listing__window_start__month AS listing__window_start__month
-            , subq_14.listing__window_start__quarter AS listing__window_start__quarter
-            , subq_14.listing__window_start__year AS listing__window_start__year
-            , subq_14.listing__window_start__extract_year AS listing__window_start__extract_year
-            , subq_14.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
-            , subq_14.listing__window_start__extract_month AS listing__window_start__extract_month
-            , subq_14.listing__window_start__extract_day AS listing__window_start__extract_day
-            , subq_14.listing__window_start__extract_dow AS listing__window_start__extract_dow
-            , subq_14.listing__window_start__extract_doy AS listing__window_start__extract_doy
-            , subq_14.listing__window_end__day AS listing__window_end__day
-            , subq_14.listing__window_end__week AS listing__window_end__week
-            , subq_14.listing__window_end__month AS listing__window_end__month
-            , subq_14.listing__window_end__quarter AS listing__window_end__quarter
-            , subq_14.listing__window_end__year AS listing__window_end__year
-            , subq_14.listing__window_end__extract_year AS listing__window_end__extract_year
-            , subq_14.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
-            , subq_14.listing__window_end__extract_month AS listing__window_end__extract_month
-            , subq_14.listing__window_end__extract_day AS listing__window_end__extract_day
-            , subq_14.listing__window_end__extract_dow AS listing__window_end__extract_dow
-            , subq_14.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_16.ds__day AS user__ds__day
-            , subq_16.ds__week AS user__ds__week
-            , subq_16.ds__month AS user__ds__month
-            , subq_16.ds__quarter AS user__ds__quarter
-            , subq_16.ds__year AS user__ds__year
-            , subq_16.ds__extract_year AS user__ds__extract_year
-            , subq_16.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_16.ds__extract_month AS user__ds__extract_month
-            , subq_16.ds__extract_day AS user__ds__extract_day
-            , subq_16.ds__extract_dow AS user__ds__extract_dow
-            , subq_16.ds__extract_doy AS user__ds__extract_doy
-            , subq_14.listing AS listing
-            , subq_14.user AS user
-            , subq_14.listing__user AS listing__user
-            , subq_14.country AS country
-            , subq_14.is_lux AS is_lux
-            , subq_14.capacity AS capacity
-            , subq_14.listing__country AS listing__country
-            , subq_14.listing__is_lux AS listing__is_lux
-            , subq_14.listing__capacity AS listing__capacity
-            , subq_16.home_state_latest AS user__home_state_latest
+            subq_3.window_start__day AS window_start__day
+            , subq_3.window_start__week AS window_start__week
+            , subq_3.window_start__month AS window_start__month
+            , subq_3.window_start__quarter AS window_start__quarter
+            , subq_3.window_start__year AS window_start__year
+            , subq_3.window_start__extract_year AS window_start__extract_year
+            , subq_3.window_start__extract_quarter AS window_start__extract_quarter
+            , subq_3.window_start__extract_month AS window_start__extract_month
+            , subq_3.window_start__extract_day AS window_start__extract_day
+            , subq_3.window_start__extract_dow AS window_start__extract_dow
+            , subq_3.window_start__extract_doy AS window_start__extract_doy
+            , subq_3.window_end__day AS window_end__day
+            , subq_3.window_end__week AS window_end__week
+            , subq_3.window_end__month AS window_end__month
+            , subq_3.window_end__quarter AS window_end__quarter
+            , subq_3.window_end__year AS window_end__year
+            , subq_3.window_end__extract_year AS window_end__extract_year
+            , subq_3.window_end__extract_quarter AS window_end__extract_quarter
+            , subq_3.window_end__extract_month AS window_end__extract_month
+            , subq_3.window_end__extract_day AS window_end__extract_day
+            , subq_3.window_end__extract_dow AS window_end__extract_dow
+            , subq_3.window_end__extract_doy AS window_end__extract_doy
+            , subq_3.listing__window_start__day AS listing__window_start__day
+            , subq_3.listing__window_start__week AS listing__window_start__week
+            , subq_3.listing__window_start__month AS listing__window_start__month
+            , subq_3.listing__window_start__quarter AS listing__window_start__quarter
+            , subq_3.listing__window_start__year AS listing__window_start__year
+            , subq_3.listing__window_start__extract_year AS listing__window_start__extract_year
+            , subq_3.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+            , subq_3.listing__window_start__extract_month AS listing__window_start__extract_month
+            , subq_3.listing__window_start__extract_day AS listing__window_start__extract_day
+            , subq_3.listing__window_start__extract_dow AS listing__window_start__extract_dow
+            , subq_3.listing__window_start__extract_doy AS listing__window_start__extract_doy
+            , subq_3.listing__window_end__day AS listing__window_end__day
+            , subq_3.listing__window_end__week AS listing__window_end__week
+            , subq_3.listing__window_end__month AS listing__window_end__month
+            , subq_3.listing__window_end__quarter AS listing__window_end__quarter
+            , subq_3.listing__window_end__year AS listing__window_end__year
+            , subq_3.listing__window_end__extract_year AS listing__window_end__extract_year
+            , subq_3.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+            , subq_3.listing__window_end__extract_month AS listing__window_end__extract_month
+            , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
+            , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
+            , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.user AS user
+            , subq_3.listing__user AS listing__user
+            , subq_3.country AS country
+            , subq_3.is_lux AS is_lux
+            , subq_3.capacity AS capacity
+            , subq_3.listing__country AS listing__country
+            , subq_3.listing__is_lux AS listing__is_lux
+            , subq_3.listing__capacity AS listing__capacity
+            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT
@@ -346,7 +346,7 @@ FROM (
               , listings_src_26000.user_id AS user
               , listings_src_26000.user_id AS listing__user
             FROM ***************************.dim_listings listings_src_26000
-          ) subq_14
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'home_state_latest',
@@ -376,31 +376,31 @@ FROM (
             --   'user',
             -- ]
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.user__ds__day
-              , subq_15.user__ds__week
-              , subq_15.user__ds__month
-              , subq_15.user__ds__quarter
-              , subq_15.user__ds__year
-              , subq_15.user__ds__extract_year
-              , subq_15.user__ds__extract_quarter
-              , subq_15.user__ds__extract_month
-              , subq_15.user__ds__extract_day
-              , subq_15.user__ds__extract_dow
-              , subq_15.user__ds__extract_doy
-              , subq_15.user
-              , subq_15.home_state_latest
-              , subq_15.user__home_state_latest
+              subq_4.ds__day
+              , subq_4.ds__week
+              , subq_4.ds__month
+              , subq_4.ds__quarter
+              , subq_4.ds__year
+              , subq_4.ds__extract_year
+              , subq_4.ds__extract_quarter
+              , subq_4.ds__extract_month
+              , subq_4.ds__extract_day
+              , subq_4.ds__extract_dow
+              , subq_4.ds__extract_doy
+              , subq_4.user__ds__day
+              , subq_4.user__ds__week
+              , subq_4.user__ds__month
+              , subq_4.user__ds__quarter
+              , subq_4.user__ds__year
+              , subq_4.user__ds__extract_year
+              , subq_4.user__ds__extract_quarter
+              , subq_4.user__ds__extract_month
+              , subq_4.user__ds__extract_day
+              , subq_4.user__ds__extract_dow
+              , subq_4.user__ds__extract_doy
+              , subq_4.user
+              , subq_4.home_state_latest
+              , subq_4.user__home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -430,29 +430,29 @@ FROM (
                 , users_latest_src_26000.home_state_latest AS user__home_state_latest
                 , users_latest_src_26000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_26000
-            ) subq_15
-          ) subq_16
+            ) subq_4
+          ) subq_5
           ON
-            subq_14.user = subq_16.user
-        ) subq_17
-      ) subq_18
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_13.listing = subq_18.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_13.metric_time__day >= subq_18.window_start__day
+            subq_2.metric_time__day >= subq_7.window_start__day
           ) AND (
             (
-              subq_13.metric_time__day < subq_18.window_end__day
+              subq_2.metric_time__day < subq_7.window_end__day
             ) OR (
-              subq_18.window_end__day IS NULL
+              subq_7.window_end__day IS NULL
             )
           )
         )
-    ) subq_19
-  ) subq_20
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-) subq_21
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_35.metric_time__day AS metric_time__day
-  , subq_40.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_35.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_35
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_40
+) subq_18
 ON
   (
-    subq_35.listing = subq_40.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_35.metric_time__day >= subq_40.window_start__day
+      subq_13.metric_time__day >= subq_18.window_start__day
     ) AND (
       (
-        subq_35.metric_time__day < subq_40.window_end__day
+        subq_13.metric_time__day < subq_18.window_end__day
       ) OR (
-        subq_40.window_end__day IS NULL
+        subq_18.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_35.metric_time__day
-  , subq_40.user__home_state_latest
+  subq_13.metric_time__day
+  , subq_18.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , subq_13.listing__lux_listing__is_confirmed_lux
-  , subq_13.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__lux_listing__is_confirmed_lux
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-    , SUM(subq_12.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__lux_listing__is_confirmed_lux', 'metric_time__day']
     SELECT
-      subq_11.metric_time__day
-      , subq_11.listing__lux_listing__is_confirmed_lux
-      , subq_11.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__lux_listing__is_confirmed_lux
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_5.metric_time__day AS metric_time__day
-        , subq_10.lux_listing__window_start__day AS listing__lux_listing__window_start__day
-        , subq_10.lux_listing__window_end__day AS listing__lux_listing__window_end__day
-        , subq_5.listing AS listing
-        , subq_10.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-        , subq_5.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
+        , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.listing
-          , subq_4.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.ds__day AS metric_time__day
-            , subq_3.ds__week AS metric_time__week
-            , subq_3.ds__month AS metric_time__month
-            , subq_3.ds__quarter AS metric_time__quarter
-            , subq_3.ds__year AS metric_time__year
-            , subq_3.ds__extract_year AS metric_time__extract_year
-            , subq_3.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_3.ds__extract_month AS metric_time__extract_month
-            , subq_3.ds__extract_day AS metric_time__extract_day
-            , subq_3.ds__extract_dow AS metric_time__extract_dow
-            , subq_3.ds__extract_doy AS metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.user
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.booking__user
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,45 +211,45 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_3
-        ) subq_4
-      ) subq_5
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
         SELECT
-          subq_9.lux_listing__window_start__day
-          , subq_9.lux_listing__window_end__day
-          , subq_9.listing
-          , subq_9.lux_listing__is_confirmed_lux
+          subq_6.lux_listing__window_start__day
+          , subq_6.lux_listing__window_end__day
+          , subq_6.listing
+          , subq_6.lux_listing__is_confirmed_lux
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_8.window_start__day AS lux_listing__window_start__day
-            , subq_8.window_start__week AS lux_listing__window_start__week
-            , subq_8.window_start__month AS lux_listing__window_start__month
-            , subq_8.window_start__quarter AS lux_listing__window_start__quarter
-            , subq_8.window_start__year AS lux_listing__window_start__year
-            , subq_8.window_start__extract_year AS lux_listing__window_start__extract_year
-            , subq_8.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
-            , subq_8.window_start__extract_month AS lux_listing__window_start__extract_month
-            , subq_8.window_start__extract_day AS lux_listing__window_start__extract_day
-            , subq_8.window_start__extract_dow AS lux_listing__window_start__extract_dow
-            , subq_8.window_start__extract_doy AS lux_listing__window_start__extract_doy
-            , subq_8.window_end__day AS lux_listing__window_end__day
-            , subq_8.window_end__week AS lux_listing__window_end__week
-            , subq_8.window_end__month AS lux_listing__window_end__month
-            , subq_8.window_end__quarter AS lux_listing__window_end__quarter
-            , subq_8.window_end__year AS lux_listing__window_end__year
-            , subq_8.window_end__extract_year AS lux_listing__window_end__extract_year
-            , subq_8.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
-            , subq_8.window_end__extract_month AS lux_listing__window_end__extract_month
-            , subq_8.window_end__extract_day AS lux_listing__window_end__extract_day
-            , subq_8.window_end__extract_dow AS lux_listing__window_end__extract_dow
-            , subq_8.window_end__extract_doy AS lux_listing__window_end__extract_doy
-            , subq_6.listing AS listing
-            , subq_6.lux_listing AS lux_listing
-            , subq_6.listing__lux_listing AS listing__lux_listing
-            , subq_8.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            subq_5.window_start__day AS lux_listing__window_start__day
+            , subq_5.window_start__week AS lux_listing__window_start__week
+            , subq_5.window_start__month AS lux_listing__window_start__month
+            , subq_5.window_start__quarter AS lux_listing__window_start__quarter
+            , subq_5.window_start__year AS lux_listing__window_start__year
+            , subq_5.window_start__extract_year AS lux_listing__window_start__extract_year
+            , subq_5.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
+            , subq_5.window_start__extract_month AS lux_listing__window_start__extract_month
+            , subq_5.window_start__extract_day AS lux_listing__window_start__extract_day
+            , subq_5.window_start__extract_dow AS lux_listing__window_start__extract_dow
+            , subq_5.window_start__extract_doy AS lux_listing__window_start__extract_doy
+            , subq_5.window_end__day AS lux_listing__window_end__day
+            , subq_5.window_end__week AS lux_listing__window_end__week
+            , subq_5.window_end__month AS lux_listing__window_end__month
+            , subq_5.window_end__quarter AS lux_listing__window_end__quarter
+            , subq_5.window_end__year AS lux_listing__window_end__year
+            , subq_5.window_end__extract_year AS lux_listing__window_end__extract_year
+            , subq_5.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
+            , subq_5.window_end__extract_month AS lux_listing__window_end__extract_month
+            , subq_5.window_end__extract_day AS lux_listing__window_end__extract_day
+            , subq_5.window_end__extract_dow AS lux_listing__window_end__extract_dow
+            , subq_5.window_end__extract_doy AS lux_listing__window_end__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.lux_listing AS lux_listing
+            , subq_3.listing__lux_listing AS listing__lux_listing
+            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT
@@ -257,7 +257,7 @@ FROM (
               , lux_listing_mapping_src_26000.lux_listing_id AS lux_listing
               , lux_listing_mapping_src_26000.lux_listing_id AS listing__lux_listing
             FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_26000
-          ) subq_6
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'is_confirmed_lux',
@@ -309,53 +309,53 @@ FROM (
             --   'lux_listing',
             -- ]
             SELECT
-              subq_7.window_start__day
-              , subq_7.window_start__week
-              , subq_7.window_start__month
-              , subq_7.window_start__quarter
-              , subq_7.window_start__year
-              , subq_7.window_start__extract_year
-              , subq_7.window_start__extract_quarter
-              , subq_7.window_start__extract_month
-              , subq_7.window_start__extract_day
-              , subq_7.window_start__extract_dow
-              , subq_7.window_start__extract_doy
-              , subq_7.window_end__day
-              , subq_7.window_end__week
-              , subq_7.window_end__month
-              , subq_7.window_end__quarter
-              , subq_7.window_end__year
-              , subq_7.window_end__extract_year
-              , subq_7.window_end__extract_quarter
-              , subq_7.window_end__extract_month
-              , subq_7.window_end__extract_day
-              , subq_7.window_end__extract_dow
-              , subq_7.window_end__extract_doy
-              , subq_7.lux_listing__window_start__day
-              , subq_7.lux_listing__window_start__week
-              , subq_7.lux_listing__window_start__month
-              , subq_7.lux_listing__window_start__quarter
-              , subq_7.lux_listing__window_start__year
-              , subq_7.lux_listing__window_start__extract_year
-              , subq_7.lux_listing__window_start__extract_quarter
-              , subq_7.lux_listing__window_start__extract_month
-              , subq_7.lux_listing__window_start__extract_day
-              , subq_7.lux_listing__window_start__extract_dow
-              , subq_7.lux_listing__window_start__extract_doy
-              , subq_7.lux_listing__window_end__day
-              , subq_7.lux_listing__window_end__week
-              , subq_7.lux_listing__window_end__month
-              , subq_7.lux_listing__window_end__quarter
-              , subq_7.lux_listing__window_end__year
-              , subq_7.lux_listing__window_end__extract_year
-              , subq_7.lux_listing__window_end__extract_quarter
-              , subq_7.lux_listing__window_end__extract_month
-              , subq_7.lux_listing__window_end__extract_day
-              , subq_7.lux_listing__window_end__extract_dow
-              , subq_7.lux_listing__window_end__extract_doy
-              , subq_7.lux_listing
-              , subq_7.is_confirmed_lux
-              , subq_7.lux_listing__is_confirmed_lux
+              subq_4.window_start__day
+              , subq_4.window_start__week
+              , subq_4.window_start__month
+              , subq_4.window_start__quarter
+              , subq_4.window_start__year
+              , subq_4.window_start__extract_year
+              , subq_4.window_start__extract_quarter
+              , subq_4.window_start__extract_month
+              , subq_4.window_start__extract_day
+              , subq_4.window_start__extract_dow
+              , subq_4.window_start__extract_doy
+              , subq_4.window_end__day
+              , subq_4.window_end__week
+              , subq_4.window_end__month
+              , subq_4.window_end__quarter
+              , subq_4.window_end__year
+              , subq_4.window_end__extract_year
+              , subq_4.window_end__extract_quarter
+              , subq_4.window_end__extract_month
+              , subq_4.window_end__extract_day
+              , subq_4.window_end__extract_dow
+              , subq_4.window_end__extract_doy
+              , subq_4.lux_listing__window_start__day
+              , subq_4.lux_listing__window_start__week
+              , subq_4.lux_listing__window_start__month
+              , subq_4.lux_listing__window_start__quarter
+              , subq_4.lux_listing__window_start__year
+              , subq_4.lux_listing__window_start__extract_year
+              , subq_4.lux_listing__window_start__extract_quarter
+              , subq_4.lux_listing__window_start__extract_month
+              , subq_4.lux_listing__window_start__extract_day
+              , subq_4.lux_listing__window_start__extract_dow
+              , subq_4.lux_listing__window_start__extract_doy
+              , subq_4.lux_listing__window_end__day
+              , subq_4.lux_listing__window_end__week
+              , subq_4.lux_listing__window_end__month
+              , subq_4.lux_listing__window_end__quarter
+              , subq_4.lux_listing__window_end__year
+              , subq_4.lux_listing__window_end__extract_year
+              , subq_4.lux_listing__window_end__extract_quarter
+              , subq_4.lux_listing__window_end__extract_month
+              , subq_4.lux_listing__window_end__extract_day
+              , subq_4.lux_listing__window_end__extract_dow
+              , subq_4.lux_listing__window_end__extract_doy
+              , subq_4.lux_listing
+              , subq_4.is_confirmed_lux
+              , subq_4.lux_listing__is_confirmed_lux
             FROM (
               -- Read Elements From Semantic Model 'lux_listings'
               SELECT
@@ -407,29 +407,29 @@ FROM (
                 , lux_listings_src_26000.is_confirmed_lux AS lux_listing__is_confirmed_lux
                 , lux_listings_src_26000.lux_listing_id AS lux_listing
               FROM ***************************.dim_lux_listings lux_listings_src_26000
-            ) subq_7
-          ) subq_8
+            ) subq_4
+          ) subq_5
           ON
-            subq_6.lux_listing = subq_8.lux_listing
-        ) subq_9
-      ) subq_10
+            subq_3.lux_listing = subq_5.lux_listing
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_5.listing = subq_10.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_5.metric_time__day >= subq_10.lux_listing__window_start__day
+            subq_2.metric_time__day >= subq_7.lux_listing__window_start__day
           ) AND (
             (
-              subq_5.metric_time__day < subq_10.lux_listing__window_end__day
+              subq_2.metric_time__day < subq_7.lux_listing__window_end__day
             ) OR (
-              subq_10.lux_listing__window_end__day IS NULL
+              subq_7.lux_listing__window_end__day IS NULL
             )
           )
         )
-    ) subq_11
-  ) subq_12
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-) subq_13
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time__day AS metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_19.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_19
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_24
+) subq_18
 ON
   (
-    subq_19.listing = subq_24.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
+      subq_13.metric_time__day >= subq_18.lux_listing__window_start__day
     ) AND (
       (
-        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
+        subq_13.metric_time__day < subq_18.lux_listing__window_end__day
       ) OR (
-        subq_24.lux_listing__window_end__day IS NULL
+        subq_18.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_19.metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux
+  subq_13.metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0.sql
@@ -1,93 +1,93 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.account_id__customer_id__customer_name
-  , subq_17.txn_count
+  subq_12.account_id__customer_id__customer_name
+  , subq_12.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.account_id__customer_id__customer_name
-    , SUM(subq_16.txn_count) AS txn_count
+    subq_11.account_id__customer_id__customer_name
+    , SUM(subq_11.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_15.account_id__customer_id__customer_name
-      , subq_15.txn_count
+      subq_10.account_id__customer_id__customer_name
+      , subq_10.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_7.ds_partitioned__day AS ds_partitioned__day
-        , subq_14.ds_partitioned__day AS account_id__ds_partitioned__day
-        , subq_7.account_id AS account_id
-        , subq_14.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_7.txn_count AS txn_count
+        subq_2.ds_partitioned__day AS ds_partitioned__day
+        , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.account_id AS account_id
+        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_6.ds_partitioned__day
-          , subq_6.account_id
-          , subq_6.txn_count
+          subq_1.ds_partitioned__day
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds_partitioned__day
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.ds_partitioned__extract_year
-            , subq_5.ds_partitioned__extract_quarter
-            , subq_5.ds_partitioned__extract_month
-            , subq_5.ds_partitioned__extract_day
-            , subq_5.ds_partitioned__extract_dow
-            , subq_5.ds_partitioned__extract_doy
-            , subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.account_id__ds_partitioned__day
-            , subq_5.account_id__ds_partitioned__week
-            , subq_5.account_id__ds_partitioned__month
-            , subq_5.account_id__ds_partitioned__quarter
-            , subq_5.account_id__ds_partitioned__year
-            , subq_5.account_id__ds_partitioned__extract_year
-            , subq_5.account_id__ds_partitioned__extract_quarter
-            , subq_5.account_id__ds_partitioned__extract_month
-            , subq_5.account_id__ds_partitioned__extract_day
-            , subq_5.account_id__ds_partitioned__extract_dow
-            , subq_5.account_id__ds_partitioned__extract_doy
-            , subq_5.account_id__ds__day
-            , subq_5.account_id__ds__week
-            , subq_5.account_id__ds__month
-            , subq_5.account_id__ds__quarter
-            , subq_5.account_id__ds__year
-            , subq_5.account_id__ds__extract_year
-            , subq_5.account_id__ds__extract_quarter
-            , subq_5.account_id__ds__extract_month
-            , subq_5.account_id__ds__extract_day
-            , subq_5.account_id__ds__extract_dow
-            , subq_5.account_id__ds__extract_doy
-            , subq_5.ds__day AS metric_time__day
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.ds__extract_year AS metric_time__extract_year
-            , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_5.ds__extract_month AS metric_time__extract_month
-            , subq_5.ds__extract_day AS metric_time__extract_day
-            , subq_5.ds__extract_dow AS metric_time__extract_dow
-            , subq_5.ds__extract_doy AS metric_time__extract_doy
-            , subq_5.account_id
-            , subq_5.account_month
-            , subq_5.account_id__account_month
-            , subq_5.txn_count
+            subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.account_id__ds_partitioned__day
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds_partitioned__extract_year
+            , subq_0.account_id__ds_partitioned__extract_quarter
+            , subq_0.account_id__ds_partitioned__extract_month
+            , subq_0.account_id__ds_partitioned__extract_day
+            , subq_0.account_id__ds_partitioned__extract_dow
+            , subq_0.account_id__ds_partitioned__extract_doy
+            , subq_0.account_id__ds__day
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.account_id__ds__extract_year
+            , subq_0.account_id__ds__extract_quarter
+            , subq_0.account_id__ds__extract_month
+            , subq_0.account_id__ds__extract_day
+            , subq_0.account_id__ds__extract_dow
+            , subq_0.account_id__ds__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
@@ -140,151 +140,151 @@ FROM (
               , account_month_txns_src_22000.account_month AS account_id__account_month
               , account_month_txns_src_22000.account_id
             FROM ***************************.account_month_txns account_month_txns_src_22000
-          ) subq_5
-        ) subq_6
-      ) subq_7
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_13.ds_partitioned__day
-          , subq_13.account_id
-          , subq_13.customer_id__customer_name
+          subq_8.ds_partitioned__day
+          , subq_8.account_id
+          , subq_8.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_9.ds_partitioned__day AS ds_partitioned__day
-            , subq_9.ds_partitioned__week AS ds_partitioned__week
-            , subq_9.ds_partitioned__month AS ds_partitioned__month
-            , subq_9.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_9.ds_partitioned__year AS ds_partitioned__year
-            , subq_9.ds_partitioned__extract_year AS ds_partitioned__extract_year
-            , subq_9.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-            , subq_9.ds_partitioned__extract_month AS ds_partitioned__extract_month
-            , subq_9.ds_partitioned__extract_day AS ds_partitioned__extract_day
-            , subq_9.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-            , subq_9.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-            , subq_9.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-            , subq_9.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_9.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_9.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_9.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_9.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-            , subq_9.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-            , subq_9.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-            , subq_9.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-            , subq_9.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-            , subq_9.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-            , subq_9.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-            , subq_9.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-            , subq_9.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-            , subq_9.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-            , subq_9.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-            , subq_9.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-            , subq_9.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-            , subq_9.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-            , subq_9.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-            , subq_9.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-            , subq_9.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
-            , subq_9.metric_time__month AS metric_time__month
-            , subq_9.metric_time__quarter AS metric_time__quarter
-            , subq_9.metric_time__year AS metric_time__year
-            , subq_9.metric_time__extract_year AS metric_time__extract_year
-            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_9.metric_time__extract_month AS metric_time__extract_month
-            , subq_9.metric_time__extract_day AS metric_time__extract_day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_12.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_12.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_12.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_12.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_12.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_12.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_12.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_12.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_12.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_12.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_12.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_12.metric_time__day AS customer_id__metric_time__day
-            , subq_12.metric_time__week AS customer_id__metric_time__week
-            , subq_12.metric_time__month AS customer_id__metric_time__month
-            , subq_12.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_12.metric_time__year AS customer_id__metric_time__year
-            , subq_12.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_12.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_12.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_12.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_12.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_12.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-            , subq_9.account_id AS account_id
-            , subq_9.customer_id AS customer_id
-            , subq_9.account_id__customer_id AS account_id__customer_id
-            , subq_9.bridge_account__account_id AS bridge_account__account_id
-            , subq_9.bridge_account__customer_id AS bridge_account__customer_id
-            , subq_9.extra_dim AS extra_dim
-            , subq_9.account_id__extra_dim AS account_id__extra_dim
-            , subq_9.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_12.customer_name AS customer_id__customer_name
-            , subq_12.customer_atomic_weight AS customer_id__customer_atomic_weight
-            , subq_9.account_customer_combos AS account_customer_combos
+            subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_4.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+            , subq_4.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+            , subq_4.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+            , subq_4.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+            , subq_4.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+            , subq_4.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+            , subq_4.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+            , subq_4.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+            , subq_4.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+            , subq_4.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+            , subq_4.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+            , subq_4.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+            , subq_4.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+            , subq_4.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+            , subq_4.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+            , subq_4.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+            , subq_4.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.account_id AS account_id
+            , subq_4.customer_id AS customer_id
+            , subq_4.account_id__customer_id AS account_id__customer_id
+            , subq_4.bridge_account__account_id AS bridge_account__account_id
+            , subq_4.bridge_account__customer_id AS bridge_account__customer_id
+            , subq_4.extra_dim AS extra_dim
+            , subq_4.account_id__extra_dim AS account_id__extra_dim
+            , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
+            , subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'
             SELECT
-              subq_8.ds_partitioned__day
-              , subq_8.ds_partitioned__week
-              , subq_8.ds_partitioned__month
-              , subq_8.ds_partitioned__quarter
-              , subq_8.ds_partitioned__year
-              , subq_8.ds_partitioned__extract_year
-              , subq_8.ds_partitioned__extract_quarter
-              , subq_8.ds_partitioned__extract_month
-              , subq_8.ds_partitioned__extract_day
-              , subq_8.ds_partitioned__extract_dow
-              , subq_8.ds_partitioned__extract_doy
-              , subq_8.account_id__ds_partitioned__day
-              , subq_8.account_id__ds_partitioned__week
-              , subq_8.account_id__ds_partitioned__month
-              , subq_8.account_id__ds_partitioned__quarter
-              , subq_8.account_id__ds_partitioned__year
-              , subq_8.account_id__ds_partitioned__extract_year
-              , subq_8.account_id__ds_partitioned__extract_quarter
-              , subq_8.account_id__ds_partitioned__extract_month
-              , subq_8.account_id__ds_partitioned__extract_day
-              , subq_8.account_id__ds_partitioned__extract_dow
-              , subq_8.account_id__ds_partitioned__extract_doy
-              , subq_8.bridge_account__ds_partitioned__day
-              , subq_8.bridge_account__ds_partitioned__week
-              , subq_8.bridge_account__ds_partitioned__month
-              , subq_8.bridge_account__ds_partitioned__quarter
-              , subq_8.bridge_account__ds_partitioned__year
-              , subq_8.bridge_account__ds_partitioned__extract_year
-              , subq_8.bridge_account__ds_partitioned__extract_quarter
-              , subq_8.bridge_account__ds_partitioned__extract_month
-              , subq_8.bridge_account__ds_partitioned__extract_day
-              , subq_8.bridge_account__ds_partitioned__extract_dow
-              , subq_8.bridge_account__ds_partitioned__extract_doy
-              , subq_8.ds_partitioned__day AS metric_time__day
-              , subq_8.ds_partitioned__week AS metric_time__week
-              , subq_8.ds_partitioned__month AS metric_time__month
-              , subq_8.ds_partitioned__quarter AS metric_time__quarter
-              , subq_8.ds_partitioned__year AS metric_time__year
-              , subq_8.ds_partitioned__extract_year AS metric_time__extract_year
-              , subq_8.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-              , subq_8.ds_partitioned__extract_month AS metric_time__extract_month
-              , subq_8.ds_partitioned__extract_day AS metric_time__extract_day
-              , subq_8.ds_partitioned__extract_dow AS metric_time__extract_dow
-              , subq_8.ds_partitioned__extract_doy AS metric_time__extract_doy
-              , subq_8.account_id
-              , subq_8.customer_id
-              , subq_8.account_id__customer_id
-              , subq_8.bridge_account__account_id
-              , subq_8.bridge_account__customer_id
-              , subq_8.extra_dim
-              , subq_8.account_id__extra_dim
-              , subq_8.bridge_account__extra_dim
-              , subq_8.account_customer_combos
+              subq_3.ds_partitioned__day
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.ds_partitioned__extract_year
+              , subq_3.ds_partitioned__extract_quarter
+              , subq_3.ds_partitioned__extract_month
+              , subq_3.ds_partitioned__extract_day
+              , subq_3.ds_partitioned__extract_dow
+              , subq_3.ds_partitioned__extract_doy
+              , subq_3.account_id__ds_partitioned__day
+              , subq_3.account_id__ds_partitioned__week
+              , subq_3.account_id__ds_partitioned__month
+              , subq_3.account_id__ds_partitioned__quarter
+              , subq_3.account_id__ds_partitioned__year
+              , subq_3.account_id__ds_partitioned__extract_year
+              , subq_3.account_id__ds_partitioned__extract_quarter
+              , subq_3.account_id__ds_partitioned__extract_month
+              , subq_3.account_id__ds_partitioned__extract_day
+              , subq_3.account_id__ds_partitioned__extract_dow
+              , subq_3.account_id__ds_partitioned__extract_doy
+              , subq_3.bridge_account__ds_partitioned__day
+              , subq_3.bridge_account__ds_partitioned__week
+              , subq_3.bridge_account__ds_partitioned__month
+              , subq_3.bridge_account__ds_partitioned__quarter
+              , subq_3.bridge_account__ds_partitioned__year
+              , subq_3.bridge_account__ds_partitioned__extract_year
+              , subq_3.bridge_account__ds_partitioned__extract_quarter
+              , subq_3.bridge_account__ds_partitioned__extract_month
+              , subq_3.bridge_account__ds_partitioned__extract_day
+              , subq_3.bridge_account__ds_partitioned__extract_dow
+              , subq_3.bridge_account__ds_partitioned__extract_doy
+              , subq_3.ds_partitioned__day AS metric_time__day
+              , subq_3.ds_partitioned__week AS metric_time__week
+              , subq_3.ds_partitioned__month AS metric_time__month
+              , subq_3.ds_partitioned__quarter AS metric_time__quarter
+              , subq_3.ds_partitioned__year AS metric_time__year
+              , subq_3.ds_partitioned__extract_year AS metric_time__extract_year
+              , subq_3.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+              , subq_3.ds_partitioned__extract_month AS metric_time__extract_month
+              , subq_3.ds_partitioned__extract_day AS metric_time__extract_day
+              , subq_3.ds_partitioned__extract_dow AS metric_time__extract_dow
+              , subq_3.ds_partitioned__extract_doy AS metric_time__extract_doy
+              , subq_3.account_id
+              , subq_3.customer_id
+              , subq_3.account_id__customer_id
+              , subq_3.bridge_account__account_id
+              , subq_3.bridge_account__customer_id
+              , subq_3.extra_dim
+              , subq_3.account_id__extra_dim
+              , subq_3.bridge_account__extra_dim
+              , subq_3.account_customer_combos
             FROM (
               -- Read Elements From Semantic Model 'bridge_table'
               SELECT
@@ -331,8 +331,8 @@ FROM (
                 , bridge_table_src_22000.account_id AS bridge_account__account_id
                 , bridge_table_src_22000.customer_id AS bridge_account__customer_id
               FROM ***************************.bridge_table bridge_table_src_22000
-            ) subq_8
-          ) subq_9
+            ) subq_3
+          ) subq_4
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'customer_name',
@@ -375,86 +375,86 @@ FROM (
             --   'customer_id',
             -- ]
             SELECT
-              subq_11.ds_partitioned__day
-              , subq_11.ds_partitioned__week
-              , subq_11.ds_partitioned__month
-              , subq_11.ds_partitioned__quarter
-              , subq_11.ds_partitioned__year
-              , subq_11.ds_partitioned__extract_year
-              , subq_11.ds_partitioned__extract_quarter
-              , subq_11.ds_partitioned__extract_month
-              , subq_11.ds_partitioned__extract_day
-              , subq_11.ds_partitioned__extract_dow
-              , subq_11.ds_partitioned__extract_doy
-              , subq_11.customer_id__ds_partitioned__day
-              , subq_11.customer_id__ds_partitioned__week
-              , subq_11.customer_id__ds_partitioned__month
-              , subq_11.customer_id__ds_partitioned__quarter
-              , subq_11.customer_id__ds_partitioned__year
-              , subq_11.customer_id__ds_partitioned__extract_year
-              , subq_11.customer_id__ds_partitioned__extract_quarter
-              , subq_11.customer_id__ds_partitioned__extract_month
-              , subq_11.customer_id__ds_partitioned__extract_day
-              , subq_11.customer_id__ds_partitioned__extract_dow
-              , subq_11.customer_id__ds_partitioned__extract_doy
-              , subq_11.metric_time__day
-              , subq_11.metric_time__week
-              , subq_11.metric_time__month
-              , subq_11.metric_time__quarter
-              , subq_11.metric_time__year
-              , subq_11.metric_time__extract_year
-              , subq_11.metric_time__extract_quarter
-              , subq_11.metric_time__extract_month
-              , subq_11.metric_time__extract_day
-              , subq_11.metric_time__extract_dow
-              , subq_11.metric_time__extract_doy
-              , subq_11.customer_id
-              , subq_11.customer_name
-              , subq_11.customer_atomic_weight
-              , subq_11.customer_id__customer_name
-              , subq_11.customer_id__customer_atomic_weight
+              subq_6.ds_partitioned__day
+              , subq_6.ds_partitioned__week
+              , subq_6.ds_partitioned__month
+              , subq_6.ds_partitioned__quarter
+              , subq_6.ds_partitioned__year
+              , subq_6.ds_partitioned__extract_year
+              , subq_6.ds_partitioned__extract_quarter
+              , subq_6.ds_partitioned__extract_month
+              , subq_6.ds_partitioned__extract_day
+              , subq_6.ds_partitioned__extract_dow
+              , subq_6.ds_partitioned__extract_doy
+              , subq_6.customer_id__ds_partitioned__day
+              , subq_6.customer_id__ds_partitioned__week
+              , subq_6.customer_id__ds_partitioned__month
+              , subq_6.customer_id__ds_partitioned__quarter
+              , subq_6.customer_id__ds_partitioned__year
+              , subq_6.customer_id__ds_partitioned__extract_year
+              , subq_6.customer_id__ds_partitioned__extract_quarter
+              , subq_6.customer_id__ds_partitioned__extract_month
+              , subq_6.customer_id__ds_partitioned__extract_day
+              , subq_6.customer_id__ds_partitioned__extract_dow
+              , subq_6.customer_id__ds_partitioned__extract_doy
+              , subq_6.metric_time__day
+              , subq_6.metric_time__week
+              , subq_6.metric_time__month
+              , subq_6.metric_time__quarter
+              , subq_6.metric_time__year
+              , subq_6.metric_time__extract_year
+              , subq_6.metric_time__extract_quarter
+              , subq_6.metric_time__extract_month
+              , subq_6.metric_time__extract_day
+              , subq_6.metric_time__extract_dow
+              , subq_6.metric_time__extract_doy
+              , subq_6.customer_id
+              , subq_6.customer_name
+              , subq_6.customer_atomic_weight
+              , subq_6.customer_id__customer_name
+              , subq_6.customer_id__customer_atomic_weight
             FROM (
               -- Metric Time Dimension 'ds_partitioned'
               SELECT
-                subq_10.ds_partitioned__day
-                , subq_10.ds_partitioned__week
-                , subq_10.ds_partitioned__month
-                , subq_10.ds_partitioned__quarter
-                , subq_10.ds_partitioned__year
-                , subq_10.ds_partitioned__extract_year
-                , subq_10.ds_partitioned__extract_quarter
-                , subq_10.ds_partitioned__extract_month
-                , subq_10.ds_partitioned__extract_day
-                , subq_10.ds_partitioned__extract_dow
-                , subq_10.ds_partitioned__extract_doy
-                , subq_10.customer_id__ds_partitioned__day
-                , subq_10.customer_id__ds_partitioned__week
-                , subq_10.customer_id__ds_partitioned__month
-                , subq_10.customer_id__ds_partitioned__quarter
-                , subq_10.customer_id__ds_partitioned__year
-                , subq_10.customer_id__ds_partitioned__extract_year
-                , subq_10.customer_id__ds_partitioned__extract_quarter
-                , subq_10.customer_id__ds_partitioned__extract_month
-                , subq_10.customer_id__ds_partitioned__extract_day
-                , subq_10.customer_id__ds_partitioned__extract_dow
-                , subq_10.customer_id__ds_partitioned__extract_doy
-                , subq_10.ds_partitioned__day AS metric_time__day
-                , subq_10.ds_partitioned__week AS metric_time__week
-                , subq_10.ds_partitioned__month AS metric_time__month
-                , subq_10.ds_partitioned__quarter AS metric_time__quarter
-                , subq_10.ds_partitioned__year AS metric_time__year
-                , subq_10.ds_partitioned__extract_year AS metric_time__extract_year
-                , subq_10.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                , subq_10.ds_partitioned__extract_month AS metric_time__extract_month
-                , subq_10.ds_partitioned__extract_day AS metric_time__extract_day
-                , subq_10.ds_partitioned__extract_dow AS metric_time__extract_dow
-                , subq_10.ds_partitioned__extract_doy AS metric_time__extract_doy
-                , subq_10.customer_id
-                , subq_10.customer_name
-                , subq_10.customer_atomic_weight
-                , subq_10.customer_id__customer_name
-                , subq_10.customer_id__customer_atomic_weight
-                , subq_10.customers
+                subq_5.ds_partitioned__day
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.ds_partitioned__extract_year
+                , subq_5.ds_partitioned__extract_quarter
+                , subq_5.ds_partitioned__extract_month
+                , subq_5.ds_partitioned__extract_day
+                , subq_5.ds_partitioned__extract_dow
+                , subq_5.ds_partitioned__extract_doy
+                , subq_5.customer_id__ds_partitioned__day
+                , subq_5.customer_id__ds_partitioned__week
+                , subq_5.customer_id__ds_partitioned__month
+                , subq_5.customer_id__ds_partitioned__quarter
+                , subq_5.customer_id__ds_partitioned__year
+                , subq_5.customer_id__ds_partitioned__extract_year
+                , subq_5.customer_id__ds_partitioned__extract_quarter
+                , subq_5.customer_id__ds_partitioned__extract_month
+                , subq_5.customer_id__ds_partitioned__extract_day
+                , subq_5.customer_id__ds_partitioned__extract_dow
+                , subq_5.customer_id__ds_partitioned__extract_doy
+                , subq_5.ds_partitioned__day AS metric_time__day
+                , subq_5.ds_partitioned__week AS metric_time__week
+                , subq_5.ds_partitioned__month AS metric_time__month
+                , subq_5.ds_partitioned__quarter AS metric_time__quarter
+                , subq_5.ds_partitioned__year AS metric_time__year
+                , subq_5.ds_partitioned__extract_year AS metric_time__extract_year
+                , subq_5.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                , subq_5.ds_partitioned__extract_month AS metric_time__extract_month
+                , subq_5.ds_partitioned__extract_day AS metric_time__extract_day
+                , subq_5.ds_partitioned__extract_dow AS metric_time__extract_dow
+                , subq_5.ds_partitioned__extract_doy AS metric_time__extract_doy
+                , subq_5.customer_id
+                , subq_5.customer_name
+                , subq_5.customer_atomic_weight
+                , subq_5.customer_id__customer_name
+                , subq_5.customer_id__customer_atomic_weight
+                , subq_5.customers
               FROM (
                 -- Read Elements From Semantic Model 'customer_table'
                 SELECT
@@ -487,25 +487,25 @@ FROM (
                   , EXTRACT(doy FROM customer_table_src_22000.ds_partitioned) AS customer_id__ds_partitioned__extract_doy
                   , customer_table_src_22000.customer_id
                 FROM ***************************.customer_table customer_table_src_22000
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_5
+            ) subq_6
+          ) subq_7
           ON
             (
-              subq_9.customer_id = subq_12.customer_id
+              subq_4.customer_id = subq_7.customer_id
             ) AND (
-              subq_9.ds_partitioned__day = subq_12.ds_partitioned__day
+              subq_4.ds_partitioned__day = subq_7.ds_partitioned__day
             )
-        ) subq_13
-      ) subq_14
+        ) subq_8
+      ) subq_9
       ON
         (
-          subq_7.account_id = subq_14.account_id
+          subq_2.account_id = subq_9.account_id
         ) AND (
-          subq_7.ds_partitioned__day = subq_14.ds_partitioned__day
+          subq_2.ds_partitioned__day = subq_9.ds_partitioned__day
         )
-    ) subq_15
-  ) subq_16
+    ) subq_10
+  ) subq_11
   GROUP BY
-    subq_16.account_id__customer_id__customer_name
-) subq_17
+    subq_11.account_id__customer_id__customer_name
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_22.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_32
+) subq_22
 ON
   (
-    account_month_txns_src_22000.account_id = subq_32.account_id
+    account_month_txns_src_22000.account_id = subq_22.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_22.ds_partitioned__day
   )
 GROUP BY
-  subq_32.customer_id__customer_name
+  subq_22.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,221 +1,221 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_9.bookings) AS bookings
-  , MAX(subq_15.listings) AS listings
+  MAX(subq_5.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.bookings
+    subq_4.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_7.bookings) AS bookings
+      SUM(subq_3.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings',]
       SELECT
-        subq_6.bookings
+        subq_2.bookings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_5.ds__day
-          , subq_5.ds__week
-          , subq_5.ds__month
-          , subq_5.ds__quarter
-          , subq_5.ds__year
-          , subq_5.ds__extract_year
-          , subq_5.ds__extract_quarter
-          , subq_5.ds__extract_month
-          , subq_5.ds__extract_day
-          , subq_5.ds__extract_dow
-          , subq_5.ds__extract_doy
-          , subq_5.ds_partitioned__day
-          , subq_5.ds_partitioned__week
-          , subq_5.ds_partitioned__month
-          , subq_5.ds_partitioned__quarter
-          , subq_5.ds_partitioned__year
-          , subq_5.ds_partitioned__extract_year
-          , subq_5.ds_partitioned__extract_quarter
-          , subq_5.ds_partitioned__extract_month
-          , subq_5.ds_partitioned__extract_day
-          , subq_5.ds_partitioned__extract_dow
-          , subq_5.ds_partitioned__extract_doy
-          , subq_5.paid_at__day
-          , subq_5.paid_at__week
-          , subq_5.paid_at__month
-          , subq_5.paid_at__quarter
-          , subq_5.paid_at__year
-          , subq_5.paid_at__extract_year
-          , subq_5.paid_at__extract_quarter
-          , subq_5.paid_at__extract_month
-          , subq_5.paid_at__extract_day
-          , subq_5.paid_at__extract_dow
-          , subq_5.paid_at__extract_doy
-          , subq_5.booking__ds__day
-          , subq_5.booking__ds__week
-          , subq_5.booking__ds__month
-          , subq_5.booking__ds__quarter
-          , subq_5.booking__ds__year
-          , subq_5.booking__ds__extract_year
-          , subq_5.booking__ds__extract_quarter
-          , subq_5.booking__ds__extract_month
-          , subq_5.booking__ds__extract_day
-          , subq_5.booking__ds__extract_dow
-          , subq_5.booking__ds__extract_doy
-          , subq_5.booking__ds_partitioned__day
-          , subq_5.booking__ds_partitioned__week
-          , subq_5.booking__ds_partitioned__month
-          , subq_5.booking__ds_partitioned__quarter
-          , subq_5.booking__ds_partitioned__year
-          , subq_5.booking__ds_partitioned__extract_year
-          , subq_5.booking__ds_partitioned__extract_quarter
-          , subq_5.booking__ds_partitioned__extract_month
-          , subq_5.booking__ds_partitioned__extract_day
-          , subq_5.booking__ds_partitioned__extract_dow
-          , subq_5.booking__ds_partitioned__extract_doy
-          , subq_5.booking__paid_at__day
-          , subq_5.booking__paid_at__week
-          , subq_5.booking__paid_at__month
-          , subq_5.booking__paid_at__quarter
-          , subq_5.booking__paid_at__year
-          , subq_5.booking__paid_at__extract_year
-          , subq_5.booking__paid_at__extract_quarter
-          , subq_5.booking__paid_at__extract_month
-          , subq_5.booking__paid_at__extract_day
-          , subq_5.booking__paid_at__extract_dow
-          , subq_5.booking__paid_at__extract_doy
-          , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
-          , subq_5.listing
-          , subq_5.guest
-          , subq_5.host
-          , subq_5.booking__listing
-          , subq_5.booking__guest
-          , subq_5.booking__host
-          , subq_5.is_instant
-          , subq_5.booking__is_instant
-          , subq_5.bookings
-          , subq_5.instant_bookings
-          , subq_5.booking_value
-          , subq_5.max_booking_value
-          , subq_5.min_booking_value
-          , subq_5.bookers
-          , subq_5.average_booking_value
-          , subq_5.referred_bookings
-          , subq_5.median_booking_value
-          , subq_5.booking_value_p99
-          , subq_5.discrete_booking_value_p99
-          , subq_5.approximate_continuous_booking_value_p99
-          , subq_5.approximate_discrete_booking_value_p99
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds_partitioned__day
+          , subq_1.ds_partitioned__week
+          , subq_1.ds_partitioned__month
+          , subq_1.ds_partitioned__quarter
+          , subq_1.ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy
+          , subq_1.paid_at__day
+          , subq_1.paid_at__week
+          , subq_1.paid_at__month
+          , subq_1.paid_at__quarter
+          , subq_1.paid_at__year
+          , subq_1.paid_at__extract_year
+          , subq_1.paid_at__extract_quarter
+          , subq_1.paid_at__extract_month
+          , subq_1.paid_at__extract_day
+          , subq_1.paid_at__extract_dow
+          , subq_1.paid_at__extract_doy
+          , subq_1.booking__ds__day
+          , subq_1.booking__ds__week
+          , subq_1.booking__ds__month
+          , subq_1.booking__ds__quarter
+          , subq_1.booking__ds__year
+          , subq_1.booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month
+          , subq_1.booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day
+          , subq_1.booking__paid_at__week
+          , subq_1.booking__paid_at__month
+          , subq_1.booking__paid_at__quarter
+          , subq_1.booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy
+          , subq_1.metric_time__day
+          , subq_1.metric_time__week
+          , subq_1.metric_time__month
+          , subq_1.metric_time__quarter
+          , subq_1.metric_time__year
+          , subq_1.metric_time__extract_year
+          , subq_1.metric_time__extract_quarter
+          , subq_1.metric_time__extract_month
+          , subq_1.metric_time__extract_day
+          , subq_1.metric_time__extract_dow
+          , subq_1.metric_time__extract_doy
+          , subq_1.listing
+          , subq_1.guest
+          , subq_1.host
+          , subq_1.booking__listing
+          , subq_1.booking__guest
+          , subq_1.booking__host
+          , subq_1.is_instant
+          , subq_1.booking__is_instant
+          , subq_1.bookings
+          , subq_1.instant_bookings
+          , subq_1.booking_value
+          , subq_1.max_booking_value
+          , subq_1.min_booking_value
+          , subq_1.bookers
+          , subq_1.average_booking_value
+          , subq_1.referred_bookings
+          , subq_1.median_booking_value
+          , subq_1.booking_value_p99
+          , subq_1.discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds__day
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds__extract_year
-            , subq_4.ds__extract_quarter
-            , subq_4.ds__extract_month
-            , subq_4.ds__extract_day
-            , subq_4.ds__extract_dow
-            , subq_4.ds__extract_doy
-            , subq_4.ds_partitioned__day
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.ds_partitioned__extract_year
-            , subq_4.ds_partitioned__extract_quarter
-            , subq_4.ds_partitioned__extract_month
-            , subq_4.ds_partitioned__extract_day
-            , subq_4.ds_partitioned__extract_dow
-            , subq_4.ds_partitioned__extract_doy
-            , subq_4.paid_at__day
-            , subq_4.paid_at__week
-            , subq_4.paid_at__month
-            , subq_4.paid_at__quarter
-            , subq_4.paid_at__year
-            , subq_4.paid_at__extract_year
-            , subq_4.paid_at__extract_quarter
-            , subq_4.paid_at__extract_month
-            , subq_4.paid_at__extract_day
-            , subq_4.paid_at__extract_dow
-            , subq_4.paid_at__extract_doy
-            , subq_4.booking__ds__day
-            , subq_4.booking__ds__week
-            , subq_4.booking__ds__month
-            , subq_4.booking__ds__quarter
-            , subq_4.booking__ds__year
-            , subq_4.booking__ds__extract_year
-            , subq_4.booking__ds__extract_quarter
-            , subq_4.booking__ds__extract_month
-            , subq_4.booking__ds__extract_day
-            , subq_4.booking__ds__extract_dow
-            , subq_4.booking__ds__extract_doy
-            , subq_4.booking__ds_partitioned__day
-            , subq_4.booking__ds_partitioned__week
-            , subq_4.booking__ds_partitioned__month
-            , subq_4.booking__ds_partitioned__quarter
-            , subq_4.booking__ds_partitioned__year
-            , subq_4.booking__ds_partitioned__extract_year
-            , subq_4.booking__ds_partitioned__extract_quarter
-            , subq_4.booking__ds_partitioned__extract_month
-            , subq_4.booking__ds_partitioned__extract_day
-            , subq_4.booking__ds_partitioned__extract_dow
-            , subq_4.booking__ds_partitioned__extract_doy
-            , subq_4.booking__paid_at__day
-            , subq_4.booking__paid_at__week
-            , subq_4.booking__paid_at__month
-            , subq_4.booking__paid_at__quarter
-            , subq_4.booking__paid_at__year
-            , subq_4.booking__paid_at__extract_year
-            , subq_4.booking__paid_at__extract_quarter
-            , subq_4.booking__paid_at__extract_month
-            , subq_4.booking__paid_at__extract_day
-            , subq_4.booking__paid_at__extract_dow
-            , subq_4.booking__paid_at__extract_doy
-            , subq_4.ds__day AS metric_time__day
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.ds__extract_year AS metric_time__extract_year
-            , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_4.ds__extract_month AS metric_time__extract_month
-            , subq_4.ds__extract_day AS metric_time__extract_day
-            , subq_4.ds__extract_dow AS metric_time__extract_dow
-            , subq_4.ds__extract_doy AS metric_time__extract_doy
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.booking__listing
-            , subq_4.booking__guest
-            , subq_4.booking__host
-            , subq_4.is_instant
-            , subq_4.booking__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
-            , subq_4.median_booking_value
-            , subq_4.booking_value_p99
-            , subq_4.discrete_booking_value_p99
-            , subq_4.approximate_continuous_booking_value_p99
-            , subq_4.approximate_discrete_booking_value_p99
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -308,165 +308,165 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_4
-        ) subq_5
-        WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_0
+        ) subq_1
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_2
+    ) subq_3
+  ) subq_4
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_14.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_13.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements: ['listings',]
       SELECT
-        subq_12.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_11.ds__day
-          , subq_11.ds__week
-          , subq_11.ds__month
-          , subq_11.ds__quarter
-          , subq_11.ds__year
-          , subq_11.ds__extract_year
-          , subq_11.ds__extract_quarter
-          , subq_11.ds__extract_month
-          , subq_11.ds__extract_day
-          , subq_11.ds__extract_dow
-          , subq_11.ds__extract_doy
-          , subq_11.created_at__day
-          , subq_11.created_at__week
-          , subq_11.created_at__month
-          , subq_11.created_at__quarter
-          , subq_11.created_at__year
-          , subq_11.created_at__extract_year
-          , subq_11.created_at__extract_quarter
-          , subq_11.created_at__extract_month
-          , subq_11.created_at__extract_day
-          , subq_11.created_at__extract_dow
-          , subq_11.created_at__extract_doy
-          , subq_11.listing__ds__day
-          , subq_11.listing__ds__week
-          , subq_11.listing__ds__month
-          , subq_11.listing__ds__quarter
-          , subq_11.listing__ds__year
-          , subq_11.listing__ds__extract_year
-          , subq_11.listing__ds__extract_quarter
-          , subq_11.listing__ds__extract_month
-          , subq_11.listing__ds__extract_day
-          , subq_11.listing__ds__extract_dow
-          , subq_11.listing__ds__extract_doy
-          , subq_11.listing__created_at__day
-          , subq_11.listing__created_at__week
-          , subq_11.listing__created_at__month
-          , subq_11.listing__created_at__quarter
-          , subq_11.listing__created_at__year
-          , subq_11.listing__created_at__extract_year
-          , subq_11.listing__created_at__extract_quarter
-          , subq_11.listing__created_at__extract_month
-          , subq_11.listing__created_at__extract_day
-          , subq_11.listing__created_at__extract_dow
-          , subq_11.listing__created_at__extract_doy
-          , subq_11.metric_time__day
-          , subq_11.metric_time__week
-          , subq_11.metric_time__month
-          , subq_11.metric_time__quarter
-          , subq_11.metric_time__year
-          , subq_11.metric_time__extract_year
-          , subq_11.metric_time__extract_quarter
-          , subq_11.metric_time__extract_month
-          , subq_11.metric_time__extract_day
-          , subq_11.metric_time__extract_dow
-          , subq_11.metric_time__extract_doy
-          , subq_11.listing
-          , subq_11.user
-          , subq_11.listing__user
-          , subq_11.country_latest
-          , subq_11.is_lux_latest
-          , subq_11.capacity_latest
-          , subq_11.listing__country_latest
-          , subq_11.listing__is_lux_latest
-          , subq_11.listing__capacity_latest
-          , subq_11.listings
-          , subq_11.largest_listing
-          , subq_11.smallest_listing
+          subq_7.ds__day
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.ds__extract_year
+          , subq_7.ds__extract_quarter
+          , subq_7.ds__extract_month
+          , subq_7.ds__extract_day
+          , subq_7.ds__extract_dow
+          , subq_7.ds__extract_doy
+          , subq_7.created_at__day
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.created_at__extract_year
+          , subq_7.created_at__extract_quarter
+          , subq_7.created_at__extract_month
+          , subq_7.created_at__extract_day
+          , subq_7.created_at__extract_dow
+          , subq_7.created_at__extract_doy
+          , subq_7.listing__ds__day
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__ds__extract_year
+          , subq_7.listing__ds__extract_quarter
+          , subq_7.listing__ds__extract_month
+          , subq_7.listing__ds__extract_day
+          , subq_7.listing__ds__extract_dow
+          , subq_7.listing__ds__extract_doy
+          , subq_7.listing__created_at__day
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.listing__created_at__extract_year
+          , subq_7.listing__created_at__extract_quarter
+          , subq_7.listing__created_at__extract_month
+          , subq_7.listing__created_at__extract_day
+          , subq_7.listing__created_at__extract_dow
+          , subq_7.listing__created_at__extract_doy
+          , subq_7.metric_time__day
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.created_at__day
-            , subq_10.created_at__week
-            , subq_10.created_at__month
-            , subq_10.created_at__quarter
-            , subq_10.created_at__year
-            , subq_10.created_at__extract_year
-            , subq_10.created_at__extract_quarter
-            , subq_10.created_at__extract_month
-            , subq_10.created_at__extract_day
-            , subq_10.created_at__extract_dow
-            , subq_10.created_at__extract_doy
-            , subq_10.listing__ds__day
-            , subq_10.listing__ds__week
-            , subq_10.listing__ds__month
-            , subq_10.listing__ds__quarter
-            , subq_10.listing__ds__year
-            , subq_10.listing__ds__extract_year
-            , subq_10.listing__ds__extract_quarter
-            , subq_10.listing__ds__extract_month
-            , subq_10.listing__ds__extract_day
-            , subq_10.listing__ds__extract_dow
-            , subq_10.listing__ds__extract_doy
-            , subq_10.listing__created_at__day
-            , subq_10.listing__created_at__week
-            , subq_10.listing__created_at__month
-            , subq_10.listing__created_at__quarter
-            , subq_10.listing__created_at__year
-            , subq_10.listing__created_at__extract_year
-            , subq_10.listing__created_at__extract_quarter
-            , subq_10.listing__created_at__extract_month
-            , subq_10.listing__created_at__extract_day
-            , subq_10.listing__created_at__extract_dow
-            , subq_10.listing__created_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.user
-            , subq_10.listing__user
-            , subq_10.country_latest
-            , subq_10.is_lux_latest
-            , subq_10.capacity_latest
-            , subq_10.listing__country_latest
-            , subq_10.listing__is_lux_latest
-            , subq_10.listing__capacity_latest
-            , subq_10.listings
-            , subq_10.largest_listing
-            , subq_10.smallest_listing
+            subq_6.ds__day
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds__extract_year
+            , subq_6.ds__extract_quarter
+            , subq_6.ds__extract_month
+            , subq_6.ds__extract_day
+            , subq_6.ds__extract_dow
+            , subq_6.ds__extract_doy
+            , subq_6.created_at__day
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.created_at__extract_year
+            , subq_6.created_at__extract_quarter
+            , subq_6.created_at__extract_month
+            , subq_6.created_at__extract_day
+            , subq_6.created_at__extract_dow
+            , subq_6.created_at__extract_doy
+            , subq_6.listing__ds__day
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__ds__extract_year
+            , subq_6.listing__ds__extract_quarter
+            , subq_6.listing__ds__extract_month
+            , subq_6.listing__ds__extract_day
+            , subq_6.listing__ds__extract_dow
+            , subq_6.listing__ds__extract_doy
+            , subq_6.listing__created_at__day
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.listing__created_at__extract_year
+            , subq_6.listing__created_at__extract_quarter
+            , subq_6.listing__created_at__extract_month
+            , subq_6.listing__created_at__extract_day
+            , subq_6.listing__created_at__extract_dow
+            , subq_6.listing__created_at__extract_doy
+            , subq_6.ds__day AS metric_time__day
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.ds__extract_year AS metric_time__extract_year
+            , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_6.ds__extract_month AS metric_time__extract_month
+            , subq_6.ds__extract_day AS metric_time__extract_day
+            , subq_6.ds__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__extract_doy AS metric_time__extract_doy
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -527,10 +527,10 @@ CROSS JOIN (
               , listings_latest_src_28000.user_id AS user
               , listings_latest_src_28000.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_28000
-          ) subq_10
-        ) subq_11
-        WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_12
-    ) subq_13
-  ) subq_14
-) subq_15
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_8
+    ) subq_9
+  ) subq_10
+) subq_11

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_25.bookings) AS bookings
-  , MAX(subq_31.listings) AS listings
+  MAX(subq_17.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_25
+) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_31
+) subq_23

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_15.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_13.metric_time__day
+  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_14.booking_value) AS booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_12.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.booking_value AS booking_value_with_is_instant_constraint
+      subq_6.metric_time__day
+      , subq_6.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , SUM(subq_7.booking_value) AS booking_value
+        subq_5.metric_time__day
+        , SUM(subq_5.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.booking_value
+          subq_4.metric_time__day
+          , subq_4.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.booking_value
+      subq_11.metric_time__day
+      , subq_11.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , SUM(subq_12.booking_value) AS booking_value
+        subq_10.metric_time__day
+        , SUM(subq_10.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.booking_value
+          subq_9.metric_time__day
+          , subq_9.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_30.booking_value) AS booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_26.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
+  subq_7.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.metric_time__day
-    , subq_8.bookings AS delayed_bookings
+    subq_6.metric_time__day
+    , subq_6.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -323,15 +323,15 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE NOT booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE NOT booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
-) subq_9
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_9
     WHERE NOT booking__is_instant
-  ) subq_15
+  ) subq_11
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_19
+) subq_15

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.listing__user__home_state_latest
-  , subq_21.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__user__home_state_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-    , SUM(subq_20.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__user__home_state_latest', 'metric_time__day']
     SELECT
-      subq_19.metric_time__day
-      , subq_19.listing__user__home_state_latest
-      , subq_19.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__user__home_state_latest
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_13.metric_time__day AS metric_time__day
-        , subq_18.window_start__day AS listing__window_start__day
-        , subq_18.window_end__day AS listing__window_end__day
-        , subq_13.listing AS listing
-        , subq_18.user__home_state_latest AS listing__user__home_state_latest
-        , subq_13.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.window_start__day AS listing__window_start__day
+        , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.user__home_state_latest AS listing__user__home_state_latest
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_12.metric_time__day
-          , subq_12.listing
-          , subq_12.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds__day
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds__extract_year
-            , subq_11.ds__extract_quarter
-            , subq_11.ds__extract_month
-            , subq_11.ds__extract_day
-            , subq_11.ds__extract_dow
-            , subq_11.ds__extract_doy
-            , subq_11.ds_partitioned__day
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.ds_partitioned__extract_year
-            , subq_11.ds_partitioned__extract_quarter
-            , subq_11.ds_partitioned__extract_month
-            , subq_11.ds_partitioned__extract_day
-            , subq_11.ds_partitioned__extract_dow
-            , subq_11.ds_partitioned__extract_doy
-            , subq_11.paid_at__day
-            , subq_11.paid_at__week
-            , subq_11.paid_at__month
-            , subq_11.paid_at__quarter
-            , subq_11.paid_at__year
-            , subq_11.paid_at__extract_year
-            , subq_11.paid_at__extract_quarter
-            , subq_11.paid_at__extract_month
-            , subq_11.paid_at__extract_day
-            , subq_11.paid_at__extract_dow
-            , subq_11.paid_at__extract_doy
-            , subq_11.booking__ds__day
-            , subq_11.booking__ds__week
-            , subq_11.booking__ds__month
-            , subq_11.booking__ds__quarter
-            , subq_11.booking__ds__year
-            , subq_11.booking__ds__extract_year
-            , subq_11.booking__ds__extract_quarter
-            , subq_11.booking__ds__extract_month
-            , subq_11.booking__ds__extract_day
-            , subq_11.booking__ds__extract_dow
-            , subq_11.booking__ds__extract_doy
-            , subq_11.booking__ds_partitioned__day
-            , subq_11.booking__ds_partitioned__week
-            , subq_11.booking__ds_partitioned__month
-            , subq_11.booking__ds_partitioned__quarter
-            , subq_11.booking__ds_partitioned__year
-            , subq_11.booking__ds_partitioned__extract_year
-            , subq_11.booking__ds_partitioned__extract_quarter
-            , subq_11.booking__ds_partitioned__extract_month
-            , subq_11.booking__ds_partitioned__extract_day
-            , subq_11.booking__ds_partitioned__extract_dow
-            , subq_11.booking__ds_partitioned__extract_doy
-            , subq_11.booking__paid_at__day
-            , subq_11.booking__paid_at__week
-            , subq_11.booking__paid_at__month
-            , subq_11.booking__paid_at__quarter
-            , subq_11.booking__paid_at__year
-            , subq_11.booking__paid_at__extract_year
-            , subq_11.booking__paid_at__extract_quarter
-            , subq_11.booking__paid_at__extract_month
-            , subq_11.booking__paid_at__extract_day
-            , subq_11.booking__paid_at__extract_dow
-            , subq_11.booking__paid_at__extract_doy
-            , subq_11.ds__day AS metric_time__day
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.ds__extract_year AS metric_time__extract_year
-            , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_11.ds__extract_month AS metric_time__extract_month
-            , subq_11.ds__extract_day AS metric_time__extract_day
-            , subq_11.ds__extract_dow AS metric_time__extract_dow
-            , subq_11.ds__extract_doy AS metric_time__extract_doy
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.user
-            , subq_11.booking__listing
-            , subq_11.booking__guest
-            , subq_11.booking__host
-            , subq_11.booking__user
-            , subq_11.is_instant
-            , subq_11.booking__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,84 +211,84 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
         SELECT
-          subq_17.window_start__day
-          , subq_17.window_end__day
-          , subq_17.listing
-          , subq_17.user__home_state_latest
+          subq_6.window_start__day
+          , subq_6.window_end__day
+          , subq_6.listing
+          , subq_6.user__home_state_latest
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.window_start__day AS window_start__day
-            , subq_14.window_start__week AS window_start__week
-            , subq_14.window_start__month AS window_start__month
-            , subq_14.window_start__quarter AS window_start__quarter
-            , subq_14.window_start__year AS window_start__year
-            , subq_14.window_start__extract_year AS window_start__extract_year
-            , subq_14.window_start__extract_quarter AS window_start__extract_quarter
-            , subq_14.window_start__extract_month AS window_start__extract_month
-            , subq_14.window_start__extract_day AS window_start__extract_day
-            , subq_14.window_start__extract_dow AS window_start__extract_dow
-            , subq_14.window_start__extract_doy AS window_start__extract_doy
-            , subq_14.window_end__day AS window_end__day
-            , subq_14.window_end__week AS window_end__week
-            , subq_14.window_end__month AS window_end__month
-            , subq_14.window_end__quarter AS window_end__quarter
-            , subq_14.window_end__year AS window_end__year
-            , subq_14.window_end__extract_year AS window_end__extract_year
-            , subq_14.window_end__extract_quarter AS window_end__extract_quarter
-            , subq_14.window_end__extract_month AS window_end__extract_month
-            , subq_14.window_end__extract_day AS window_end__extract_day
-            , subq_14.window_end__extract_dow AS window_end__extract_dow
-            , subq_14.window_end__extract_doy AS window_end__extract_doy
-            , subq_14.listing__window_start__day AS listing__window_start__day
-            , subq_14.listing__window_start__week AS listing__window_start__week
-            , subq_14.listing__window_start__month AS listing__window_start__month
-            , subq_14.listing__window_start__quarter AS listing__window_start__quarter
-            , subq_14.listing__window_start__year AS listing__window_start__year
-            , subq_14.listing__window_start__extract_year AS listing__window_start__extract_year
-            , subq_14.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
-            , subq_14.listing__window_start__extract_month AS listing__window_start__extract_month
-            , subq_14.listing__window_start__extract_day AS listing__window_start__extract_day
-            , subq_14.listing__window_start__extract_dow AS listing__window_start__extract_dow
-            , subq_14.listing__window_start__extract_doy AS listing__window_start__extract_doy
-            , subq_14.listing__window_end__day AS listing__window_end__day
-            , subq_14.listing__window_end__week AS listing__window_end__week
-            , subq_14.listing__window_end__month AS listing__window_end__month
-            , subq_14.listing__window_end__quarter AS listing__window_end__quarter
-            , subq_14.listing__window_end__year AS listing__window_end__year
-            , subq_14.listing__window_end__extract_year AS listing__window_end__extract_year
-            , subq_14.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
-            , subq_14.listing__window_end__extract_month AS listing__window_end__extract_month
-            , subq_14.listing__window_end__extract_day AS listing__window_end__extract_day
-            , subq_14.listing__window_end__extract_dow AS listing__window_end__extract_dow
-            , subq_14.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_16.ds__day AS user__ds__day
-            , subq_16.ds__week AS user__ds__week
-            , subq_16.ds__month AS user__ds__month
-            , subq_16.ds__quarter AS user__ds__quarter
-            , subq_16.ds__year AS user__ds__year
-            , subq_16.ds__extract_year AS user__ds__extract_year
-            , subq_16.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_16.ds__extract_month AS user__ds__extract_month
-            , subq_16.ds__extract_day AS user__ds__extract_day
-            , subq_16.ds__extract_dow AS user__ds__extract_dow
-            , subq_16.ds__extract_doy AS user__ds__extract_doy
-            , subq_14.listing AS listing
-            , subq_14.user AS user
-            , subq_14.listing__user AS listing__user
-            , subq_14.country AS country
-            , subq_14.is_lux AS is_lux
-            , subq_14.capacity AS capacity
-            , subq_14.listing__country AS listing__country
-            , subq_14.listing__is_lux AS listing__is_lux
-            , subq_14.listing__capacity AS listing__capacity
-            , subq_16.home_state_latest AS user__home_state_latest
+            subq_3.window_start__day AS window_start__day
+            , subq_3.window_start__week AS window_start__week
+            , subq_3.window_start__month AS window_start__month
+            , subq_3.window_start__quarter AS window_start__quarter
+            , subq_3.window_start__year AS window_start__year
+            , subq_3.window_start__extract_year AS window_start__extract_year
+            , subq_3.window_start__extract_quarter AS window_start__extract_quarter
+            , subq_3.window_start__extract_month AS window_start__extract_month
+            , subq_3.window_start__extract_day AS window_start__extract_day
+            , subq_3.window_start__extract_dow AS window_start__extract_dow
+            , subq_3.window_start__extract_doy AS window_start__extract_doy
+            , subq_3.window_end__day AS window_end__day
+            , subq_3.window_end__week AS window_end__week
+            , subq_3.window_end__month AS window_end__month
+            , subq_3.window_end__quarter AS window_end__quarter
+            , subq_3.window_end__year AS window_end__year
+            , subq_3.window_end__extract_year AS window_end__extract_year
+            , subq_3.window_end__extract_quarter AS window_end__extract_quarter
+            , subq_3.window_end__extract_month AS window_end__extract_month
+            , subq_3.window_end__extract_day AS window_end__extract_day
+            , subq_3.window_end__extract_dow AS window_end__extract_dow
+            , subq_3.window_end__extract_doy AS window_end__extract_doy
+            , subq_3.listing__window_start__day AS listing__window_start__day
+            , subq_3.listing__window_start__week AS listing__window_start__week
+            , subq_3.listing__window_start__month AS listing__window_start__month
+            , subq_3.listing__window_start__quarter AS listing__window_start__quarter
+            , subq_3.listing__window_start__year AS listing__window_start__year
+            , subq_3.listing__window_start__extract_year AS listing__window_start__extract_year
+            , subq_3.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+            , subq_3.listing__window_start__extract_month AS listing__window_start__extract_month
+            , subq_3.listing__window_start__extract_day AS listing__window_start__extract_day
+            , subq_3.listing__window_start__extract_dow AS listing__window_start__extract_dow
+            , subq_3.listing__window_start__extract_doy AS listing__window_start__extract_doy
+            , subq_3.listing__window_end__day AS listing__window_end__day
+            , subq_3.listing__window_end__week AS listing__window_end__week
+            , subq_3.listing__window_end__month AS listing__window_end__month
+            , subq_3.listing__window_end__quarter AS listing__window_end__quarter
+            , subq_3.listing__window_end__year AS listing__window_end__year
+            , subq_3.listing__window_end__extract_year AS listing__window_end__extract_year
+            , subq_3.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+            , subq_3.listing__window_end__extract_month AS listing__window_end__extract_month
+            , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
+            , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
+            , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.user AS user
+            , subq_3.listing__user AS listing__user
+            , subq_3.country AS country
+            , subq_3.is_lux AS is_lux
+            , subq_3.capacity AS capacity
+            , subq_3.listing__country AS listing__country
+            , subq_3.listing__is_lux AS listing__is_lux
+            , subq_3.listing__capacity AS listing__capacity
+            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT
@@ -346,7 +346,7 @@ FROM (
               , listings_src_26000.user_id AS user
               , listings_src_26000.user_id AS listing__user
             FROM ***************************.dim_listings listings_src_26000
-          ) subq_14
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'home_state_latest',
@@ -376,31 +376,31 @@ FROM (
             --   'user',
             -- ]
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.user__ds__day
-              , subq_15.user__ds__week
-              , subq_15.user__ds__month
-              , subq_15.user__ds__quarter
-              , subq_15.user__ds__year
-              , subq_15.user__ds__extract_year
-              , subq_15.user__ds__extract_quarter
-              , subq_15.user__ds__extract_month
-              , subq_15.user__ds__extract_day
-              , subq_15.user__ds__extract_dow
-              , subq_15.user__ds__extract_doy
-              , subq_15.user
-              , subq_15.home_state_latest
-              , subq_15.user__home_state_latest
+              subq_4.ds__day
+              , subq_4.ds__week
+              , subq_4.ds__month
+              , subq_4.ds__quarter
+              , subq_4.ds__year
+              , subq_4.ds__extract_year
+              , subq_4.ds__extract_quarter
+              , subq_4.ds__extract_month
+              , subq_4.ds__extract_day
+              , subq_4.ds__extract_dow
+              , subq_4.ds__extract_doy
+              , subq_4.user__ds__day
+              , subq_4.user__ds__week
+              , subq_4.user__ds__month
+              , subq_4.user__ds__quarter
+              , subq_4.user__ds__year
+              , subq_4.user__ds__extract_year
+              , subq_4.user__ds__extract_quarter
+              , subq_4.user__ds__extract_month
+              , subq_4.user__ds__extract_day
+              , subq_4.user__ds__extract_dow
+              , subq_4.user__ds__extract_doy
+              , subq_4.user
+              , subq_4.home_state_latest
+              , subq_4.user__home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -430,29 +430,29 @@ FROM (
                 , users_latest_src_26000.home_state_latest AS user__home_state_latest
                 , users_latest_src_26000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_26000
-            ) subq_15
-          ) subq_16
+            ) subq_4
+          ) subq_5
           ON
-            subq_14.user = subq_16.user
-        ) subq_17
-      ) subq_18
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_13.listing = subq_18.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_13.metric_time__day >= subq_18.window_start__day
+            subq_2.metric_time__day >= subq_7.window_start__day
           ) AND (
             (
-              subq_13.metric_time__day < subq_18.window_end__day
+              subq_2.metric_time__day < subq_7.window_end__day
             ) OR (
-              subq_18.window_end__day IS NULL
+              subq_7.window_end__day IS NULL
             )
           )
         )
-    ) subq_19
-  ) subq_20
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-) subq_21
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_35.metric_time__day AS metric_time__day
-  , subq_40.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_35.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_35
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_40
+) subq_18
 ON
   (
-    subq_35.listing = subq_40.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_35.metric_time__day >= subq_40.window_start__day
+      subq_13.metric_time__day >= subq_18.window_start__day
     ) AND (
       (
-        subq_35.metric_time__day < subq_40.window_end__day
+        subq_13.metric_time__day < subq_18.window_end__day
       ) OR (
-        subq_40.window_end__day IS NULL
+        subq_18.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_35.metric_time__day
-  , subq_40.user__home_state_latest
+  subq_13.metric_time__day
+  , subq_18.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , subq_13.listing__lux_listing__is_confirmed_lux
-  , subq_13.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__lux_listing__is_confirmed_lux
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-    , SUM(subq_12.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__lux_listing__is_confirmed_lux', 'metric_time__day']
     SELECT
-      subq_11.metric_time__day
-      , subq_11.listing__lux_listing__is_confirmed_lux
-      , subq_11.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__lux_listing__is_confirmed_lux
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_5.metric_time__day AS metric_time__day
-        , subq_10.lux_listing__window_start__day AS listing__lux_listing__window_start__day
-        , subq_10.lux_listing__window_end__day AS listing__lux_listing__window_end__day
-        , subq_5.listing AS listing
-        , subq_10.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-        , subq_5.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
+        , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.listing
-          , subq_4.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.ds__day AS metric_time__day
-            , subq_3.ds__week AS metric_time__week
-            , subq_3.ds__month AS metric_time__month
-            , subq_3.ds__quarter AS metric_time__quarter
-            , subq_3.ds__year AS metric_time__year
-            , subq_3.ds__extract_year AS metric_time__extract_year
-            , subq_3.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_3.ds__extract_month AS metric_time__extract_month
-            , subq_3.ds__extract_day AS metric_time__extract_day
-            , subq_3.ds__extract_dow AS metric_time__extract_dow
-            , subq_3.ds__extract_doy AS metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.user
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.booking__user
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,45 +211,45 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_3
-        ) subq_4
-      ) subq_5
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
         SELECT
-          subq_9.lux_listing__window_start__day
-          , subq_9.lux_listing__window_end__day
-          , subq_9.listing
-          , subq_9.lux_listing__is_confirmed_lux
+          subq_6.lux_listing__window_start__day
+          , subq_6.lux_listing__window_end__day
+          , subq_6.listing
+          , subq_6.lux_listing__is_confirmed_lux
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_8.window_start__day AS lux_listing__window_start__day
-            , subq_8.window_start__week AS lux_listing__window_start__week
-            , subq_8.window_start__month AS lux_listing__window_start__month
-            , subq_8.window_start__quarter AS lux_listing__window_start__quarter
-            , subq_8.window_start__year AS lux_listing__window_start__year
-            , subq_8.window_start__extract_year AS lux_listing__window_start__extract_year
-            , subq_8.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
-            , subq_8.window_start__extract_month AS lux_listing__window_start__extract_month
-            , subq_8.window_start__extract_day AS lux_listing__window_start__extract_day
-            , subq_8.window_start__extract_dow AS lux_listing__window_start__extract_dow
-            , subq_8.window_start__extract_doy AS lux_listing__window_start__extract_doy
-            , subq_8.window_end__day AS lux_listing__window_end__day
-            , subq_8.window_end__week AS lux_listing__window_end__week
-            , subq_8.window_end__month AS lux_listing__window_end__month
-            , subq_8.window_end__quarter AS lux_listing__window_end__quarter
-            , subq_8.window_end__year AS lux_listing__window_end__year
-            , subq_8.window_end__extract_year AS lux_listing__window_end__extract_year
-            , subq_8.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
-            , subq_8.window_end__extract_month AS lux_listing__window_end__extract_month
-            , subq_8.window_end__extract_day AS lux_listing__window_end__extract_day
-            , subq_8.window_end__extract_dow AS lux_listing__window_end__extract_dow
-            , subq_8.window_end__extract_doy AS lux_listing__window_end__extract_doy
-            , subq_6.listing AS listing
-            , subq_6.lux_listing AS lux_listing
-            , subq_6.listing__lux_listing AS listing__lux_listing
-            , subq_8.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            subq_5.window_start__day AS lux_listing__window_start__day
+            , subq_5.window_start__week AS lux_listing__window_start__week
+            , subq_5.window_start__month AS lux_listing__window_start__month
+            , subq_5.window_start__quarter AS lux_listing__window_start__quarter
+            , subq_5.window_start__year AS lux_listing__window_start__year
+            , subq_5.window_start__extract_year AS lux_listing__window_start__extract_year
+            , subq_5.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
+            , subq_5.window_start__extract_month AS lux_listing__window_start__extract_month
+            , subq_5.window_start__extract_day AS lux_listing__window_start__extract_day
+            , subq_5.window_start__extract_dow AS lux_listing__window_start__extract_dow
+            , subq_5.window_start__extract_doy AS lux_listing__window_start__extract_doy
+            , subq_5.window_end__day AS lux_listing__window_end__day
+            , subq_5.window_end__week AS lux_listing__window_end__week
+            , subq_5.window_end__month AS lux_listing__window_end__month
+            , subq_5.window_end__quarter AS lux_listing__window_end__quarter
+            , subq_5.window_end__year AS lux_listing__window_end__year
+            , subq_5.window_end__extract_year AS lux_listing__window_end__extract_year
+            , subq_5.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
+            , subq_5.window_end__extract_month AS lux_listing__window_end__extract_month
+            , subq_5.window_end__extract_day AS lux_listing__window_end__extract_day
+            , subq_5.window_end__extract_dow AS lux_listing__window_end__extract_dow
+            , subq_5.window_end__extract_doy AS lux_listing__window_end__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.lux_listing AS lux_listing
+            , subq_3.listing__lux_listing AS listing__lux_listing
+            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT
@@ -257,7 +257,7 @@ FROM (
               , lux_listing_mapping_src_26000.lux_listing_id AS lux_listing
               , lux_listing_mapping_src_26000.lux_listing_id AS listing__lux_listing
             FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_26000
-          ) subq_6
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'is_confirmed_lux',
@@ -309,53 +309,53 @@ FROM (
             --   'lux_listing',
             -- ]
             SELECT
-              subq_7.window_start__day
-              , subq_7.window_start__week
-              , subq_7.window_start__month
-              , subq_7.window_start__quarter
-              , subq_7.window_start__year
-              , subq_7.window_start__extract_year
-              , subq_7.window_start__extract_quarter
-              , subq_7.window_start__extract_month
-              , subq_7.window_start__extract_day
-              , subq_7.window_start__extract_dow
-              , subq_7.window_start__extract_doy
-              , subq_7.window_end__day
-              , subq_7.window_end__week
-              , subq_7.window_end__month
-              , subq_7.window_end__quarter
-              , subq_7.window_end__year
-              , subq_7.window_end__extract_year
-              , subq_7.window_end__extract_quarter
-              , subq_7.window_end__extract_month
-              , subq_7.window_end__extract_day
-              , subq_7.window_end__extract_dow
-              , subq_7.window_end__extract_doy
-              , subq_7.lux_listing__window_start__day
-              , subq_7.lux_listing__window_start__week
-              , subq_7.lux_listing__window_start__month
-              , subq_7.lux_listing__window_start__quarter
-              , subq_7.lux_listing__window_start__year
-              , subq_7.lux_listing__window_start__extract_year
-              , subq_7.lux_listing__window_start__extract_quarter
-              , subq_7.lux_listing__window_start__extract_month
-              , subq_7.lux_listing__window_start__extract_day
-              , subq_7.lux_listing__window_start__extract_dow
-              , subq_7.lux_listing__window_start__extract_doy
-              , subq_7.lux_listing__window_end__day
-              , subq_7.lux_listing__window_end__week
-              , subq_7.lux_listing__window_end__month
-              , subq_7.lux_listing__window_end__quarter
-              , subq_7.lux_listing__window_end__year
-              , subq_7.lux_listing__window_end__extract_year
-              , subq_7.lux_listing__window_end__extract_quarter
-              , subq_7.lux_listing__window_end__extract_month
-              , subq_7.lux_listing__window_end__extract_day
-              , subq_7.lux_listing__window_end__extract_dow
-              , subq_7.lux_listing__window_end__extract_doy
-              , subq_7.lux_listing
-              , subq_7.is_confirmed_lux
-              , subq_7.lux_listing__is_confirmed_lux
+              subq_4.window_start__day
+              , subq_4.window_start__week
+              , subq_4.window_start__month
+              , subq_4.window_start__quarter
+              , subq_4.window_start__year
+              , subq_4.window_start__extract_year
+              , subq_4.window_start__extract_quarter
+              , subq_4.window_start__extract_month
+              , subq_4.window_start__extract_day
+              , subq_4.window_start__extract_dow
+              , subq_4.window_start__extract_doy
+              , subq_4.window_end__day
+              , subq_4.window_end__week
+              , subq_4.window_end__month
+              , subq_4.window_end__quarter
+              , subq_4.window_end__year
+              , subq_4.window_end__extract_year
+              , subq_4.window_end__extract_quarter
+              , subq_4.window_end__extract_month
+              , subq_4.window_end__extract_day
+              , subq_4.window_end__extract_dow
+              , subq_4.window_end__extract_doy
+              , subq_4.lux_listing__window_start__day
+              , subq_4.lux_listing__window_start__week
+              , subq_4.lux_listing__window_start__month
+              , subq_4.lux_listing__window_start__quarter
+              , subq_4.lux_listing__window_start__year
+              , subq_4.lux_listing__window_start__extract_year
+              , subq_4.lux_listing__window_start__extract_quarter
+              , subq_4.lux_listing__window_start__extract_month
+              , subq_4.lux_listing__window_start__extract_day
+              , subq_4.lux_listing__window_start__extract_dow
+              , subq_4.lux_listing__window_start__extract_doy
+              , subq_4.lux_listing__window_end__day
+              , subq_4.lux_listing__window_end__week
+              , subq_4.lux_listing__window_end__month
+              , subq_4.lux_listing__window_end__quarter
+              , subq_4.lux_listing__window_end__year
+              , subq_4.lux_listing__window_end__extract_year
+              , subq_4.lux_listing__window_end__extract_quarter
+              , subq_4.lux_listing__window_end__extract_month
+              , subq_4.lux_listing__window_end__extract_day
+              , subq_4.lux_listing__window_end__extract_dow
+              , subq_4.lux_listing__window_end__extract_doy
+              , subq_4.lux_listing
+              , subq_4.is_confirmed_lux
+              , subq_4.lux_listing__is_confirmed_lux
             FROM (
               -- Read Elements From Semantic Model 'lux_listings'
               SELECT
@@ -407,29 +407,29 @@ FROM (
                 , lux_listings_src_26000.is_confirmed_lux AS lux_listing__is_confirmed_lux
                 , lux_listings_src_26000.lux_listing_id AS lux_listing
               FROM ***************************.dim_lux_listings lux_listings_src_26000
-            ) subq_7
-          ) subq_8
+            ) subq_4
+          ) subq_5
           ON
-            subq_6.lux_listing = subq_8.lux_listing
-        ) subq_9
-      ) subq_10
+            subq_3.lux_listing = subq_5.lux_listing
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_5.listing = subq_10.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_5.metric_time__day >= subq_10.lux_listing__window_start__day
+            subq_2.metric_time__day >= subq_7.lux_listing__window_start__day
           ) AND (
             (
-              subq_5.metric_time__day < subq_10.lux_listing__window_end__day
+              subq_2.metric_time__day < subq_7.lux_listing__window_end__day
             ) OR (
-              subq_10.lux_listing__window_end__day IS NULL
+              subq_7.lux_listing__window_end__day IS NULL
             )
           )
         )
-    ) subq_11
-  ) subq_12
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-) subq_13
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time__day AS metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_19.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_19
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_24
+) subq_18
 ON
   (
-    subq_19.listing = subq_24.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
+      subq_13.metric_time__day >= subq_18.lux_listing__window_start__day
     ) AND (
       (
-        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
+        subq_13.metric_time__day < subq_18.lux_listing__window_end__day
       ) OR (
-        subq_24.lux_listing__window_end__day IS NULL
+        subq_18.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_19.metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux
+  subq_13.metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multihop_node__plan0.sql
@@ -1,93 +1,93 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.account_id__customer_id__customer_name
-  , subq_17.txn_count
+  subq_12.account_id__customer_id__customer_name
+  , subq_12.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.account_id__customer_id__customer_name
-    , SUM(subq_16.txn_count) AS txn_count
+    subq_11.account_id__customer_id__customer_name
+    , SUM(subq_11.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_15.account_id__customer_id__customer_name
-      , subq_15.txn_count
+      subq_10.account_id__customer_id__customer_name
+      , subq_10.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_7.ds_partitioned__day AS ds_partitioned__day
-        , subq_14.ds_partitioned__day AS account_id__ds_partitioned__day
-        , subq_7.account_id AS account_id
-        , subq_14.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_7.txn_count AS txn_count
+        subq_2.ds_partitioned__day AS ds_partitioned__day
+        , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.account_id AS account_id
+        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_6.ds_partitioned__day
-          , subq_6.account_id
-          , subq_6.txn_count
+          subq_1.ds_partitioned__day
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds_partitioned__day
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.ds_partitioned__extract_year
-            , subq_5.ds_partitioned__extract_quarter
-            , subq_5.ds_partitioned__extract_month
-            , subq_5.ds_partitioned__extract_day
-            , subq_5.ds_partitioned__extract_dow
-            , subq_5.ds_partitioned__extract_doy
-            , subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.account_id__ds_partitioned__day
-            , subq_5.account_id__ds_partitioned__week
-            , subq_5.account_id__ds_partitioned__month
-            , subq_5.account_id__ds_partitioned__quarter
-            , subq_5.account_id__ds_partitioned__year
-            , subq_5.account_id__ds_partitioned__extract_year
-            , subq_5.account_id__ds_partitioned__extract_quarter
-            , subq_5.account_id__ds_partitioned__extract_month
-            , subq_5.account_id__ds_partitioned__extract_day
-            , subq_5.account_id__ds_partitioned__extract_dow
-            , subq_5.account_id__ds_partitioned__extract_doy
-            , subq_5.account_id__ds__day
-            , subq_5.account_id__ds__week
-            , subq_5.account_id__ds__month
-            , subq_5.account_id__ds__quarter
-            , subq_5.account_id__ds__year
-            , subq_5.account_id__ds__extract_year
-            , subq_5.account_id__ds__extract_quarter
-            , subq_5.account_id__ds__extract_month
-            , subq_5.account_id__ds__extract_day
-            , subq_5.account_id__ds__extract_dow
-            , subq_5.account_id__ds__extract_doy
-            , subq_5.ds__day AS metric_time__day
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.ds__extract_year AS metric_time__extract_year
-            , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_5.ds__extract_month AS metric_time__extract_month
-            , subq_5.ds__extract_day AS metric_time__extract_day
-            , subq_5.ds__extract_dow AS metric_time__extract_dow
-            , subq_5.ds__extract_doy AS metric_time__extract_doy
-            , subq_5.account_id
-            , subq_5.account_month
-            , subq_5.account_id__account_month
-            , subq_5.txn_count
+            subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.account_id__ds_partitioned__day
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds_partitioned__extract_year
+            , subq_0.account_id__ds_partitioned__extract_quarter
+            , subq_0.account_id__ds_partitioned__extract_month
+            , subq_0.account_id__ds_partitioned__extract_day
+            , subq_0.account_id__ds_partitioned__extract_dow
+            , subq_0.account_id__ds_partitioned__extract_doy
+            , subq_0.account_id__ds__day
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.account_id__ds__extract_year
+            , subq_0.account_id__ds__extract_quarter
+            , subq_0.account_id__ds__extract_month
+            , subq_0.account_id__ds__extract_day
+            , subq_0.account_id__ds__extract_dow
+            , subq_0.account_id__ds__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
@@ -140,151 +140,151 @@ FROM (
               , account_month_txns_src_22000.account_month AS account_id__account_month
               , account_month_txns_src_22000.account_id
             FROM ***************************.account_month_txns account_month_txns_src_22000
-          ) subq_5
-        ) subq_6
-      ) subq_7
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_13.ds_partitioned__day
-          , subq_13.account_id
-          , subq_13.customer_id__customer_name
+          subq_8.ds_partitioned__day
+          , subq_8.account_id
+          , subq_8.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_9.ds_partitioned__day AS ds_partitioned__day
-            , subq_9.ds_partitioned__week AS ds_partitioned__week
-            , subq_9.ds_partitioned__month AS ds_partitioned__month
-            , subq_9.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_9.ds_partitioned__year AS ds_partitioned__year
-            , subq_9.ds_partitioned__extract_year AS ds_partitioned__extract_year
-            , subq_9.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-            , subq_9.ds_partitioned__extract_month AS ds_partitioned__extract_month
-            , subq_9.ds_partitioned__extract_day AS ds_partitioned__extract_day
-            , subq_9.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-            , subq_9.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-            , subq_9.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-            , subq_9.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_9.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_9.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_9.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_9.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-            , subq_9.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-            , subq_9.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-            , subq_9.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-            , subq_9.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-            , subq_9.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-            , subq_9.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-            , subq_9.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-            , subq_9.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-            , subq_9.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-            , subq_9.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-            , subq_9.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-            , subq_9.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-            , subq_9.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-            , subq_9.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-            , subq_9.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-            , subq_9.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
-            , subq_9.metric_time__month AS metric_time__month
-            , subq_9.metric_time__quarter AS metric_time__quarter
-            , subq_9.metric_time__year AS metric_time__year
-            , subq_9.metric_time__extract_year AS metric_time__extract_year
-            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_9.metric_time__extract_month AS metric_time__extract_month
-            , subq_9.metric_time__extract_day AS metric_time__extract_day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_12.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_12.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_12.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_12.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_12.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_12.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_12.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_12.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_12.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_12.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_12.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_12.metric_time__day AS customer_id__metric_time__day
-            , subq_12.metric_time__week AS customer_id__metric_time__week
-            , subq_12.metric_time__month AS customer_id__metric_time__month
-            , subq_12.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_12.metric_time__year AS customer_id__metric_time__year
-            , subq_12.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_12.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_12.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_12.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_12.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_12.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-            , subq_9.account_id AS account_id
-            , subq_9.customer_id AS customer_id
-            , subq_9.account_id__customer_id AS account_id__customer_id
-            , subq_9.bridge_account__account_id AS bridge_account__account_id
-            , subq_9.bridge_account__customer_id AS bridge_account__customer_id
-            , subq_9.extra_dim AS extra_dim
-            , subq_9.account_id__extra_dim AS account_id__extra_dim
-            , subq_9.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_12.customer_name AS customer_id__customer_name
-            , subq_12.customer_atomic_weight AS customer_id__customer_atomic_weight
-            , subq_9.account_customer_combos AS account_customer_combos
+            subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_4.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+            , subq_4.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+            , subq_4.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+            , subq_4.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+            , subq_4.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+            , subq_4.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+            , subq_4.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+            , subq_4.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+            , subq_4.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+            , subq_4.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+            , subq_4.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+            , subq_4.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+            , subq_4.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+            , subq_4.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+            , subq_4.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+            , subq_4.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+            , subq_4.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.account_id AS account_id
+            , subq_4.customer_id AS customer_id
+            , subq_4.account_id__customer_id AS account_id__customer_id
+            , subq_4.bridge_account__account_id AS bridge_account__account_id
+            , subq_4.bridge_account__customer_id AS bridge_account__customer_id
+            , subq_4.extra_dim AS extra_dim
+            , subq_4.account_id__extra_dim AS account_id__extra_dim
+            , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
+            , subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'
             SELECT
-              subq_8.ds_partitioned__day
-              , subq_8.ds_partitioned__week
-              , subq_8.ds_partitioned__month
-              , subq_8.ds_partitioned__quarter
-              , subq_8.ds_partitioned__year
-              , subq_8.ds_partitioned__extract_year
-              , subq_8.ds_partitioned__extract_quarter
-              , subq_8.ds_partitioned__extract_month
-              , subq_8.ds_partitioned__extract_day
-              , subq_8.ds_partitioned__extract_dow
-              , subq_8.ds_partitioned__extract_doy
-              , subq_8.account_id__ds_partitioned__day
-              , subq_8.account_id__ds_partitioned__week
-              , subq_8.account_id__ds_partitioned__month
-              , subq_8.account_id__ds_partitioned__quarter
-              , subq_8.account_id__ds_partitioned__year
-              , subq_8.account_id__ds_partitioned__extract_year
-              , subq_8.account_id__ds_partitioned__extract_quarter
-              , subq_8.account_id__ds_partitioned__extract_month
-              , subq_8.account_id__ds_partitioned__extract_day
-              , subq_8.account_id__ds_partitioned__extract_dow
-              , subq_8.account_id__ds_partitioned__extract_doy
-              , subq_8.bridge_account__ds_partitioned__day
-              , subq_8.bridge_account__ds_partitioned__week
-              , subq_8.bridge_account__ds_partitioned__month
-              , subq_8.bridge_account__ds_partitioned__quarter
-              , subq_8.bridge_account__ds_partitioned__year
-              , subq_8.bridge_account__ds_partitioned__extract_year
-              , subq_8.bridge_account__ds_partitioned__extract_quarter
-              , subq_8.bridge_account__ds_partitioned__extract_month
-              , subq_8.bridge_account__ds_partitioned__extract_day
-              , subq_8.bridge_account__ds_partitioned__extract_dow
-              , subq_8.bridge_account__ds_partitioned__extract_doy
-              , subq_8.ds_partitioned__day AS metric_time__day
-              , subq_8.ds_partitioned__week AS metric_time__week
-              , subq_8.ds_partitioned__month AS metric_time__month
-              , subq_8.ds_partitioned__quarter AS metric_time__quarter
-              , subq_8.ds_partitioned__year AS metric_time__year
-              , subq_8.ds_partitioned__extract_year AS metric_time__extract_year
-              , subq_8.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-              , subq_8.ds_partitioned__extract_month AS metric_time__extract_month
-              , subq_8.ds_partitioned__extract_day AS metric_time__extract_day
-              , subq_8.ds_partitioned__extract_dow AS metric_time__extract_dow
-              , subq_8.ds_partitioned__extract_doy AS metric_time__extract_doy
-              , subq_8.account_id
-              , subq_8.customer_id
-              , subq_8.account_id__customer_id
-              , subq_8.bridge_account__account_id
-              , subq_8.bridge_account__customer_id
-              , subq_8.extra_dim
-              , subq_8.account_id__extra_dim
-              , subq_8.bridge_account__extra_dim
-              , subq_8.account_customer_combos
+              subq_3.ds_partitioned__day
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.ds_partitioned__extract_year
+              , subq_3.ds_partitioned__extract_quarter
+              , subq_3.ds_partitioned__extract_month
+              , subq_3.ds_partitioned__extract_day
+              , subq_3.ds_partitioned__extract_dow
+              , subq_3.ds_partitioned__extract_doy
+              , subq_3.account_id__ds_partitioned__day
+              , subq_3.account_id__ds_partitioned__week
+              , subq_3.account_id__ds_partitioned__month
+              , subq_3.account_id__ds_partitioned__quarter
+              , subq_3.account_id__ds_partitioned__year
+              , subq_3.account_id__ds_partitioned__extract_year
+              , subq_3.account_id__ds_partitioned__extract_quarter
+              , subq_3.account_id__ds_partitioned__extract_month
+              , subq_3.account_id__ds_partitioned__extract_day
+              , subq_3.account_id__ds_partitioned__extract_dow
+              , subq_3.account_id__ds_partitioned__extract_doy
+              , subq_3.bridge_account__ds_partitioned__day
+              , subq_3.bridge_account__ds_partitioned__week
+              , subq_3.bridge_account__ds_partitioned__month
+              , subq_3.bridge_account__ds_partitioned__quarter
+              , subq_3.bridge_account__ds_partitioned__year
+              , subq_3.bridge_account__ds_partitioned__extract_year
+              , subq_3.bridge_account__ds_partitioned__extract_quarter
+              , subq_3.bridge_account__ds_partitioned__extract_month
+              , subq_3.bridge_account__ds_partitioned__extract_day
+              , subq_3.bridge_account__ds_partitioned__extract_dow
+              , subq_3.bridge_account__ds_partitioned__extract_doy
+              , subq_3.ds_partitioned__day AS metric_time__day
+              , subq_3.ds_partitioned__week AS metric_time__week
+              , subq_3.ds_partitioned__month AS metric_time__month
+              , subq_3.ds_partitioned__quarter AS metric_time__quarter
+              , subq_3.ds_partitioned__year AS metric_time__year
+              , subq_3.ds_partitioned__extract_year AS metric_time__extract_year
+              , subq_3.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+              , subq_3.ds_partitioned__extract_month AS metric_time__extract_month
+              , subq_3.ds_partitioned__extract_day AS metric_time__extract_day
+              , subq_3.ds_partitioned__extract_dow AS metric_time__extract_dow
+              , subq_3.ds_partitioned__extract_doy AS metric_time__extract_doy
+              , subq_3.account_id
+              , subq_3.customer_id
+              , subq_3.account_id__customer_id
+              , subq_3.bridge_account__account_id
+              , subq_3.bridge_account__customer_id
+              , subq_3.extra_dim
+              , subq_3.account_id__extra_dim
+              , subq_3.bridge_account__extra_dim
+              , subq_3.account_customer_combos
             FROM (
               -- Read Elements From Semantic Model 'bridge_table'
               SELECT
@@ -331,8 +331,8 @@ FROM (
                 , bridge_table_src_22000.account_id AS bridge_account__account_id
                 , bridge_table_src_22000.customer_id AS bridge_account__customer_id
               FROM ***************************.bridge_table bridge_table_src_22000
-            ) subq_8
-          ) subq_9
+            ) subq_3
+          ) subq_4
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'customer_name',
@@ -375,86 +375,86 @@ FROM (
             --   'customer_id',
             -- ]
             SELECT
-              subq_11.ds_partitioned__day
-              , subq_11.ds_partitioned__week
-              , subq_11.ds_partitioned__month
-              , subq_11.ds_partitioned__quarter
-              , subq_11.ds_partitioned__year
-              , subq_11.ds_partitioned__extract_year
-              , subq_11.ds_partitioned__extract_quarter
-              , subq_11.ds_partitioned__extract_month
-              , subq_11.ds_partitioned__extract_day
-              , subq_11.ds_partitioned__extract_dow
-              , subq_11.ds_partitioned__extract_doy
-              , subq_11.customer_id__ds_partitioned__day
-              , subq_11.customer_id__ds_partitioned__week
-              , subq_11.customer_id__ds_partitioned__month
-              , subq_11.customer_id__ds_partitioned__quarter
-              , subq_11.customer_id__ds_partitioned__year
-              , subq_11.customer_id__ds_partitioned__extract_year
-              , subq_11.customer_id__ds_partitioned__extract_quarter
-              , subq_11.customer_id__ds_partitioned__extract_month
-              , subq_11.customer_id__ds_partitioned__extract_day
-              , subq_11.customer_id__ds_partitioned__extract_dow
-              , subq_11.customer_id__ds_partitioned__extract_doy
-              , subq_11.metric_time__day
-              , subq_11.metric_time__week
-              , subq_11.metric_time__month
-              , subq_11.metric_time__quarter
-              , subq_11.metric_time__year
-              , subq_11.metric_time__extract_year
-              , subq_11.metric_time__extract_quarter
-              , subq_11.metric_time__extract_month
-              , subq_11.metric_time__extract_day
-              , subq_11.metric_time__extract_dow
-              , subq_11.metric_time__extract_doy
-              , subq_11.customer_id
-              , subq_11.customer_name
-              , subq_11.customer_atomic_weight
-              , subq_11.customer_id__customer_name
-              , subq_11.customer_id__customer_atomic_weight
+              subq_6.ds_partitioned__day
+              , subq_6.ds_partitioned__week
+              , subq_6.ds_partitioned__month
+              , subq_6.ds_partitioned__quarter
+              , subq_6.ds_partitioned__year
+              , subq_6.ds_partitioned__extract_year
+              , subq_6.ds_partitioned__extract_quarter
+              , subq_6.ds_partitioned__extract_month
+              , subq_6.ds_partitioned__extract_day
+              , subq_6.ds_partitioned__extract_dow
+              , subq_6.ds_partitioned__extract_doy
+              , subq_6.customer_id__ds_partitioned__day
+              , subq_6.customer_id__ds_partitioned__week
+              , subq_6.customer_id__ds_partitioned__month
+              , subq_6.customer_id__ds_partitioned__quarter
+              , subq_6.customer_id__ds_partitioned__year
+              , subq_6.customer_id__ds_partitioned__extract_year
+              , subq_6.customer_id__ds_partitioned__extract_quarter
+              , subq_6.customer_id__ds_partitioned__extract_month
+              , subq_6.customer_id__ds_partitioned__extract_day
+              , subq_6.customer_id__ds_partitioned__extract_dow
+              , subq_6.customer_id__ds_partitioned__extract_doy
+              , subq_6.metric_time__day
+              , subq_6.metric_time__week
+              , subq_6.metric_time__month
+              , subq_6.metric_time__quarter
+              , subq_6.metric_time__year
+              , subq_6.metric_time__extract_year
+              , subq_6.metric_time__extract_quarter
+              , subq_6.metric_time__extract_month
+              , subq_6.metric_time__extract_day
+              , subq_6.metric_time__extract_dow
+              , subq_6.metric_time__extract_doy
+              , subq_6.customer_id
+              , subq_6.customer_name
+              , subq_6.customer_atomic_weight
+              , subq_6.customer_id__customer_name
+              , subq_6.customer_id__customer_atomic_weight
             FROM (
               -- Metric Time Dimension 'ds_partitioned'
               SELECT
-                subq_10.ds_partitioned__day
-                , subq_10.ds_partitioned__week
-                , subq_10.ds_partitioned__month
-                , subq_10.ds_partitioned__quarter
-                , subq_10.ds_partitioned__year
-                , subq_10.ds_partitioned__extract_year
-                , subq_10.ds_partitioned__extract_quarter
-                , subq_10.ds_partitioned__extract_month
-                , subq_10.ds_partitioned__extract_day
-                , subq_10.ds_partitioned__extract_dow
-                , subq_10.ds_partitioned__extract_doy
-                , subq_10.customer_id__ds_partitioned__day
-                , subq_10.customer_id__ds_partitioned__week
-                , subq_10.customer_id__ds_partitioned__month
-                , subq_10.customer_id__ds_partitioned__quarter
-                , subq_10.customer_id__ds_partitioned__year
-                , subq_10.customer_id__ds_partitioned__extract_year
-                , subq_10.customer_id__ds_partitioned__extract_quarter
-                , subq_10.customer_id__ds_partitioned__extract_month
-                , subq_10.customer_id__ds_partitioned__extract_day
-                , subq_10.customer_id__ds_partitioned__extract_dow
-                , subq_10.customer_id__ds_partitioned__extract_doy
-                , subq_10.ds_partitioned__day AS metric_time__day
-                , subq_10.ds_partitioned__week AS metric_time__week
-                , subq_10.ds_partitioned__month AS metric_time__month
-                , subq_10.ds_partitioned__quarter AS metric_time__quarter
-                , subq_10.ds_partitioned__year AS metric_time__year
-                , subq_10.ds_partitioned__extract_year AS metric_time__extract_year
-                , subq_10.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                , subq_10.ds_partitioned__extract_month AS metric_time__extract_month
-                , subq_10.ds_partitioned__extract_day AS metric_time__extract_day
-                , subq_10.ds_partitioned__extract_dow AS metric_time__extract_dow
-                , subq_10.ds_partitioned__extract_doy AS metric_time__extract_doy
-                , subq_10.customer_id
-                , subq_10.customer_name
-                , subq_10.customer_atomic_weight
-                , subq_10.customer_id__customer_name
-                , subq_10.customer_id__customer_atomic_weight
-                , subq_10.customers
+                subq_5.ds_partitioned__day
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.ds_partitioned__extract_year
+                , subq_5.ds_partitioned__extract_quarter
+                , subq_5.ds_partitioned__extract_month
+                , subq_5.ds_partitioned__extract_day
+                , subq_5.ds_partitioned__extract_dow
+                , subq_5.ds_partitioned__extract_doy
+                , subq_5.customer_id__ds_partitioned__day
+                , subq_5.customer_id__ds_partitioned__week
+                , subq_5.customer_id__ds_partitioned__month
+                , subq_5.customer_id__ds_partitioned__quarter
+                , subq_5.customer_id__ds_partitioned__year
+                , subq_5.customer_id__ds_partitioned__extract_year
+                , subq_5.customer_id__ds_partitioned__extract_quarter
+                , subq_5.customer_id__ds_partitioned__extract_month
+                , subq_5.customer_id__ds_partitioned__extract_day
+                , subq_5.customer_id__ds_partitioned__extract_dow
+                , subq_5.customer_id__ds_partitioned__extract_doy
+                , subq_5.ds_partitioned__day AS metric_time__day
+                , subq_5.ds_partitioned__week AS metric_time__week
+                , subq_5.ds_partitioned__month AS metric_time__month
+                , subq_5.ds_partitioned__quarter AS metric_time__quarter
+                , subq_5.ds_partitioned__year AS metric_time__year
+                , subq_5.ds_partitioned__extract_year AS metric_time__extract_year
+                , subq_5.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                , subq_5.ds_partitioned__extract_month AS metric_time__extract_month
+                , subq_5.ds_partitioned__extract_day AS metric_time__extract_day
+                , subq_5.ds_partitioned__extract_dow AS metric_time__extract_dow
+                , subq_5.ds_partitioned__extract_doy AS metric_time__extract_doy
+                , subq_5.customer_id
+                , subq_5.customer_name
+                , subq_5.customer_atomic_weight
+                , subq_5.customer_id__customer_name
+                , subq_5.customer_id__customer_atomic_weight
+                , subq_5.customers
               FROM (
                 -- Read Elements From Semantic Model 'customer_table'
                 SELECT
@@ -487,25 +487,25 @@ FROM (
                   , EXTRACT(doy FROM customer_table_src_22000.ds_partitioned) AS customer_id__ds_partitioned__extract_doy
                   , customer_table_src_22000.customer_id
                 FROM ***************************.customer_table customer_table_src_22000
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_5
+            ) subq_6
+          ) subq_7
           ON
             (
-              subq_9.customer_id = subq_12.customer_id
+              subq_4.customer_id = subq_7.customer_id
             ) AND (
-              subq_9.ds_partitioned__day = subq_12.ds_partitioned__day
+              subq_4.ds_partitioned__day = subq_7.ds_partitioned__day
             )
-        ) subq_13
-      ) subq_14
+        ) subq_8
+      ) subq_9
       ON
         (
-          subq_7.account_id = subq_14.account_id
+          subq_2.account_id = subq_9.account_id
         ) AND (
-          subq_7.ds_partitioned__day = subq_14.ds_partitioned__day
+          subq_2.ds_partitioned__day = subq_9.ds_partitioned__day
         )
-    ) subq_15
-  ) subq_16
+    ) subq_10
+  ) subq_11
   GROUP BY
-    subq_16.account_id__customer_id__customer_name
-) subq_17
+    subq_11.account_id__customer_id__customer_name
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_22.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_32
+) subq_22
 ON
   (
-    account_month_txns_src_22000.account_id = subq_32.account_id
+    account_month_txns_src_22000.account_id = subq_22.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_22.ds_partitioned__day
   )
 GROUP BY
-  subq_32.customer_id__customer_name
+  subq_22.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,221 +1,221 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_9.bookings) AS bookings
-  , MAX(subq_15.listings) AS listings
+  MAX(subq_5.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.bookings
+    subq_4.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_7.bookings) AS bookings
+      SUM(subq_3.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings',]
       SELECT
-        subq_6.bookings
+        subq_2.bookings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_5.ds__day
-          , subq_5.ds__week
-          , subq_5.ds__month
-          , subq_5.ds__quarter
-          , subq_5.ds__year
-          , subq_5.ds__extract_year
-          , subq_5.ds__extract_quarter
-          , subq_5.ds__extract_month
-          , subq_5.ds__extract_day
-          , subq_5.ds__extract_dow
-          , subq_5.ds__extract_doy
-          , subq_5.ds_partitioned__day
-          , subq_5.ds_partitioned__week
-          , subq_5.ds_partitioned__month
-          , subq_5.ds_partitioned__quarter
-          , subq_5.ds_partitioned__year
-          , subq_5.ds_partitioned__extract_year
-          , subq_5.ds_partitioned__extract_quarter
-          , subq_5.ds_partitioned__extract_month
-          , subq_5.ds_partitioned__extract_day
-          , subq_5.ds_partitioned__extract_dow
-          , subq_5.ds_partitioned__extract_doy
-          , subq_5.paid_at__day
-          , subq_5.paid_at__week
-          , subq_5.paid_at__month
-          , subq_5.paid_at__quarter
-          , subq_5.paid_at__year
-          , subq_5.paid_at__extract_year
-          , subq_5.paid_at__extract_quarter
-          , subq_5.paid_at__extract_month
-          , subq_5.paid_at__extract_day
-          , subq_5.paid_at__extract_dow
-          , subq_5.paid_at__extract_doy
-          , subq_5.booking__ds__day
-          , subq_5.booking__ds__week
-          , subq_5.booking__ds__month
-          , subq_5.booking__ds__quarter
-          , subq_5.booking__ds__year
-          , subq_5.booking__ds__extract_year
-          , subq_5.booking__ds__extract_quarter
-          , subq_5.booking__ds__extract_month
-          , subq_5.booking__ds__extract_day
-          , subq_5.booking__ds__extract_dow
-          , subq_5.booking__ds__extract_doy
-          , subq_5.booking__ds_partitioned__day
-          , subq_5.booking__ds_partitioned__week
-          , subq_5.booking__ds_partitioned__month
-          , subq_5.booking__ds_partitioned__quarter
-          , subq_5.booking__ds_partitioned__year
-          , subq_5.booking__ds_partitioned__extract_year
-          , subq_5.booking__ds_partitioned__extract_quarter
-          , subq_5.booking__ds_partitioned__extract_month
-          , subq_5.booking__ds_partitioned__extract_day
-          , subq_5.booking__ds_partitioned__extract_dow
-          , subq_5.booking__ds_partitioned__extract_doy
-          , subq_5.booking__paid_at__day
-          , subq_5.booking__paid_at__week
-          , subq_5.booking__paid_at__month
-          , subq_5.booking__paid_at__quarter
-          , subq_5.booking__paid_at__year
-          , subq_5.booking__paid_at__extract_year
-          , subq_5.booking__paid_at__extract_quarter
-          , subq_5.booking__paid_at__extract_month
-          , subq_5.booking__paid_at__extract_day
-          , subq_5.booking__paid_at__extract_dow
-          , subq_5.booking__paid_at__extract_doy
-          , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
-          , subq_5.listing
-          , subq_5.guest
-          , subq_5.host
-          , subq_5.booking__listing
-          , subq_5.booking__guest
-          , subq_5.booking__host
-          , subq_5.is_instant
-          , subq_5.booking__is_instant
-          , subq_5.bookings
-          , subq_5.instant_bookings
-          , subq_5.booking_value
-          , subq_5.max_booking_value
-          , subq_5.min_booking_value
-          , subq_5.bookers
-          , subq_5.average_booking_value
-          , subq_5.referred_bookings
-          , subq_5.median_booking_value
-          , subq_5.booking_value_p99
-          , subq_5.discrete_booking_value_p99
-          , subq_5.approximate_continuous_booking_value_p99
-          , subq_5.approximate_discrete_booking_value_p99
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds_partitioned__day
+          , subq_1.ds_partitioned__week
+          , subq_1.ds_partitioned__month
+          , subq_1.ds_partitioned__quarter
+          , subq_1.ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy
+          , subq_1.paid_at__day
+          , subq_1.paid_at__week
+          , subq_1.paid_at__month
+          , subq_1.paid_at__quarter
+          , subq_1.paid_at__year
+          , subq_1.paid_at__extract_year
+          , subq_1.paid_at__extract_quarter
+          , subq_1.paid_at__extract_month
+          , subq_1.paid_at__extract_day
+          , subq_1.paid_at__extract_dow
+          , subq_1.paid_at__extract_doy
+          , subq_1.booking__ds__day
+          , subq_1.booking__ds__week
+          , subq_1.booking__ds__month
+          , subq_1.booking__ds__quarter
+          , subq_1.booking__ds__year
+          , subq_1.booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month
+          , subq_1.booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day
+          , subq_1.booking__paid_at__week
+          , subq_1.booking__paid_at__month
+          , subq_1.booking__paid_at__quarter
+          , subq_1.booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy
+          , subq_1.metric_time__day
+          , subq_1.metric_time__week
+          , subq_1.metric_time__month
+          , subq_1.metric_time__quarter
+          , subq_1.metric_time__year
+          , subq_1.metric_time__extract_year
+          , subq_1.metric_time__extract_quarter
+          , subq_1.metric_time__extract_month
+          , subq_1.metric_time__extract_day
+          , subq_1.metric_time__extract_dow
+          , subq_1.metric_time__extract_doy
+          , subq_1.listing
+          , subq_1.guest
+          , subq_1.host
+          , subq_1.booking__listing
+          , subq_1.booking__guest
+          , subq_1.booking__host
+          , subq_1.is_instant
+          , subq_1.booking__is_instant
+          , subq_1.bookings
+          , subq_1.instant_bookings
+          , subq_1.booking_value
+          , subq_1.max_booking_value
+          , subq_1.min_booking_value
+          , subq_1.bookers
+          , subq_1.average_booking_value
+          , subq_1.referred_bookings
+          , subq_1.median_booking_value
+          , subq_1.booking_value_p99
+          , subq_1.discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds__day
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds__extract_year
-            , subq_4.ds__extract_quarter
-            , subq_4.ds__extract_month
-            , subq_4.ds__extract_day
-            , subq_4.ds__extract_dow
-            , subq_4.ds__extract_doy
-            , subq_4.ds_partitioned__day
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.ds_partitioned__extract_year
-            , subq_4.ds_partitioned__extract_quarter
-            , subq_4.ds_partitioned__extract_month
-            , subq_4.ds_partitioned__extract_day
-            , subq_4.ds_partitioned__extract_dow
-            , subq_4.ds_partitioned__extract_doy
-            , subq_4.paid_at__day
-            , subq_4.paid_at__week
-            , subq_4.paid_at__month
-            , subq_4.paid_at__quarter
-            , subq_4.paid_at__year
-            , subq_4.paid_at__extract_year
-            , subq_4.paid_at__extract_quarter
-            , subq_4.paid_at__extract_month
-            , subq_4.paid_at__extract_day
-            , subq_4.paid_at__extract_dow
-            , subq_4.paid_at__extract_doy
-            , subq_4.booking__ds__day
-            , subq_4.booking__ds__week
-            , subq_4.booking__ds__month
-            , subq_4.booking__ds__quarter
-            , subq_4.booking__ds__year
-            , subq_4.booking__ds__extract_year
-            , subq_4.booking__ds__extract_quarter
-            , subq_4.booking__ds__extract_month
-            , subq_4.booking__ds__extract_day
-            , subq_4.booking__ds__extract_dow
-            , subq_4.booking__ds__extract_doy
-            , subq_4.booking__ds_partitioned__day
-            , subq_4.booking__ds_partitioned__week
-            , subq_4.booking__ds_partitioned__month
-            , subq_4.booking__ds_partitioned__quarter
-            , subq_4.booking__ds_partitioned__year
-            , subq_4.booking__ds_partitioned__extract_year
-            , subq_4.booking__ds_partitioned__extract_quarter
-            , subq_4.booking__ds_partitioned__extract_month
-            , subq_4.booking__ds_partitioned__extract_day
-            , subq_4.booking__ds_partitioned__extract_dow
-            , subq_4.booking__ds_partitioned__extract_doy
-            , subq_4.booking__paid_at__day
-            , subq_4.booking__paid_at__week
-            , subq_4.booking__paid_at__month
-            , subq_4.booking__paid_at__quarter
-            , subq_4.booking__paid_at__year
-            , subq_4.booking__paid_at__extract_year
-            , subq_4.booking__paid_at__extract_quarter
-            , subq_4.booking__paid_at__extract_month
-            , subq_4.booking__paid_at__extract_day
-            , subq_4.booking__paid_at__extract_dow
-            , subq_4.booking__paid_at__extract_doy
-            , subq_4.ds__day AS metric_time__day
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.ds__extract_year AS metric_time__extract_year
-            , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_4.ds__extract_month AS metric_time__extract_month
-            , subq_4.ds__extract_day AS metric_time__extract_day
-            , subq_4.ds__extract_dow AS metric_time__extract_dow
-            , subq_4.ds__extract_doy AS metric_time__extract_doy
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.booking__listing
-            , subq_4.booking__guest
-            , subq_4.booking__host
-            , subq_4.is_instant
-            , subq_4.booking__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
-            , subq_4.median_booking_value
-            , subq_4.booking_value_p99
-            , subq_4.discrete_booking_value_p99
-            , subq_4.approximate_continuous_booking_value_p99
-            , subq_4.approximate_discrete_booking_value_p99
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -308,165 +308,165 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_4
-        ) subq_5
-        WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_0
+        ) subq_1
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_2
+    ) subq_3
+  ) subq_4
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_14.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_13.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements: ['listings',]
       SELECT
-        subq_12.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_11.ds__day
-          , subq_11.ds__week
-          , subq_11.ds__month
-          , subq_11.ds__quarter
-          , subq_11.ds__year
-          , subq_11.ds__extract_year
-          , subq_11.ds__extract_quarter
-          , subq_11.ds__extract_month
-          , subq_11.ds__extract_day
-          , subq_11.ds__extract_dow
-          , subq_11.ds__extract_doy
-          , subq_11.created_at__day
-          , subq_11.created_at__week
-          , subq_11.created_at__month
-          , subq_11.created_at__quarter
-          , subq_11.created_at__year
-          , subq_11.created_at__extract_year
-          , subq_11.created_at__extract_quarter
-          , subq_11.created_at__extract_month
-          , subq_11.created_at__extract_day
-          , subq_11.created_at__extract_dow
-          , subq_11.created_at__extract_doy
-          , subq_11.listing__ds__day
-          , subq_11.listing__ds__week
-          , subq_11.listing__ds__month
-          , subq_11.listing__ds__quarter
-          , subq_11.listing__ds__year
-          , subq_11.listing__ds__extract_year
-          , subq_11.listing__ds__extract_quarter
-          , subq_11.listing__ds__extract_month
-          , subq_11.listing__ds__extract_day
-          , subq_11.listing__ds__extract_dow
-          , subq_11.listing__ds__extract_doy
-          , subq_11.listing__created_at__day
-          , subq_11.listing__created_at__week
-          , subq_11.listing__created_at__month
-          , subq_11.listing__created_at__quarter
-          , subq_11.listing__created_at__year
-          , subq_11.listing__created_at__extract_year
-          , subq_11.listing__created_at__extract_quarter
-          , subq_11.listing__created_at__extract_month
-          , subq_11.listing__created_at__extract_day
-          , subq_11.listing__created_at__extract_dow
-          , subq_11.listing__created_at__extract_doy
-          , subq_11.metric_time__day
-          , subq_11.metric_time__week
-          , subq_11.metric_time__month
-          , subq_11.metric_time__quarter
-          , subq_11.metric_time__year
-          , subq_11.metric_time__extract_year
-          , subq_11.metric_time__extract_quarter
-          , subq_11.metric_time__extract_month
-          , subq_11.metric_time__extract_day
-          , subq_11.metric_time__extract_dow
-          , subq_11.metric_time__extract_doy
-          , subq_11.listing
-          , subq_11.user
-          , subq_11.listing__user
-          , subq_11.country_latest
-          , subq_11.is_lux_latest
-          , subq_11.capacity_latest
-          , subq_11.listing__country_latest
-          , subq_11.listing__is_lux_latest
-          , subq_11.listing__capacity_latest
-          , subq_11.listings
-          , subq_11.largest_listing
-          , subq_11.smallest_listing
+          subq_7.ds__day
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.ds__extract_year
+          , subq_7.ds__extract_quarter
+          , subq_7.ds__extract_month
+          , subq_7.ds__extract_day
+          , subq_7.ds__extract_dow
+          , subq_7.ds__extract_doy
+          , subq_7.created_at__day
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.created_at__extract_year
+          , subq_7.created_at__extract_quarter
+          , subq_7.created_at__extract_month
+          , subq_7.created_at__extract_day
+          , subq_7.created_at__extract_dow
+          , subq_7.created_at__extract_doy
+          , subq_7.listing__ds__day
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__ds__extract_year
+          , subq_7.listing__ds__extract_quarter
+          , subq_7.listing__ds__extract_month
+          , subq_7.listing__ds__extract_day
+          , subq_7.listing__ds__extract_dow
+          , subq_7.listing__ds__extract_doy
+          , subq_7.listing__created_at__day
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.listing__created_at__extract_year
+          , subq_7.listing__created_at__extract_quarter
+          , subq_7.listing__created_at__extract_month
+          , subq_7.listing__created_at__extract_day
+          , subq_7.listing__created_at__extract_dow
+          , subq_7.listing__created_at__extract_doy
+          , subq_7.metric_time__day
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.created_at__day
-            , subq_10.created_at__week
-            , subq_10.created_at__month
-            , subq_10.created_at__quarter
-            , subq_10.created_at__year
-            , subq_10.created_at__extract_year
-            , subq_10.created_at__extract_quarter
-            , subq_10.created_at__extract_month
-            , subq_10.created_at__extract_day
-            , subq_10.created_at__extract_dow
-            , subq_10.created_at__extract_doy
-            , subq_10.listing__ds__day
-            , subq_10.listing__ds__week
-            , subq_10.listing__ds__month
-            , subq_10.listing__ds__quarter
-            , subq_10.listing__ds__year
-            , subq_10.listing__ds__extract_year
-            , subq_10.listing__ds__extract_quarter
-            , subq_10.listing__ds__extract_month
-            , subq_10.listing__ds__extract_day
-            , subq_10.listing__ds__extract_dow
-            , subq_10.listing__ds__extract_doy
-            , subq_10.listing__created_at__day
-            , subq_10.listing__created_at__week
-            , subq_10.listing__created_at__month
-            , subq_10.listing__created_at__quarter
-            , subq_10.listing__created_at__year
-            , subq_10.listing__created_at__extract_year
-            , subq_10.listing__created_at__extract_quarter
-            , subq_10.listing__created_at__extract_month
-            , subq_10.listing__created_at__extract_day
-            , subq_10.listing__created_at__extract_dow
-            , subq_10.listing__created_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.user
-            , subq_10.listing__user
-            , subq_10.country_latest
-            , subq_10.is_lux_latest
-            , subq_10.capacity_latest
-            , subq_10.listing__country_latest
-            , subq_10.listing__is_lux_latest
-            , subq_10.listing__capacity_latest
-            , subq_10.listings
-            , subq_10.largest_listing
-            , subq_10.smallest_listing
+            subq_6.ds__day
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds__extract_year
+            , subq_6.ds__extract_quarter
+            , subq_6.ds__extract_month
+            , subq_6.ds__extract_day
+            , subq_6.ds__extract_dow
+            , subq_6.ds__extract_doy
+            , subq_6.created_at__day
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.created_at__extract_year
+            , subq_6.created_at__extract_quarter
+            , subq_6.created_at__extract_month
+            , subq_6.created_at__extract_day
+            , subq_6.created_at__extract_dow
+            , subq_6.created_at__extract_doy
+            , subq_6.listing__ds__day
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__ds__extract_year
+            , subq_6.listing__ds__extract_quarter
+            , subq_6.listing__ds__extract_month
+            , subq_6.listing__ds__extract_day
+            , subq_6.listing__ds__extract_dow
+            , subq_6.listing__ds__extract_doy
+            , subq_6.listing__created_at__day
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.listing__created_at__extract_year
+            , subq_6.listing__created_at__extract_quarter
+            , subq_6.listing__created_at__extract_month
+            , subq_6.listing__created_at__extract_day
+            , subq_6.listing__created_at__extract_dow
+            , subq_6.listing__created_at__extract_doy
+            , subq_6.ds__day AS metric_time__day
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.ds__extract_year AS metric_time__extract_year
+            , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_6.ds__extract_month AS metric_time__extract_month
+            , subq_6.ds__extract_day AS metric_time__extract_day
+            , subq_6.ds__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__extract_doy AS metric_time__extract_doy
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -527,10 +527,10 @@ CROSS JOIN (
               , listings_latest_src_28000.user_id AS user
               , listings_latest_src_28000.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_28000
-          ) subq_10
-        ) subq_11
-        WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_12
-    ) subq_13
-  ) subq_14
-) subq_15
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_8
+    ) subq_9
+  ) subq_10
+) subq_11

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_25.bookings) AS bookings
-  , MAX(subq_31.listings) AS listings
+  MAX(subq_17.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_25
+) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_31
+) subq_23

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_15.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_13.metric_time__day
+  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_14.booking_value) AS booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_12.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.booking_value AS booking_value_with_is_instant_constraint
+      subq_6.metric_time__day
+      , subq_6.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , SUM(subq_7.booking_value) AS booking_value
+        subq_5.metric_time__day
+        , SUM(subq_5.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.booking_value
+          subq_4.metric_time__day
+          , subq_4.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.booking_value
+      subq_11.metric_time__day
+      , subq_11.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , SUM(subq_12.booking_value) AS booking_value
+        subq_10.metric_time__day
+        , SUM(subq_10.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.booking_value
+          subq_9.metric_time__day
+          , subq_9.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_30.booking_value) AS booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_26.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
+  subq_7.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.metric_time__day
-    , subq_8.bookings AS delayed_bookings
+    subq_6.metric_time__day
+    , subq_6.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -323,15 +323,15 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE NOT booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE NOT booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
-) subq_9
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_9
     WHERE NOT booking__is_instant
-  ) subq_15
+  ) subq_11
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_19
+) subq_15

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.listing__user__home_state_latest
-  , subq_21.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__user__home_state_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-    , SUM(subq_20.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__user__home_state_latest', 'metric_time__day']
     SELECT
-      subq_19.metric_time__day
-      , subq_19.listing__user__home_state_latest
-      , subq_19.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__user__home_state_latest
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_13.metric_time__day AS metric_time__day
-        , subq_18.window_start__day AS listing__window_start__day
-        , subq_18.window_end__day AS listing__window_end__day
-        , subq_13.listing AS listing
-        , subq_18.user__home_state_latest AS listing__user__home_state_latest
-        , subq_13.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.window_start__day AS listing__window_start__day
+        , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.user__home_state_latest AS listing__user__home_state_latest
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_12.metric_time__day
-          , subq_12.listing
-          , subq_12.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds__day
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds__extract_year
-            , subq_11.ds__extract_quarter
-            , subq_11.ds__extract_month
-            , subq_11.ds__extract_day
-            , subq_11.ds__extract_dow
-            , subq_11.ds__extract_doy
-            , subq_11.ds_partitioned__day
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.ds_partitioned__extract_year
-            , subq_11.ds_partitioned__extract_quarter
-            , subq_11.ds_partitioned__extract_month
-            , subq_11.ds_partitioned__extract_day
-            , subq_11.ds_partitioned__extract_dow
-            , subq_11.ds_partitioned__extract_doy
-            , subq_11.paid_at__day
-            , subq_11.paid_at__week
-            , subq_11.paid_at__month
-            , subq_11.paid_at__quarter
-            , subq_11.paid_at__year
-            , subq_11.paid_at__extract_year
-            , subq_11.paid_at__extract_quarter
-            , subq_11.paid_at__extract_month
-            , subq_11.paid_at__extract_day
-            , subq_11.paid_at__extract_dow
-            , subq_11.paid_at__extract_doy
-            , subq_11.booking__ds__day
-            , subq_11.booking__ds__week
-            , subq_11.booking__ds__month
-            , subq_11.booking__ds__quarter
-            , subq_11.booking__ds__year
-            , subq_11.booking__ds__extract_year
-            , subq_11.booking__ds__extract_quarter
-            , subq_11.booking__ds__extract_month
-            , subq_11.booking__ds__extract_day
-            , subq_11.booking__ds__extract_dow
-            , subq_11.booking__ds__extract_doy
-            , subq_11.booking__ds_partitioned__day
-            , subq_11.booking__ds_partitioned__week
-            , subq_11.booking__ds_partitioned__month
-            , subq_11.booking__ds_partitioned__quarter
-            , subq_11.booking__ds_partitioned__year
-            , subq_11.booking__ds_partitioned__extract_year
-            , subq_11.booking__ds_partitioned__extract_quarter
-            , subq_11.booking__ds_partitioned__extract_month
-            , subq_11.booking__ds_partitioned__extract_day
-            , subq_11.booking__ds_partitioned__extract_dow
-            , subq_11.booking__ds_partitioned__extract_doy
-            , subq_11.booking__paid_at__day
-            , subq_11.booking__paid_at__week
-            , subq_11.booking__paid_at__month
-            , subq_11.booking__paid_at__quarter
-            , subq_11.booking__paid_at__year
-            , subq_11.booking__paid_at__extract_year
-            , subq_11.booking__paid_at__extract_quarter
-            , subq_11.booking__paid_at__extract_month
-            , subq_11.booking__paid_at__extract_day
-            , subq_11.booking__paid_at__extract_dow
-            , subq_11.booking__paid_at__extract_doy
-            , subq_11.ds__day AS metric_time__day
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.ds__extract_year AS metric_time__extract_year
-            , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_11.ds__extract_month AS metric_time__extract_month
-            , subq_11.ds__extract_day AS metric_time__extract_day
-            , subq_11.ds__extract_dow AS metric_time__extract_dow
-            , subq_11.ds__extract_doy AS metric_time__extract_doy
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.user
-            , subq_11.booking__listing
-            , subq_11.booking__guest
-            , subq_11.booking__host
-            , subq_11.booking__user
-            , subq_11.is_instant
-            , subq_11.booking__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,84 +211,84 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
         SELECT
-          subq_17.window_start__day
-          , subq_17.window_end__day
-          , subq_17.listing
-          , subq_17.user__home_state_latest
+          subq_6.window_start__day
+          , subq_6.window_end__day
+          , subq_6.listing
+          , subq_6.user__home_state_latest
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.window_start__day AS window_start__day
-            , subq_14.window_start__week AS window_start__week
-            , subq_14.window_start__month AS window_start__month
-            , subq_14.window_start__quarter AS window_start__quarter
-            , subq_14.window_start__year AS window_start__year
-            , subq_14.window_start__extract_year AS window_start__extract_year
-            , subq_14.window_start__extract_quarter AS window_start__extract_quarter
-            , subq_14.window_start__extract_month AS window_start__extract_month
-            , subq_14.window_start__extract_day AS window_start__extract_day
-            , subq_14.window_start__extract_dow AS window_start__extract_dow
-            , subq_14.window_start__extract_doy AS window_start__extract_doy
-            , subq_14.window_end__day AS window_end__day
-            , subq_14.window_end__week AS window_end__week
-            , subq_14.window_end__month AS window_end__month
-            , subq_14.window_end__quarter AS window_end__quarter
-            , subq_14.window_end__year AS window_end__year
-            , subq_14.window_end__extract_year AS window_end__extract_year
-            , subq_14.window_end__extract_quarter AS window_end__extract_quarter
-            , subq_14.window_end__extract_month AS window_end__extract_month
-            , subq_14.window_end__extract_day AS window_end__extract_day
-            , subq_14.window_end__extract_dow AS window_end__extract_dow
-            , subq_14.window_end__extract_doy AS window_end__extract_doy
-            , subq_14.listing__window_start__day AS listing__window_start__day
-            , subq_14.listing__window_start__week AS listing__window_start__week
-            , subq_14.listing__window_start__month AS listing__window_start__month
-            , subq_14.listing__window_start__quarter AS listing__window_start__quarter
-            , subq_14.listing__window_start__year AS listing__window_start__year
-            , subq_14.listing__window_start__extract_year AS listing__window_start__extract_year
-            , subq_14.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
-            , subq_14.listing__window_start__extract_month AS listing__window_start__extract_month
-            , subq_14.listing__window_start__extract_day AS listing__window_start__extract_day
-            , subq_14.listing__window_start__extract_dow AS listing__window_start__extract_dow
-            , subq_14.listing__window_start__extract_doy AS listing__window_start__extract_doy
-            , subq_14.listing__window_end__day AS listing__window_end__day
-            , subq_14.listing__window_end__week AS listing__window_end__week
-            , subq_14.listing__window_end__month AS listing__window_end__month
-            , subq_14.listing__window_end__quarter AS listing__window_end__quarter
-            , subq_14.listing__window_end__year AS listing__window_end__year
-            , subq_14.listing__window_end__extract_year AS listing__window_end__extract_year
-            , subq_14.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
-            , subq_14.listing__window_end__extract_month AS listing__window_end__extract_month
-            , subq_14.listing__window_end__extract_day AS listing__window_end__extract_day
-            , subq_14.listing__window_end__extract_dow AS listing__window_end__extract_dow
-            , subq_14.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_16.ds__day AS user__ds__day
-            , subq_16.ds__week AS user__ds__week
-            , subq_16.ds__month AS user__ds__month
-            , subq_16.ds__quarter AS user__ds__quarter
-            , subq_16.ds__year AS user__ds__year
-            , subq_16.ds__extract_year AS user__ds__extract_year
-            , subq_16.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_16.ds__extract_month AS user__ds__extract_month
-            , subq_16.ds__extract_day AS user__ds__extract_day
-            , subq_16.ds__extract_dow AS user__ds__extract_dow
-            , subq_16.ds__extract_doy AS user__ds__extract_doy
-            , subq_14.listing AS listing
-            , subq_14.user AS user
-            , subq_14.listing__user AS listing__user
-            , subq_14.country AS country
-            , subq_14.is_lux AS is_lux
-            , subq_14.capacity AS capacity
-            , subq_14.listing__country AS listing__country
-            , subq_14.listing__is_lux AS listing__is_lux
-            , subq_14.listing__capacity AS listing__capacity
-            , subq_16.home_state_latest AS user__home_state_latest
+            subq_3.window_start__day AS window_start__day
+            , subq_3.window_start__week AS window_start__week
+            , subq_3.window_start__month AS window_start__month
+            , subq_3.window_start__quarter AS window_start__quarter
+            , subq_3.window_start__year AS window_start__year
+            , subq_3.window_start__extract_year AS window_start__extract_year
+            , subq_3.window_start__extract_quarter AS window_start__extract_quarter
+            , subq_3.window_start__extract_month AS window_start__extract_month
+            , subq_3.window_start__extract_day AS window_start__extract_day
+            , subq_3.window_start__extract_dow AS window_start__extract_dow
+            , subq_3.window_start__extract_doy AS window_start__extract_doy
+            , subq_3.window_end__day AS window_end__day
+            , subq_3.window_end__week AS window_end__week
+            , subq_3.window_end__month AS window_end__month
+            , subq_3.window_end__quarter AS window_end__quarter
+            , subq_3.window_end__year AS window_end__year
+            , subq_3.window_end__extract_year AS window_end__extract_year
+            , subq_3.window_end__extract_quarter AS window_end__extract_quarter
+            , subq_3.window_end__extract_month AS window_end__extract_month
+            , subq_3.window_end__extract_day AS window_end__extract_day
+            , subq_3.window_end__extract_dow AS window_end__extract_dow
+            , subq_3.window_end__extract_doy AS window_end__extract_doy
+            , subq_3.listing__window_start__day AS listing__window_start__day
+            , subq_3.listing__window_start__week AS listing__window_start__week
+            , subq_3.listing__window_start__month AS listing__window_start__month
+            , subq_3.listing__window_start__quarter AS listing__window_start__quarter
+            , subq_3.listing__window_start__year AS listing__window_start__year
+            , subq_3.listing__window_start__extract_year AS listing__window_start__extract_year
+            , subq_3.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+            , subq_3.listing__window_start__extract_month AS listing__window_start__extract_month
+            , subq_3.listing__window_start__extract_day AS listing__window_start__extract_day
+            , subq_3.listing__window_start__extract_dow AS listing__window_start__extract_dow
+            , subq_3.listing__window_start__extract_doy AS listing__window_start__extract_doy
+            , subq_3.listing__window_end__day AS listing__window_end__day
+            , subq_3.listing__window_end__week AS listing__window_end__week
+            , subq_3.listing__window_end__month AS listing__window_end__month
+            , subq_3.listing__window_end__quarter AS listing__window_end__quarter
+            , subq_3.listing__window_end__year AS listing__window_end__year
+            , subq_3.listing__window_end__extract_year AS listing__window_end__extract_year
+            , subq_3.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+            , subq_3.listing__window_end__extract_month AS listing__window_end__extract_month
+            , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
+            , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
+            , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.user AS user
+            , subq_3.listing__user AS listing__user
+            , subq_3.country AS country
+            , subq_3.is_lux AS is_lux
+            , subq_3.capacity AS capacity
+            , subq_3.listing__country AS listing__country
+            , subq_3.listing__is_lux AS listing__is_lux
+            , subq_3.listing__capacity AS listing__capacity
+            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT
@@ -346,7 +346,7 @@ FROM (
               , listings_src_26000.user_id AS user
               , listings_src_26000.user_id AS listing__user
             FROM ***************************.dim_listings listings_src_26000
-          ) subq_14
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'home_state_latest',
@@ -376,31 +376,31 @@ FROM (
             --   'user',
             -- ]
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.user__ds__day
-              , subq_15.user__ds__week
-              , subq_15.user__ds__month
-              , subq_15.user__ds__quarter
-              , subq_15.user__ds__year
-              , subq_15.user__ds__extract_year
-              , subq_15.user__ds__extract_quarter
-              , subq_15.user__ds__extract_month
-              , subq_15.user__ds__extract_day
-              , subq_15.user__ds__extract_dow
-              , subq_15.user__ds__extract_doy
-              , subq_15.user
-              , subq_15.home_state_latest
-              , subq_15.user__home_state_latest
+              subq_4.ds__day
+              , subq_4.ds__week
+              , subq_4.ds__month
+              , subq_4.ds__quarter
+              , subq_4.ds__year
+              , subq_4.ds__extract_year
+              , subq_4.ds__extract_quarter
+              , subq_4.ds__extract_month
+              , subq_4.ds__extract_day
+              , subq_4.ds__extract_dow
+              , subq_4.ds__extract_doy
+              , subq_4.user__ds__day
+              , subq_4.user__ds__week
+              , subq_4.user__ds__month
+              , subq_4.user__ds__quarter
+              , subq_4.user__ds__year
+              , subq_4.user__ds__extract_year
+              , subq_4.user__ds__extract_quarter
+              , subq_4.user__ds__extract_month
+              , subq_4.user__ds__extract_day
+              , subq_4.user__ds__extract_dow
+              , subq_4.user__ds__extract_doy
+              , subq_4.user
+              , subq_4.home_state_latest
+              , subq_4.user__home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -430,29 +430,29 @@ FROM (
                 , users_latest_src_26000.home_state_latest AS user__home_state_latest
                 , users_latest_src_26000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_26000
-            ) subq_15
-          ) subq_16
+            ) subq_4
+          ) subq_5
           ON
-            subq_14.user = subq_16.user
-        ) subq_17
-      ) subq_18
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_13.listing = subq_18.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_13.metric_time__day >= subq_18.window_start__day
+            subq_2.metric_time__day >= subq_7.window_start__day
           ) AND (
             (
-              subq_13.metric_time__day < subq_18.window_end__day
+              subq_2.metric_time__day < subq_7.window_end__day
             ) OR (
-              subq_18.window_end__day IS NULL
+              subq_7.window_end__day IS NULL
             )
           )
         )
-    ) subq_19
-  ) subq_20
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-) subq_21
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_35.metric_time__day AS metric_time__day
-  , subq_40.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_35.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_35
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_40
+) subq_18
 ON
   (
-    subq_35.listing = subq_40.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_35.metric_time__day >= subq_40.window_start__day
+      subq_13.metric_time__day >= subq_18.window_start__day
     ) AND (
       (
-        subq_35.metric_time__day < subq_40.window_end__day
+        subq_13.metric_time__day < subq_18.window_end__day
       ) OR (
-        subq_40.window_end__day IS NULL
+        subq_18.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_35.metric_time__day
-  , subq_40.user__home_state_latest
+  subq_13.metric_time__day
+  , subq_18.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , subq_13.listing__lux_listing__is_confirmed_lux
-  , subq_13.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__lux_listing__is_confirmed_lux
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-    , SUM(subq_12.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__lux_listing__is_confirmed_lux', 'metric_time__day']
     SELECT
-      subq_11.metric_time__day
-      , subq_11.listing__lux_listing__is_confirmed_lux
-      , subq_11.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__lux_listing__is_confirmed_lux
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_5.metric_time__day AS metric_time__day
-        , subq_10.lux_listing__window_start__day AS listing__lux_listing__window_start__day
-        , subq_10.lux_listing__window_end__day AS listing__lux_listing__window_end__day
-        , subq_5.listing AS listing
-        , subq_10.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-        , subq_5.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
+        , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.listing
-          , subq_4.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.ds__day AS metric_time__day
-            , subq_3.ds__week AS metric_time__week
-            , subq_3.ds__month AS metric_time__month
-            , subq_3.ds__quarter AS metric_time__quarter
-            , subq_3.ds__year AS metric_time__year
-            , subq_3.ds__extract_year AS metric_time__extract_year
-            , subq_3.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_3.ds__extract_month AS metric_time__extract_month
-            , subq_3.ds__extract_day AS metric_time__extract_day
-            , subq_3.ds__extract_dow AS metric_time__extract_dow
-            , subq_3.ds__extract_doy AS metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.user
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.booking__user
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,45 +211,45 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_3
-        ) subq_4
-      ) subq_5
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
         SELECT
-          subq_9.lux_listing__window_start__day
-          , subq_9.lux_listing__window_end__day
-          , subq_9.listing
-          , subq_9.lux_listing__is_confirmed_lux
+          subq_6.lux_listing__window_start__day
+          , subq_6.lux_listing__window_end__day
+          , subq_6.listing
+          , subq_6.lux_listing__is_confirmed_lux
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_8.window_start__day AS lux_listing__window_start__day
-            , subq_8.window_start__week AS lux_listing__window_start__week
-            , subq_8.window_start__month AS lux_listing__window_start__month
-            , subq_8.window_start__quarter AS lux_listing__window_start__quarter
-            , subq_8.window_start__year AS lux_listing__window_start__year
-            , subq_8.window_start__extract_year AS lux_listing__window_start__extract_year
-            , subq_8.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
-            , subq_8.window_start__extract_month AS lux_listing__window_start__extract_month
-            , subq_8.window_start__extract_day AS lux_listing__window_start__extract_day
-            , subq_8.window_start__extract_dow AS lux_listing__window_start__extract_dow
-            , subq_8.window_start__extract_doy AS lux_listing__window_start__extract_doy
-            , subq_8.window_end__day AS lux_listing__window_end__day
-            , subq_8.window_end__week AS lux_listing__window_end__week
-            , subq_8.window_end__month AS lux_listing__window_end__month
-            , subq_8.window_end__quarter AS lux_listing__window_end__quarter
-            , subq_8.window_end__year AS lux_listing__window_end__year
-            , subq_8.window_end__extract_year AS lux_listing__window_end__extract_year
-            , subq_8.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
-            , subq_8.window_end__extract_month AS lux_listing__window_end__extract_month
-            , subq_8.window_end__extract_day AS lux_listing__window_end__extract_day
-            , subq_8.window_end__extract_dow AS lux_listing__window_end__extract_dow
-            , subq_8.window_end__extract_doy AS lux_listing__window_end__extract_doy
-            , subq_6.listing AS listing
-            , subq_6.lux_listing AS lux_listing
-            , subq_6.listing__lux_listing AS listing__lux_listing
-            , subq_8.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            subq_5.window_start__day AS lux_listing__window_start__day
+            , subq_5.window_start__week AS lux_listing__window_start__week
+            , subq_5.window_start__month AS lux_listing__window_start__month
+            , subq_5.window_start__quarter AS lux_listing__window_start__quarter
+            , subq_5.window_start__year AS lux_listing__window_start__year
+            , subq_5.window_start__extract_year AS lux_listing__window_start__extract_year
+            , subq_5.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
+            , subq_5.window_start__extract_month AS lux_listing__window_start__extract_month
+            , subq_5.window_start__extract_day AS lux_listing__window_start__extract_day
+            , subq_5.window_start__extract_dow AS lux_listing__window_start__extract_dow
+            , subq_5.window_start__extract_doy AS lux_listing__window_start__extract_doy
+            , subq_5.window_end__day AS lux_listing__window_end__day
+            , subq_5.window_end__week AS lux_listing__window_end__week
+            , subq_5.window_end__month AS lux_listing__window_end__month
+            , subq_5.window_end__quarter AS lux_listing__window_end__quarter
+            , subq_5.window_end__year AS lux_listing__window_end__year
+            , subq_5.window_end__extract_year AS lux_listing__window_end__extract_year
+            , subq_5.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
+            , subq_5.window_end__extract_month AS lux_listing__window_end__extract_month
+            , subq_5.window_end__extract_day AS lux_listing__window_end__extract_day
+            , subq_5.window_end__extract_dow AS lux_listing__window_end__extract_dow
+            , subq_5.window_end__extract_doy AS lux_listing__window_end__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.lux_listing AS lux_listing
+            , subq_3.listing__lux_listing AS listing__lux_listing
+            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT
@@ -257,7 +257,7 @@ FROM (
               , lux_listing_mapping_src_26000.lux_listing_id AS lux_listing
               , lux_listing_mapping_src_26000.lux_listing_id AS listing__lux_listing
             FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_26000
-          ) subq_6
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'is_confirmed_lux',
@@ -309,53 +309,53 @@ FROM (
             --   'lux_listing',
             -- ]
             SELECT
-              subq_7.window_start__day
-              , subq_7.window_start__week
-              , subq_7.window_start__month
-              , subq_7.window_start__quarter
-              , subq_7.window_start__year
-              , subq_7.window_start__extract_year
-              , subq_7.window_start__extract_quarter
-              , subq_7.window_start__extract_month
-              , subq_7.window_start__extract_day
-              , subq_7.window_start__extract_dow
-              , subq_7.window_start__extract_doy
-              , subq_7.window_end__day
-              , subq_7.window_end__week
-              , subq_7.window_end__month
-              , subq_7.window_end__quarter
-              , subq_7.window_end__year
-              , subq_7.window_end__extract_year
-              , subq_7.window_end__extract_quarter
-              , subq_7.window_end__extract_month
-              , subq_7.window_end__extract_day
-              , subq_7.window_end__extract_dow
-              , subq_7.window_end__extract_doy
-              , subq_7.lux_listing__window_start__day
-              , subq_7.lux_listing__window_start__week
-              , subq_7.lux_listing__window_start__month
-              , subq_7.lux_listing__window_start__quarter
-              , subq_7.lux_listing__window_start__year
-              , subq_7.lux_listing__window_start__extract_year
-              , subq_7.lux_listing__window_start__extract_quarter
-              , subq_7.lux_listing__window_start__extract_month
-              , subq_7.lux_listing__window_start__extract_day
-              , subq_7.lux_listing__window_start__extract_dow
-              , subq_7.lux_listing__window_start__extract_doy
-              , subq_7.lux_listing__window_end__day
-              , subq_7.lux_listing__window_end__week
-              , subq_7.lux_listing__window_end__month
-              , subq_7.lux_listing__window_end__quarter
-              , subq_7.lux_listing__window_end__year
-              , subq_7.lux_listing__window_end__extract_year
-              , subq_7.lux_listing__window_end__extract_quarter
-              , subq_7.lux_listing__window_end__extract_month
-              , subq_7.lux_listing__window_end__extract_day
-              , subq_7.lux_listing__window_end__extract_dow
-              , subq_7.lux_listing__window_end__extract_doy
-              , subq_7.lux_listing
-              , subq_7.is_confirmed_lux
-              , subq_7.lux_listing__is_confirmed_lux
+              subq_4.window_start__day
+              , subq_4.window_start__week
+              , subq_4.window_start__month
+              , subq_4.window_start__quarter
+              , subq_4.window_start__year
+              , subq_4.window_start__extract_year
+              , subq_4.window_start__extract_quarter
+              , subq_4.window_start__extract_month
+              , subq_4.window_start__extract_day
+              , subq_4.window_start__extract_dow
+              , subq_4.window_start__extract_doy
+              , subq_4.window_end__day
+              , subq_4.window_end__week
+              , subq_4.window_end__month
+              , subq_4.window_end__quarter
+              , subq_4.window_end__year
+              , subq_4.window_end__extract_year
+              , subq_4.window_end__extract_quarter
+              , subq_4.window_end__extract_month
+              , subq_4.window_end__extract_day
+              , subq_4.window_end__extract_dow
+              , subq_4.window_end__extract_doy
+              , subq_4.lux_listing__window_start__day
+              , subq_4.lux_listing__window_start__week
+              , subq_4.lux_listing__window_start__month
+              , subq_4.lux_listing__window_start__quarter
+              , subq_4.lux_listing__window_start__year
+              , subq_4.lux_listing__window_start__extract_year
+              , subq_4.lux_listing__window_start__extract_quarter
+              , subq_4.lux_listing__window_start__extract_month
+              , subq_4.lux_listing__window_start__extract_day
+              , subq_4.lux_listing__window_start__extract_dow
+              , subq_4.lux_listing__window_start__extract_doy
+              , subq_4.lux_listing__window_end__day
+              , subq_4.lux_listing__window_end__week
+              , subq_4.lux_listing__window_end__month
+              , subq_4.lux_listing__window_end__quarter
+              , subq_4.lux_listing__window_end__year
+              , subq_4.lux_listing__window_end__extract_year
+              , subq_4.lux_listing__window_end__extract_quarter
+              , subq_4.lux_listing__window_end__extract_month
+              , subq_4.lux_listing__window_end__extract_day
+              , subq_4.lux_listing__window_end__extract_dow
+              , subq_4.lux_listing__window_end__extract_doy
+              , subq_4.lux_listing
+              , subq_4.is_confirmed_lux
+              , subq_4.lux_listing__is_confirmed_lux
             FROM (
               -- Read Elements From Semantic Model 'lux_listings'
               SELECT
@@ -407,29 +407,29 @@ FROM (
                 , lux_listings_src_26000.is_confirmed_lux AS lux_listing__is_confirmed_lux
                 , lux_listings_src_26000.lux_listing_id AS lux_listing
               FROM ***************************.dim_lux_listings lux_listings_src_26000
-            ) subq_7
-          ) subq_8
+            ) subq_4
+          ) subq_5
           ON
-            subq_6.lux_listing = subq_8.lux_listing
-        ) subq_9
-      ) subq_10
+            subq_3.lux_listing = subq_5.lux_listing
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_5.listing = subq_10.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_5.metric_time__day >= subq_10.lux_listing__window_start__day
+            subq_2.metric_time__day >= subq_7.lux_listing__window_start__day
           ) AND (
             (
-              subq_5.metric_time__day < subq_10.lux_listing__window_end__day
+              subq_2.metric_time__day < subq_7.lux_listing__window_end__day
             ) OR (
-              subq_10.lux_listing__window_end__day IS NULL
+              subq_7.lux_listing__window_end__day IS NULL
             )
           )
         )
-    ) subq_11
-  ) subq_12
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-) subq_13
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time__day AS metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_19.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_19
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_24
+) subq_18
 ON
   (
-    subq_19.listing = subq_24.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
+      subq_13.metric_time__day >= subq_18.lux_listing__window_start__day
     ) AND (
       (
-        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
+        subq_13.metric_time__day < subq_18.lux_listing__window_end__day
       ) OR (
-        subq_24.lux_listing__window_end__day IS NULL
+        subq_18.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_19.metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux
+  subq_13.metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multihop_node__plan0.sql
@@ -1,93 +1,93 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.account_id__customer_id__customer_name
-  , subq_17.txn_count
+  subq_12.account_id__customer_id__customer_name
+  , subq_12.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.account_id__customer_id__customer_name
-    , SUM(subq_16.txn_count) AS txn_count
+    subq_11.account_id__customer_id__customer_name
+    , SUM(subq_11.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_15.account_id__customer_id__customer_name
-      , subq_15.txn_count
+      subq_10.account_id__customer_id__customer_name
+      , subq_10.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_7.ds_partitioned__day AS ds_partitioned__day
-        , subq_14.ds_partitioned__day AS account_id__ds_partitioned__day
-        , subq_7.account_id AS account_id
-        , subq_14.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_7.txn_count AS txn_count
+        subq_2.ds_partitioned__day AS ds_partitioned__day
+        , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.account_id AS account_id
+        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_6.ds_partitioned__day
-          , subq_6.account_id
-          , subq_6.txn_count
+          subq_1.ds_partitioned__day
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds_partitioned__day
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.ds_partitioned__extract_year
-            , subq_5.ds_partitioned__extract_quarter
-            , subq_5.ds_partitioned__extract_month
-            , subq_5.ds_partitioned__extract_day
-            , subq_5.ds_partitioned__extract_dow
-            , subq_5.ds_partitioned__extract_doy
-            , subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.account_id__ds_partitioned__day
-            , subq_5.account_id__ds_partitioned__week
-            , subq_5.account_id__ds_partitioned__month
-            , subq_5.account_id__ds_partitioned__quarter
-            , subq_5.account_id__ds_partitioned__year
-            , subq_5.account_id__ds_partitioned__extract_year
-            , subq_5.account_id__ds_partitioned__extract_quarter
-            , subq_5.account_id__ds_partitioned__extract_month
-            , subq_5.account_id__ds_partitioned__extract_day
-            , subq_5.account_id__ds_partitioned__extract_dow
-            , subq_5.account_id__ds_partitioned__extract_doy
-            , subq_5.account_id__ds__day
-            , subq_5.account_id__ds__week
-            , subq_5.account_id__ds__month
-            , subq_5.account_id__ds__quarter
-            , subq_5.account_id__ds__year
-            , subq_5.account_id__ds__extract_year
-            , subq_5.account_id__ds__extract_quarter
-            , subq_5.account_id__ds__extract_month
-            , subq_5.account_id__ds__extract_day
-            , subq_5.account_id__ds__extract_dow
-            , subq_5.account_id__ds__extract_doy
-            , subq_5.ds__day AS metric_time__day
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.ds__extract_year AS metric_time__extract_year
-            , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_5.ds__extract_month AS metric_time__extract_month
-            , subq_5.ds__extract_day AS metric_time__extract_day
-            , subq_5.ds__extract_dow AS metric_time__extract_dow
-            , subq_5.ds__extract_doy AS metric_time__extract_doy
-            , subq_5.account_id
-            , subq_5.account_month
-            , subq_5.account_id__account_month
-            , subq_5.txn_count
+            subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.account_id__ds_partitioned__day
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds_partitioned__extract_year
+            , subq_0.account_id__ds_partitioned__extract_quarter
+            , subq_0.account_id__ds_partitioned__extract_month
+            , subq_0.account_id__ds_partitioned__extract_day
+            , subq_0.account_id__ds_partitioned__extract_dow
+            , subq_0.account_id__ds_partitioned__extract_doy
+            , subq_0.account_id__ds__day
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.account_id__ds__extract_year
+            , subq_0.account_id__ds__extract_quarter
+            , subq_0.account_id__ds__extract_month
+            , subq_0.account_id__ds__extract_day
+            , subq_0.account_id__ds__extract_dow
+            , subq_0.account_id__ds__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
@@ -140,151 +140,151 @@ FROM (
               , account_month_txns_src_22000.account_month AS account_id__account_month
               , account_month_txns_src_22000.account_id
             FROM ***************************.account_month_txns account_month_txns_src_22000
-          ) subq_5
-        ) subq_6
-      ) subq_7
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_13.ds_partitioned__day
-          , subq_13.account_id
-          , subq_13.customer_id__customer_name
+          subq_8.ds_partitioned__day
+          , subq_8.account_id
+          , subq_8.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_9.ds_partitioned__day AS ds_partitioned__day
-            , subq_9.ds_partitioned__week AS ds_partitioned__week
-            , subq_9.ds_partitioned__month AS ds_partitioned__month
-            , subq_9.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_9.ds_partitioned__year AS ds_partitioned__year
-            , subq_9.ds_partitioned__extract_year AS ds_partitioned__extract_year
-            , subq_9.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-            , subq_9.ds_partitioned__extract_month AS ds_partitioned__extract_month
-            , subq_9.ds_partitioned__extract_day AS ds_partitioned__extract_day
-            , subq_9.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-            , subq_9.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-            , subq_9.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-            , subq_9.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_9.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_9.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_9.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_9.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-            , subq_9.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-            , subq_9.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-            , subq_9.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-            , subq_9.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-            , subq_9.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-            , subq_9.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-            , subq_9.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-            , subq_9.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-            , subq_9.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-            , subq_9.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-            , subq_9.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-            , subq_9.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-            , subq_9.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-            , subq_9.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-            , subq_9.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-            , subq_9.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
-            , subq_9.metric_time__month AS metric_time__month
-            , subq_9.metric_time__quarter AS metric_time__quarter
-            , subq_9.metric_time__year AS metric_time__year
-            , subq_9.metric_time__extract_year AS metric_time__extract_year
-            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_9.metric_time__extract_month AS metric_time__extract_month
-            , subq_9.metric_time__extract_day AS metric_time__extract_day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_12.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_12.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_12.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_12.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_12.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_12.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_12.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_12.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_12.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_12.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_12.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_12.metric_time__day AS customer_id__metric_time__day
-            , subq_12.metric_time__week AS customer_id__metric_time__week
-            , subq_12.metric_time__month AS customer_id__metric_time__month
-            , subq_12.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_12.metric_time__year AS customer_id__metric_time__year
-            , subq_12.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_12.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_12.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_12.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_12.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_12.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-            , subq_9.account_id AS account_id
-            , subq_9.customer_id AS customer_id
-            , subq_9.account_id__customer_id AS account_id__customer_id
-            , subq_9.bridge_account__account_id AS bridge_account__account_id
-            , subq_9.bridge_account__customer_id AS bridge_account__customer_id
-            , subq_9.extra_dim AS extra_dim
-            , subq_9.account_id__extra_dim AS account_id__extra_dim
-            , subq_9.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_12.customer_name AS customer_id__customer_name
-            , subq_12.customer_atomic_weight AS customer_id__customer_atomic_weight
-            , subq_9.account_customer_combos AS account_customer_combos
+            subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_4.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+            , subq_4.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+            , subq_4.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+            , subq_4.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+            , subq_4.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+            , subq_4.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+            , subq_4.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+            , subq_4.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+            , subq_4.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+            , subq_4.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+            , subq_4.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+            , subq_4.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+            , subq_4.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+            , subq_4.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+            , subq_4.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+            , subq_4.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+            , subq_4.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.account_id AS account_id
+            , subq_4.customer_id AS customer_id
+            , subq_4.account_id__customer_id AS account_id__customer_id
+            , subq_4.bridge_account__account_id AS bridge_account__account_id
+            , subq_4.bridge_account__customer_id AS bridge_account__customer_id
+            , subq_4.extra_dim AS extra_dim
+            , subq_4.account_id__extra_dim AS account_id__extra_dim
+            , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
+            , subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'
             SELECT
-              subq_8.ds_partitioned__day
-              , subq_8.ds_partitioned__week
-              , subq_8.ds_partitioned__month
-              , subq_8.ds_partitioned__quarter
-              , subq_8.ds_partitioned__year
-              , subq_8.ds_partitioned__extract_year
-              , subq_8.ds_partitioned__extract_quarter
-              , subq_8.ds_partitioned__extract_month
-              , subq_8.ds_partitioned__extract_day
-              , subq_8.ds_partitioned__extract_dow
-              , subq_8.ds_partitioned__extract_doy
-              , subq_8.account_id__ds_partitioned__day
-              , subq_8.account_id__ds_partitioned__week
-              , subq_8.account_id__ds_partitioned__month
-              , subq_8.account_id__ds_partitioned__quarter
-              , subq_8.account_id__ds_partitioned__year
-              , subq_8.account_id__ds_partitioned__extract_year
-              , subq_8.account_id__ds_partitioned__extract_quarter
-              , subq_8.account_id__ds_partitioned__extract_month
-              , subq_8.account_id__ds_partitioned__extract_day
-              , subq_8.account_id__ds_partitioned__extract_dow
-              , subq_8.account_id__ds_partitioned__extract_doy
-              , subq_8.bridge_account__ds_partitioned__day
-              , subq_8.bridge_account__ds_partitioned__week
-              , subq_8.bridge_account__ds_partitioned__month
-              , subq_8.bridge_account__ds_partitioned__quarter
-              , subq_8.bridge_account__ds_partitioned__year
-              , subq_8.bridge_account__ds_partitioned__extract_year
-              , subq_8.bridge_account__ds_partitioned__extract_quarter
-              , subq_8.bridge_account__ds_partitioned__extract_month
-              , subq_8.bridge_account__ds_partitioned__extract_day
-              , subq_8.bridge_account__ds_partitioned__extract_dow
-              , subq_8.bridge_account__ds_partitioned__extract_doy
-              , subq_8.ds_partitioned__day AS metric_time__day
-              , subq_8.ds_partitioned__week AS metric_time__week
-              , subq_8.ds_partitioned__month AS metric_time__month
-              , subq_8.ds_partitioned__quarter AS metric_time__quarter
-              , subq_8.ds_partitioned__year AS metric_time__year
-              , subq_8.ds_partitioned__extract_year AS metric_time__extract_year
-              , subq_8.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-              , subq_8.ds_partitioned__extract_month AS metric_time__extract_month
-              , subq_8.ds_partitioned__extract_day AS metric_time__extract_day
-              , subq_8.ds_partitioned__extract_dow AS metric_time__extract_dow
-              , subq_8.ds_partitioned__extract_doy AS metric_time__extract_doy
-              , subq_8.account_id
-              , subq_8.customer_id
-              , subq_8.account_id__customer_id
-              , subq_8.bridge_account__account_id
-              , subq_8.bridge_account__customer_id
-              , subq_8.extra_dim
-              , subq_8.account_id__extra_dim
-              , subq_8.bridge_account__extra_dim
-              , subq_8.account_customer_combos
+              subq_3.ds_partitioned__day
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.ds_partitioned__extract_year
+              , subq_3.ds_partitioned__extract_quarter
+              , subq_3.ds_partitioned__extract_month
+              , subq_3.ds_partitioned__extract_day
+              , subq_3.ds_partitioned__extract_dow
+              , subq_3.ds_partitioned__extract_doy
+              , subq_3.account_id__ds_partitioned__day
+              , subq_3.account_id__ds_partitioned__week
+              , subq_3.account_id__ds_partitioned__month
+              , subq_3.account_id__ds_partitioned__quarter
+              , subq_3.account_id__ds_partitioned__year
+              , subq_3.account_id__ds_partitioned__extract_year
+              , subq_3.account_id__ds_partitioned__extract_quarter
+              , subq_3.account_id__ds_partitioned__extract_month
+              , subq_3.account_id__ds_partitioned__extract_day
+              , subq_3.account_id__ds_partitioned__extract_dow
+              , subq_3.account_id__ds_partitioned__extract_doy
+              , subq_3.bridge_account__ds_partitioned__day
+              , subq_3.bridge_account__ds_partitioned__week
+              , subq_3.bridge_account__ds_partitioned__month
+              , subq_3.bridge_account__ds_partitioned__quarter
+              , subq_3.bridge_account__ds_partitioned__year
+              , subq_3.bridge_account__ds_partitioned__extract_year
+              , subq_3.bridge_account__ds_partitioned__extract_quarter
+              , subq_3.bridge_account__ds_partitioned__extract_month
+              , subq_3.bridge_account__ds_partitioned__extract_day
+              , subq_3.bridge_account__ds_partitioned__extract_dow
+              , subq_3.bridge_account__ds_partitioned__extract_doy
+              , subq_3.ds_partitioned__day AS metric_time__day
+              , subq_3.ds_partitioned__week AS metric_time__week
+              , subq_3.ds_partitioned__month AS metric_time__month
+              , subq_3.ds_partitioned__quarter AS metric_time__quarter
+              , subq_3.ds_partitioned__year AS metric_time__year
+              , subq_3.ds_partitioned__extract_year AS metric_time__extract_year
+              , subq_3.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+              , subq_3.ds_partitioned__extract_month AS metric_time__extract_month
+              , subq_3.ds_partitioned__extract_day AS metric_time__extract_day
+              , subq_3.ds_partitioned__extract_dow AS metric_time__extract_dow
+              , subq_3.ds_partitioned__extract_doy AS metric_time__extract_doy
+              , subq_3.account_id
+              , subq_3.customer_id
+              , subq_3.account_id__customer_id
+              , subq_3.bridge_account__account_id
+              , subq_3.bridge_account__customer_id
+              , subq_3.extra_dim
+              , subq_3.account_id__extra_dim
+              , subq_3.bridge_account__extra_dim
+              , subq_3.account_customer_combos
             FROM (
               -- Read Elements From Semantic Model 'bridge_table'
               SELECT
@@ -331,8 +331,8 @@ FROM (
                 , bridge_table_src_22000.account_id AS bridge_account__account_id
                 , bridge_table_src_22000.customer_id AS bridge_account__customer_id
               FROM ***************************.bridge_table bridge_table_src_22000
-            ) subq_8
-          ) subq_9
+            ) subq_3
+          ) subq_4
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'customer_name',
@@ -375,86 +375,86 @@ FROM (
             --   'customer_id',
             -- ]
             SELECT
-              subq_11.ds_partitioned__day
-              , subq_11.ds_partitioned__week
-              , subq_11.ds_partitioned__month
-              , subq_11.ds_partitioned__quarter
-              , subq_11.ds_partitioned__year
-              , subq_11.ds_partitioned__extract_year
-              , subq_11.ds_partitioned__extract_quarter
-              , subq_11.ds_partitioned__extract_month
-              , subq_11.ds_partitioned__extract_day
-              , subq_11.ds_partitioned__extract_dow
-              , subq_11.ds_partitioned__extract_doy
-              , subq_11.customer_id__ds_partitioned__day
-              , subq_11.customer_id__ds_partitioned__week
-              , subq_11.customer_id__ds_partitioned__month
-              , subq_11.customer_id__ds_partitioned__quarter
-              , subq_11.customer_id__ds_partitioned__year
-              , subq_11.customer_id__ds_partitioned__extract_year
-              , subq_11.customer_id__ds_partitioned__extract_quarter
-              , subq_11.customer_id__ds_partitioned__extract_month
-              , subq_11.customer_id__ds_partitioned__extract_day
-              , subq_11.customer_id__ds_partitioned__extract_dow
-              , subq_11.customer_id__ds_partitioned__extract_doy
-              , subq_11.metric_time__day
-              , subq_11.metric_time__week
-              , subq_11.metric_time__month
-              , subq_11.metric_time__quarter
-              , subq_11.metric_time__year
-              , subq_11.metric_time__extract_year
-              , subq_11.metric_time__extract_quarter
-              , subq_11.metric_time__extract_month
-              , subq_11.metric_time__extract_day
-              , subq_11.metric_time__extract_dow
-              , subq_11.metric_time__extract_doy
-              , subq_11.customer_id
-              , subq_11.customer_name
-              , subq_11.customer_atomic_weight
-              , subq_11.customer_id__customer_name
-              , subq_11.customer_id__customer_atomic_weight
+              subq_6.ds_partitioned__day
+              , subq_6.ds_partitioned__week
+              , subq_6.ds_partitioned__month
+              , subq_6.ds_partitioned__quarter
+              , subq_6.ds_partitioned__year
+              , subq_6.ds_partitioned__extract_year
+              , subq_6.ds_partitioned__extract_quarter
+              , subq_6.ds_partitioned__extract_month
+              , subq_6.ds_partitioned__extract_day
+              , subq_6.ds_partitioned__extract_dow
+              , subq_6.ds_partitioned__extract_doy
+              , subq_6.customer_id__ds_partitioned__day
+              , subq_6.customer_id__ds_partitioned__week
+              , subq_6.customer_id__ds_partitioned__month
+              , subq_6.customer_id__ds_partitioned__quarter
+              , subq_6.customer_id__ds_partitioned__year
+              , subq_6.customer_id__ds_partitioned__extract_year
+              , subq_6.customer_id__ds_partitioned__extract_quarter
+              , subq_6.customer_id__ds_partitioned__extract_month
+              , subq_6.customer_id__ds_partitioned__extract_day
+              , subq_6.customer_id__ds_partitioned__extract_dow
+              , subq_6.customer_id__ds_partitioned__extract_doy
+              , subq_6.metric_time__day
+              , subq_6.metric_time__week
+              , subq_6.metric_time__month
+              , subq_6.metric_time__quarter
+              , subq_6.metric_time__year
+              , subq_6.metric_time__extract_year
+              , subq_6.metric_time__extract_quarter
+              , subq_6.metric_time__extract_month
+              , subq_6.metric_time__extract_day
+              , subq_6.metric_time__extract_dow
+              , subq_6.metric_time__extract_doy
+              , subq_6.customer_id
+              , subq_6.customer_name
+              , subq_6.customer_atomic_weight
+              , subq_6.customer_id__customer_name
+              , subq_6.customer_id__customer_atomic_weight
             FROM (
               -- Metric Time Dimension 'ds_partitioned'
               SELECT
-                subq_10.ds_partitioned__day
-                , subq_10.ds_partitioned__week
-                , subq_10.ds_partitioned__month
-                , subq_10.ds_partitioned__quarter
-                , subq_10.ds_partitioned__year
-                , subq_10.ds_partitioned__extract_year
-                , subq_10.ds_partitioned__extract_quarter
-                , subq_10.ds_partitioned__extract_month
-                , subq_10.ds_partitioned__extract_day
-                , subq_10.ds_partitioned__extract_dow
-                , subq_10.ds_partitioned__extract_doy
-                , subq_10.customer_id__ds_partitioned__day
-                , subq_10.customer_id__ds_partitioned__week
-                , subq_10.customer_id__ds_partitioned__month
-                , subq_10.customer_id__ds_partitioned__quarter
-                , subq_10.customer_id__ds_partitioned__year
-                , subq_10.customer_id__ds_partitioned__extract_year
-                , subq_10.customer_id__ds_partitioned__extract_quarter
-                , subq_10.customer_id__ds_partitioned__extract_month
-                , subq_10.customer_id__ds_partitioned__extract_day
-                , subq_10.customer_id__ds_partitioned__extract_dow
-                , subq_10.customer_id__ds_partitioned__extract_doy
-                , subq_10.ds_partitioned__day AS metric_time__day
-                , subq_10.ds_partitioned__week AS metric_time__week
-                , subq_10.ds_partitioned__month AS metric_time__month
-                , subq_10.ds_partitioned__quarter AS metric_time__quarter
-                , subq_10.ds_partitioned__year AS metric_time__year
-                , subq_10.ds_partitioned__extract_year AS metric_time__extract_year
-                , subq_10.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                , subq_10.ds_partitioned__extract_month AS metric_time__extract_month
-                , subq_10.ds_partitioned__extract_day AS metric_time__extract_day
-                , subq_10.ds_partitioned__extract_dow AS metric_time__extract_dow
-                , subq_10.ds_partitioned__extract_doy AS metric_time__extract_doy
-                , subq_10.customer_id
-                , subq_10.customer_name
-                , subq_10.customer_atomic_weight
-                , subq_10.customer_id__customer_name
-                , subq_10.customer_id__customer_atomic_weight
-                , subq_10.customers
+                subq_5.ds_partitioned__day
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.ds_partitioned__extract_year
+                , subq_5.ds_partitioned__extract_quarter
+                , subq_5.ds_partitioned__extract_month
+                , subq_5.ds_partitioned__extract_day
+                , subq_5.ds_partitioned__extract_dow
+                , subq_5.ds_partitioned__extract_doy
+                , subq_5.customer_id__ds_partitioned__day
+                , subq_5.customer_id__ds_partitioned__week
+                , subq_5.customer_id__ds_partitioned__month
+                , subq_5.customer_id__ds_partitioned__quarter
+                , subq_5.customer_id__ds_partitioned__year
+                , subq_5.customer_id__ds_partitioned__extract_year
+                , subq_5.customer_id__ds_partitioned__extract_quarter
+                , subq_5.customer_id__ds_partitioned__extract_month
+                , subq_5.customer_id__ds_partitioned__extract_day
+                , subq_5.customer_id__ds_partitioned__extract_dow
+                , subq_5.customer_id__ds_partitioned__extract_doy
+                , subq_5.ds_partitioned__day AS metric_time__day
+                , subq_5.ds_partitioned__week AS metric_time__week
+                , subq_5.ds_partitioned__month AS metric_time__month
+                , subq_5.ds_partitioned__quarter AS metric_time__quarter
+                , subq_5.ds_partitioned__year AS metric_time__year
+                , subq_5.ds_partitioned__extract_year AS metric_time__extract_year
+                , subq_5.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                , subq_5.ds_partitioned__extract_month AS metric_time__extract_month
+                , subq_5.ds_partitioned__extract_day AS metric_time__extract_day
+                , subq_5.ds_partitioned__extract_dow AS metric_time__extract_dow
+                , subq_5.ds_partitioned__extract_doy AS metric_time__extract_doy
+                , subq_5.customer_id
+                , subq_5.customer_name
+                , subq_5.customer_atomic_weight
+                , subq_5.customer_id__customer_name
+                , subq_5.customer_id__customer_atomic_weight
+                , subq_5.customers
               FROM (
                 -- Read Elements From Semantic Model 'customer_table'
                 SELECT
@@ -487,25 +487,25 @@ FROM (
                   , EXTRACT(doy FROM customer_table_src_22000.ds_partitioned) AS customer_id__ds_partitioned__extract_doy
                   , customer_table_src_22000.customer_id
                 FROM ***************************.customer_table customer_table_src_22000
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_5
+            ) subq_6
+          ) subq_7
           ON
             (
-              subq_9.customer_id = subq_12.customer_id
+              subq_4.customer_id = subq_7.customer_id
             ) AND (
-              subq_9.ds_partitioned__day = subq_12.ds_partitioned__day
+              subq_4.ds_partitioned__day = subq_7.ds_partitioned__day
             )
-        ) subq_13
-      ) subq_14
+        ) subq_8
+      ) subq_9
       ON
         (
-          subq_7.account_id = subq_14.account_id
+          subq_2.account_id = subq_9.account_id
         ) AND (
-          subq_7.ds_partitioned__day = subq_14.ds_partitioned__day
+          subq_2.ds_partitioned__day = subq_9.ds_partitioned__day
         )
-    ) subq_15
-  ) subq_16
+    ) subq_10
+  ) subq_11
   GROUP BY
-    subq_16.account_id__customer_id__customer_name
-) subq_17
+    subq_11.account_id__customer_id__customer_name
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_22.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_32
+) subq_22
 ON
   (
-    account_month_txns_src_22000.account_id = subq_32.account_id
+    account_month_txns_src_22000.account_id = subq_22.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_22.ds_partitioned__day
   )
 GROUP BY
-  subq_32.customer_id__customer_name
+  subq_22.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,221 +1,221 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_9.bookings) AS bookings
-  , MAX(subq_15.listings) AS listings
+  MAX(subq_5.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.bookings
+    subq_4.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_7.bookings) AS bookings
+      SUM(subq_3.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings',]
       SELECT
-        subq_6.bookings
+        subq_2.bookings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_5.ds__day
-          , subq_5.ds__week
-          , subq_5.ds__month
-          , subq_5.ds__quarter
-          , subq_5.ds__year
-          , subq_5.ds__extract_year
-          , subq_5.ds__extract_quarter
-          , subq_5.ds__extract_month
-          , subq_5.ds__extract_day
-          , subq_5.ds__extract_dow
-          , subq_5.ds__extract_doy
-          , subq_5.ds_partitioned__day
-          , subq_5.ds_partitioned__week
-          , subq_5.ds_partitioned__month
-          , subq_5.ds_partitioned__quarter
-          , subq_5.ds_partitioned__year
-          , subq_5.ds_partitioned__extract_year
-          , subq_5.ds_partitioned__extract_quarter
-          , subq_5.ds_partitioned__extract_month
-          , subq_5.ds_partitioned__extract_day
-          , subq_5.ds_partitioned__extract_dow
-          , subq_5.ds_partitioned__extract_doy
-          , subq_5.paid_at__day
-          , subq_5.paid_at__week
-          , subq_5.paid_at__month
-          , subq_5.paid_at__quarter
-          , subq_5.paid_at__year
-          , subq_5.paid_at__extract_year
-          , subq_5.paid_at__extract_quarter
-          , subq_5.paid_at__extract_month
-          , subq_5.paid_at__extract_day
-          , subq_5.paid_at__extract_dow
-          , subq_5.paid_at__extract_doy
-          , subq_5.booking__ds__day
-          , subq_5.booking__ds__week
-          , subq_5.booking__ds__month
-          , subq_5.booking__ds__quarter
-          , subq_5.booking__ds__year
-          , subq_5.booking__ds__extract_year
-          , subq_5.booking__ds__extract_quarter
-          , subq_5.booking__ds__extract_month
-          , subq_5.booking__ds__extract_day
-          , subq_5.booking__ds__extract_dow
-          , subq_5.booking__ds__extract_doy
-          , subq_5.booking__ds_partitioned__day
-          , subq_5.booking__ds_partitioned__week
-          , subq_5.booking__ds_partitioned__month
-          , subq_5.booking__ds_partitioned__quarter
-          , subq_5.booking__ds_partitioned__year
-          , subq_5.booking__ds_partitioned__extract_year
-          , subq_5.booking__ds_partitioned__extract_quarter
-          , subq_5.booking__ds_partitioned__extract_month
-          , subq_5.booking__ds_partitioned__extract_day
-          , subq_5.booking__ds_partitioned__extract_dow
-          , subq_5.booking__ds_partitioned__extract_doy
-          , subq_5.booking__paid_at__day
-          , subq_5.booking__paid_at__week
-          , subq_5.booking__paid_at__month
-          , subq_5.booking__paid_at__quarter
-          , subq_5.booking__paid_at__year
-          , subq_5.booking__paid_at__extract_year
-          , subq_5.booking__paid_at__extract_quarter
-          , subq_5.booking__paid_at__extract_month
-          , subq_5.booking__paid_at__extract_day
-          , subq_5.booking__paid_at__extract_dow
-          , subq_5.booking__paid_at__extract_doy
-          , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
-          , subq_5.listing
-          , subq_5.guest
-          , subq_5.host
-          , subq_5.booking__listing
-          , subq_5.booking__guest
-          , subq_5.booking__host
-          , subq_5.is_instant
-          , subq_5.booking__is_instant
-          , subq_5.bookings
-          , subq_5.instant_bookings
-          , subq_5.booking_value
-          , subq_5.max_booking_value
-          , subq_5.min_booking_value
-          , subq_5.bookers
-          , subq_5.average_booking_value
-          , subq_5.referred_bookings
-          , subq_5.median_booking_value
-          , subq_5.booking_value_p99
-          , subq_5.discrete_booking_value_p99
-          , subq_5.approximate_continuous_booking_value_p99
-          , subq_5.approximate_discrete_booking_value_p99
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds_partitioned__day
+          , subq_1.ds_partitioned__week
+          , subq_1.ds_partitioned__month
+          , subq_1.ds_partitioned__quarter
+          , subq_1.ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy
+          , subq_1.paid_at__day
+          , subq_1.paid_at__week
+          , subq_1.paid_at__month
+          , subq_1.paid_at__quarter
+          , subq_1.paid_at__year
+          , subq_1.paid_at__extract_year
+          , subq_1.paid_at__extract_quarter
+          , subq_1.paid_at__extract_month
+          , subq_1.paid_at__extract_day
+          , subq_1.paid_at__extract_dow
+          , subq_1.paid_at__extract_doy
+          , subq_1.booking__ds__day
+          , subq_1.booking__ds__week
+          , subq_1.booking__ds__month
+          , subq_1.booking__ds__quarter
+          , subq_1.booking__ds__year
+          , subq_1.booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month
+          , subq_1.booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day
+          , subq_1.booking__paid_at__week
+          , subq_1.booking__paid_at__month
+          , subq_1.booking__paid_at__quarter
+          , subq_1.booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy
+          , subq_1.metric_time__day
+          , subq_1.metric_time__week
+          , subq_1.metric_time__month
+          , subq_1.metric_time__quarter
+          , subq_1.metric_time__year
+          , subq_1.metric_time__extract_year
+          , subq_1.metric_time__extract_quarter
+          , subq_1.metric_time__extract_month
+          , subq_1.metric_time__extract_day
+          , subq_1.metric_time__extract_dow
+          , subq_1.metric_time__extract_doy
+          , subq_1.listing
+          , subq_1.guest
+          , subq_1.host
+          , subq_1.booking__listing
+          , subq_1.booking__guest
+          , subq_1.booking__host
+          , subq_1.is_instant
+          , subq_1.booking__is_instant
+          , subq_1.bookings
+          , subq_1.instant_bookings
+          , subq_1.booking_value
+          , subq_1.max_booking_value
+          , subq_1.min_booking_value
+          , subq_1.bookers
+          , subq_1.average_booking_value
+          , subq_1.referred_bookings
+          , subq_1.median_booking_value
+          , subq_1.booking_value_p99
+          , subq_1.discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds__day
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds__extract_year
-            , subq_4.ds__extract_quarter
-            , subq_4.ds__extract_month
-            , subq_4.ds__extract_day
-            , subq_4.ds__extract_dow
-            , subq_4.ds__extract_doy
-            , subq_4.ds_partitioned__day
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.ds_partitioned__extract_year
-            , subq_4.ds_partitioned__extract_quarter
-            , subq_4.ds_partitioned__extract_month
-            , subq_4.ds_partitioned__extract_day
-            , subq_4.ds_partitioned__extract_dow
-            , subq_4.ds_partitioned__extract_doy
-            , subq_4.paid_at__day
-            , subq_4.paid_at__week
-            , subq_4.paid_at__month
-            , subq_4.paid_at__quarter
-            , subq_4.paid_at__year
-            , subq_4.paid_at__extract_year
-            , subq_4.paid_at__extract_quarter
-            , subq_4.paid_at__extract_month
-            , subq_4.paid_at__extract_day
-            , subq_4.paid_at__extract_dow
-            , subq_4.paid_at__extract_doy
-            , subq_4.booking__ds__day
-            , subq_4.booking__ds__week
-            , subq_4.booking__ds__month
-            , subq_4.booking__ds__quarter
-            , subq_4.booking__ds__year
-            , subq_4.booking__ds__extract_year
-            , subq_4.booking__ds__extract_quarter
-            , subq_4.booking__ds__extract_month
-            , subq_4.booking__ds__extract_day
-            , subq_4.booking__ds__extract_dow
-            , subq_4.booking__ds__extract_doy
-            , subq_4.booking__ds_partitioned__day
-            , subq_4.booking__ds_partitioned__week
-            , subq_4.booking__ds_partitioned__month
-            , subq_4.booking__ds_partitioned__quarter
-            , subq_4.booking__ds_partitioned__year
-            , subq_4.booking__ds_partitioned__extract_year
-            , subq_4.booking__ds_partitioned__extract_quarter
-            , subq_4.booking__ds_partitioned__extract_month
-            , subq_4.booking__ds_partitioned__extract_day
-            , subq_4.booking__ds_partitioned__extract_dow
-            , subq_4.booking__ds_partitioned__extract_doy
-            , subq_4.booking__paid_at__day
-            , subq_4.booking__paid_at__week
-            , subq_4.booking__paid_at__month
-            , subq_4.booking__paid_at__quarter
-            , subq_4.booking__paid_at__year
-            , subq_4.booking__paid_at__extract_year
-            , subq_4.booking__paid_at__extract_quarter
-            , subq_4.booking__paid_at__extract_month
-            , subq_4.booking__paid_at__extract_day
-            , subq_4.booking__paid_at__extract_dow
-            , subq_4.booking__paid_at__extract_doy
-            , subq_4.ds__day AS metric_time__day
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.ds__extract_year AS metric_time__extract_year
-            , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_4.ds__extract_month AS metric_time__extract_month
-            , subq_4.ds__extract_day AS metric_time__extract_day
-            , subq_4.ds__extract_dow AS metric_time__extract_dow
-            , subq_4.ds__extract_doy AS metric_time__extract_doy
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.booking__listing
-            , subq_4.booking__guest
-            , subq_4.booking__host
-            , subq_4.is_instant
-            , subq_4.booking__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
-            , subq_4.median_booking_value
-            , subq_4.booking_value_p99
-            , subq_4.discrete_booking_value_p99
-            , subq_4.approximate_continuous_booking_value_p99
-            , subq_4.approximate_discrete_booking_value_p99
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -308,165 +308,165 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_4
-        ) subq_5
-        WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_0
+        ) subq_1
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_2
+    ) subq_3
+  ) subq_4
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_14.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_13.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements: ['listings',]
       SELECT
-        subq_12.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_11.ds__day
-          , subq_11.ds__week
-          , subq_11.ds__month
-          , subq_11.ds__quarter
-          , subq_11.ds__year
-          , subq_11.ds__extract_year
-          , subq_11.ds__extract_quarter
-          , subq_11.ds__extract_month
-          , subq_11.ds__extract_day
-          , subq_11.ds__extract_dow
-          , subq_11.ds__extract_doy
-          , subq_11.created_at__day
-          , subq_11.created_at__week
-          , subq_11.created_at__month
-          , subq_11.created_at__quarter
-          , subq_11.created_at__year
-          , subq_11.created_at__extract_year
-          , subq_11.created_at__extract_quarter
-          , subq_11.created_at__extract_month
-          , subq_11.created_at__extract_day
-          , subq_11.created_at__extract_dow
-          , subq_11.created_at__extract_doy
-          , subq_11.listing__ds__day
-          , subq_11.listing__ds__week
-          , subq_11.listing__ds__month
-          , subq_11.listing__ds__quarter
-          , subq_11.listing__ds__year
-          , subq_11.listing__ds__extract_year
-          , subq_11.listing__ds__extract_quarter
-          , subq_11.listing__ds__extract_month
-          , subq_11.listing__ds__extract_day
-          , subq_11.listing__ds__extract_dow
-          , subq_11.listing__ds__extract_doy
-          , subq_11.listing__created_at__day
-          , subq_11.listing__created_at__week
-          , subq_11.listing__created_at__month
-          , subq_11.listing__created_at__quarter
-          , subq_11.listing__created_at__year
-          , subq_11.listing__created_at__extract_year
-          , subq_11.listing__created_at__extract_quarter
-          , subq_11.listing__created_at__extract_month
-          , subq_11.listing__created_at__extract_day
-          , subq_11.listing__created_at__extract_dow
-          , subq_11.listing__created_at__extract_doy
-          , subq_11.metric_time__day
-          , subq_11.metric_time__week
-          , subq_11.metric_time__month
-          , subq_11.metric_time__quarter
-          , subq_11.metric_time__year
-          , subq_11.metric_time__extract_year
-          , subq_11.metric_time__extract_quarter
-          , subq_11.metric_time__extract_month
-          , subq_11.metric_time__extract_day
-          , subq_11.metric_time__extract_dow
-          , subq_11.metric_time__extract_doy
-          , subq_11.listing
-          , subq_11.user
-          , subq_11.listing__user
-          , subq_11.country_latest
-          , subq_11.is_lux_latest
-          , subq_11.capacity_latest
-          , subq_11.listing__country_latest
-          , subq_11.listing__is_lux_latest
-          , subq_11.listing__capacity_latest
-          , subq_11.listings
-          , subq_11.largest_listing
-          , subq_11.smallest_listing
+          subq_7.ds__day
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.ds__extract_year
+          , subq_7.ds__extract_quarter
+          , subq_7.ds__extract_month
+          , subq_7.ds__extract_day
+          , subq_7.ds__extract_dow
+          , subq_7.ds__extract_doy
+          , subq_7.created_at__day
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.created_at__extract_year
+          , subq_7.created_at__extract_quarter
+          , subq_7.created_at__extract_month
+          , subq_7.created_at__extract_day
+          , subq_7.created_at__extract_dow
+          , subq_7.created_at__extract_doy
+          , subq_7.listing__ds__day
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__ds__extract_year
+          , subq_7.listing__ds__extract_quarter
+          , subq_7.listing__ds__extract_month
+          , subq_7.listing__ds__extract_day
+          , subq_7.listing__ds__extract_dow
+          , subq_7.listing__ds__extract_doy
+          , subq_7.listing__created_at__day
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.listing__created_at__extract_year
+          , subq_7.listing__created_at__extract_quarter
+          , subq_7.listing__created_at__extract_month
+          , subq_7.listing__created_at__extract_day
+          , subq_7.listing__created_at__extract_dow
+          , subq_7.listing__created_at__extract_doy
+          , subq_7.metric_time__day
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.created_at__day
-            , subq_10.created_at__week
-            , subq_10.created_at__month
-            , subq_10.created_at__quarter
-            , subq_10.created_at__year
-            , subq_10.created_at__extract_year
-            , subq_10.created_at__extract_quarter
-            , subq_10.created_at__extract_month
-            , subq_10.created_at__extract_day
-            , subq_10.created_at__extract_dow
-            , subq_10.created_at__extract_doy
-            , subq_10.listing__ds__day
-            , subq_10.listing__ds__week
-            , subq_10.listing__ds__month
-            , subq_10.listing__ds__quarter
-            , subq_10.listing__ds__year
-            , subq_10.listing__ds__extract_year
-            , subq_10.listing__ds__extract_quarter
-            , subq_10.listing__ds__extract_month
-            , subq_10.listing__ds__extract_day
-            , subq_10.listing__ds__extract_dow
-            , subq_10.listing__ds__extract_doy
-            , subq_10.listing__created_at__day
-            , subq_10.listing__created_at__week
-            , subq_10.listing__created_at__month
-            , subq_10.listing__created_at__quarter
-            , subq_10.listing__created_at__year
-            , subq_10.listing__created_at__extract_year
-            , subq_10.listing__created_at__extract_quarter
-            , subq_10.listing__created_at__extract_month
-            , subq_10.listing__created_at__extract_day
-            , subq_10.listing__created_at__extract_dow
-            , subq_10.listing__created_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.user
-            , subq_10.listing__user
-            , subq_10.country_latest
-            , subq_10.is_lux_latest
-            , subq_10.capacity_latest
-            , subq_10.listing__country_latest
-            , subq_10.listing__is_lux_latest
-            , subq_10.listing__capacity_latest
-            , subq_10.listings
-            , subq_10.largest_listing
-            , subq_10.smallest_listing
+            subq_6.ds__day
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds__extract_year
+            , subq_6.ds__extract_quarter
+            , subq_6.ds__extract_month
+            , subq_6.ds__extract_day
+            , subq_6.ds__extract_dow
+            , subq_6.ds__extract_doy
+            , subq_6.created_at__day
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.created_at__extract_year
+            , subq_6.created_at__extract_quarter
+            , subq_6.created_at__extract_month
+            , subq_6.created_at__extract_day
+            , subq_6.created_at__extract_dow
+            , subq_6.created_at__extract_doy
+            , subq_6.listing__ds__day
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__ds__extract_year
+            , subq_6.listing__ds__extract_quarter
+            , subq_6.listing__ds__extract_month
+            , subq_6.listing__ds__extract_day
+            , subq_6.listing__ds__extract_dow
+            , subq_6.listing__ds__extract_doy
+            , subq_6.listing__created_at__day
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.listing__created_at__extract_year
+            , subq_6.listing__created_at__extract_quarter
+            , subq_6.listing__created_at__extract_month
+            , subq_6.listing__created_at__extract_day
+            , subq_6.listing__created_at__extract_dow
+            , subq_6.listing__created_at__extract_doy
+            , subq_6.ds__day AS metric_time__day
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.ds__extract_year AS metric_time__extract_year
+            , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_6.ds__extract_month AS metric_time__extract_month
+            , subq_6.ds__extract_day AS metric_time__extract_day
+            , subq_6.ds__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__extract_doy AS metric_time__extract_doy
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -527,10 +527,10 @@ CROSS JOIN (
               , listings_latest_src_28000.user_id AS user
               , listings_latest_src_28000.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_28000
-          ) subq_10
-        ) subq_11
-        WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_12
-    ) subq_13
-  ) subq_14
-) subq_15
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_8
+    ) subq_9
+  ) subq_10
+) subq_11

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_25.bookings) AS bookings
-  , MAX(subq_31.listings) AS listings
+  MAX(subq_17.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_25
+) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_31
+) subq_23

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_15.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_13.metric_time__day
+  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_14.booking_value) AS booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_12.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.booking_value AS booking_value_with_is_instant_constraint
+      subq_6.metric_time__day
+      , subq_6.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , SUM(subq_7.booking_value) AS booking_value
+        subq_5.metric_time__day
+        , SUM(subq_5.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.booking_value
+          subq_4.metric_time__day
+          , subq_4.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.booking_value
+      subq_11.metric_time__day
+      , subq_11.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , SUM(subq_12.booking_value) AS booking_value
+        subq_10.metric_time__day
+        , SUM(subq_10.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.booking_value
+          subq_9.metric_time__day
+          , subq_9.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_30.booking_value) AS booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_26.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
+  subq_7.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.metric_time__day
-    , subq_8.bookings AS delayed_bookings
+    subq_6.metric_time__day
+    , subq_6.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -323,15 +323,15 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE NOT booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE NOT booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
-) subq_9
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_9
     WHERE NOT booking__is_instant
-  ) subq_15
+  ) subq_11
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_19
+) subq_15

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.listing__user__home_state_latest
-  , subq_21.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__user__home_state_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-    , SUM(subq_20.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__user__home_state_latest', 'metric_time__day']
     SELECT
-      subq_19.metric_time__day
-      , subq_19.listing__user__home_state_latest
-      , subq_19.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__user__home_state_latest
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_13.metric_time__day AS metric_time__day
-        , subq_18.window_start__day AS listing__window_start__day
-        , subq_18.window_end__day AS listing__window_end__day
-        , subq_13.listing AS listing
-        , subq_18.user__home_state_latest AS listing__user__home_state_latest
-        , subq_13.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.window_start__day AS listing__window_start__day
+        , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.user__home_state_latest AS listing__user__home_state_latest
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_12.metric_time__day
-          , subq_12.listing
-          , subq_12.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds__day
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds__extract_year
-            , subq_11.ds__extract_quarter
-            , subq_11.ds__extract_month
-            , subq_11.ds__extract_day
-            , subq_11.ds__extract_dow
-            , subq_11.ds__extract_doy
-            , subq_11.ds_partitioned__day
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.ds_partitioned__extract_year
-            , subq_11.ds_partitioned__extract_quarter
-            , subq_11.ds_partitioned__extract_month
-            , subq_11.ds_partitioned__extract_day
-            , subq_11.ds_partitioned__extract_dow
-            , subq_11.ds_partitioned__extract_doy
-            , subq_11.paid_at__day
-            , subq_11.paid_at__week
-            , subq_11.paid_at__month
-            , subq_11.paid_at__quarter
-            , subq_11.paid_at__year
-            , subq_11.paid_at__extract_year
-            , subq_11.paid_at__extract_quarter
-            , subq_11.paid_at__extract_month
-            , subq_11.paid_at__extract_day
-            , subq_11.paid_at__extract_dow
-            , subq_11.paid_at__extract_doy
-            , subq_11.booking__ds__day
-            , subq_11.booking__ds__week
-            , subq_11.booking__ds__month
-            , subq_11.booking__ds__quarter
-            , subq_11.booking__ds__year
-            , subq_11.booking__ds__extract_year
-            , subq_11.booking__ds__extract_quarter
-            , subq_11.booking__ds__extract_month
-            , subq_11.booking__ds__extract_day
-            , subq_11.booking__ds__extract_dow
-            , subq_11.booking__ds__extract_doy
-            , subq_11.booking__ds_partitioned__day
-            , subq_11.booking__ds_partitioned__week
-            , subq_11.booking__ds_partitioned__month
-            , subq_11.booking__ds_partitioned__quarter
-            , subq_11.booking__ds_partitioned__year
-            , subq_11.booking__ds_partitioned__extract_year
-            , subq_11.booking__ds_partitioned__extract_quarter
-            , subq_11.booking__ds_partitioned__extract_month
-            , subq_11.booking__ds_partitioned__extract_day
-            , subq_11.booking__ds_partitioned__extract_dow
-            , subq_11.booking__ds_partitioned__extract_doy
-            , subq_11.booking__paid_at__day
-            , subq_11.booking__paid_at__week
-            , subq_11.booking__paid_at__month
-            , subq_11.booking__paid_at__quarter
-            , subq_11.booking__paid_at__year
-            , subq_11.booking__paid_at__extract_year
-            , subq_11.booking__paid_at__extract_quarter
-            , subq_11.booking__paid_at__extract_month
-            , subq_11.booking__paid_at__extract_day
-            , subq_11.booking__paid_at__extract_dow
-            , subq_11.booking__paid_at__extract_doy
-            , subq_11.ds__day AS metric_time__day
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.ds__extract_year AS metric_time__extract_year
-            , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_11.ds__extract_month AS metric_time__extract_month
-            , subq_11.ds__extract_day AS metric_time__extract_day
-            , subq_11.ds__extract_dow AS metric_time__extract_dow
-            , subq_11.ds__extract_doy AS metric_time__extract_doy
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.user
-            , subq_11.booking__listing
-            , subq_11.booking__guest
-            , subq_11.booking__host
-            , subq_11.booking__user
-            , subq_11.is_instant
-            , subq_11.booking__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,84 +211,84 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
         SELECT
-          subq_17.window_start__day
-          , subq_17.window_end__day
-          , subq_17.listing
-          , subq_17.user__home_state_latest
+          subq_6.window_start__day
+          , subq_6.window_end__day
+          , subq_6.listing
+          , subq_6.user__home_state_latest
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.window_start__day AS window_start__day
-            , subq_14.window_start__week AS window_start__week
-            , subq_14.window_start__month AS window_start__month
-            , subq_14.window_start__quarter AS window_start__quarter
-            , subq_14.window_start__year AS window_start__year
-            , subq_14.window_start__extract_year AS window_start__extract_year
-            , subq_14.window_start__extract_quarter AS window_start__extract_quarter
-            , subq_14.window_start__extract_month AS window_start__extract_month
-            , subq_14.window_start__extract_day AS window_start__extract_day
-            , subq_14.window_start__extract_dow AS window_start__extract_dow
-            , subq_14.window_start__extract_doy AS window_start__extract_doy
-            , subq_14.window_end__day AS window_end__day
-            , subq_14.window_end__week AS window_end__week
-            , subq_14.window_end__month AS window_end__month
-            , subq_14.window_end__quarter AS window_end__quarter
-            , subq_14.window_end__year AS window_end__year
-            , subq_14.window_end__extract_year AS window_end__extract_year
-            , subq_14.window_end__extract_quarter AS window_end__extract_quarter
-            , subq_14.window_end__extract_month AS window_end__extract_month
-            , subq_14.window_end__extract_day AS window_end__extract_day
-            , subq_14.window_end__extract_dow AS window_end__extract_dow
-            , subq_14.window_end__extract_doy AS window_end__extract_doy
-            , subq_14.listing__window_start__day AS listing__window_start__day
-            , subq_14.listing__window_start__week AS listing__window_start__week
-            , subq_14.listing__window_start__month AS listing__window_start__month
-            , subq_14.listing__window_start__quarter AS listing__window_start__quarter
-            , subq_14.listing__window_start__year AS listing__window_start__year
-            , subq_14.listing__window_start__extract_year AS listing__window_start__extract_year
-            , subq_14.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
-            , subq_14.listing__window_start__extract_month AS listing__window_start__extract_month
-            , subq_14.listing__window_start__extract_day AS listing__window_start__extract_day
-            , subq_14.listing__window_start__extract_dow AS listing__window_start__extract_dow
-            , subq_14.listing__window_start__extract_doy AS listing__window_start__extract_doy
-            , subq_14.listing__window_end__day AS listing__window_end__day
-            , subq_14.listing__window_end__week AS listing__window_end__week
-            , subq_14.listing__window_end__month AS listing__window_end__month
-            , subq_14.listing__window_end__quarter AS listing__window_end__quarter
-            , subq_14.listing__window_end__year AS listing__window_end__year
-            , subq_14.listing__window_end__extract_year AS listing__window_end__extract_year
-            , subq_14.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
-            , subq_14.listing__window_end__extract_month AS listing__window_end__extract_month
-            , subq_14.listing__window_end__extract_day AS listing__window_end__extract_day
-            , subq_14.listing__window_end__extract_dow AS listing__window_end__extract_dow
-            , subq_14.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_16.ds__day AS user__ds__day
-            , subq_16.ds__week AS user__ds__week
-            , subq_16.ds__month AS user__ds__month
-            , subq_16.ds__quarter AS user__ds__quarter
-            , subq_16.ds__year AS user__ds__year
-            , subq_16.ds__extract_year AS user__ds__extract_year
-            , subq_16.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_16.ds__extract_month AS user__ds__extract_month
-            , subq_16.ds__extract_day AS user__ds__extract_day
-            , subq_16.ds__extract_dow AS user__ds__extract_dow
-            , subq_16.ds__extract_doy AS user__ds__extract_doy
-            , subq_14.listing AS listing
-            , subq_14.user AS user
-            , subq_14.listing__user AS listing__user
-            , subq_14.country AS country
-            , subq_14.is_lux AS is_lux
-            , subq_14.capacity AS capacity
-            , subq_14.listing__country AS listing__country
-            , subq_14.listing__is_lux AS listing__is_lux
-            , subq_14.listing__capacity AS listing__capacity
-            , subq_16.home_state_latest AS user__home_state_latest
+            subq_3.window_start__day AS window_start__day
+            , subq_3.window_start__week AS window_start__week
+            , subq_3.window_start__month AS window_start__month
+            , subq_3.window_start__quarter AS window_start__quarter
+            , subq_3.window_start__year AS window_start__year
+            , subq_3.window_start__extract_year AS window_start__extract_year
+            , subq_3.window_start__extract_quarter AS window_start__extract_quarter
+            , subq_3.window_start__extract_month AS window_start__extract_month
+            , subq_3.window_start__extract_day AS window_start__extract_day
+            , subq_3.window_start__extract_dow AS window_start__extract_dow
+            , subq_3.window_start__extract_doy AS window_start__extract_doy
+            , subq_3.window_end__day AS window_end__day
+            , subq_3.window_end__week AS window_end__week
+            , subq_3.window_end__month AS window_end__month
+            , subq_3.window_end__quarter AS window_end__quarter
+            , subq_3.window_end__year AS window_end__year
+            , subq_3.window_end__extract_year AS window_end__extract_year
+            , subq_3.window_end__extract_quarter AS window_end__extract_quarter
+            , subq_3.window_end__extract_month AS window_end__extract_month
+            , subq_3.window_end__extract_day AS window_end__extract_day
+            , subq_3.window_end__extract_dow AS window_end__extract_dow
+            , subq_3.window_end__extract_doy AS window_end__extract_doy
+            , subq_3.listing__window_start__day AS listing__window_start__day
+            , subq_3.listing__window_start__week AS listing__window_start__week
+            , subq_3.listing__window_start__month AS listing__window_start__month
+            , subq_3.listing__window_start__quarter AS listing__window_start__quarter
+            , subq_3.listing__window_start__year AS listing__window_start__year
+            , subq_3.listing__window_start__extract_year AS listing__window_start__extract_year
+            , subq_3.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+            , subq_3.listing__window_start__extract_month AS listing__window_start__extract_month
+            , subq_3.listing__window_start__extract_day AS listing__window_start__extract_day
+            , subq_3.listing__window_start__extract_dow AS listing__window_start__extract_dow
+            , subq_3.listing__window_start__extract_doy AS listing__window_start__extract_doy
+            , subq_3.listing__window_end__day AS listing__window_end__day
+            , subq_3.listing__window_end__week AS listing__window_end__week
+            , subq_3.listing__window_end__month AS listing__window_end__month
+            , subq_3.listing__window_end__quarter AS listing__window_end__quarter
+            , subq_3.listing__window_end__year AS listing__window_end__year
+            , subq_3.listing__window_end__extract_year AS listing__window_end__extract_year
+            , subq_3.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+            , subq_3.listing__window_end__extract_month AS listing__window_end__extract_month
+            , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
+            , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
+            , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.user AS user
+            , subq_3.listing__user AS listing__user
+            , subq_3.country AS country
+            , subq_3.is_lux AS is_lux
+            , subq_3.capacity AS capacity
+            , subq_3.listing__country AS listing__country
+            , subq_3.listing__is_lux AS listing__is_lux
+            , subq_3.listing__capacity AS listing__capacity
+            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT
@@ -346,7 +346,7 @@ FROM (
               , listings_src_26000.user_id AS user
               , listings_src_26000.user_id AS listing__user
             FROM ***************************.dim_listings listings_src_26000
-          ) subq_14
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'home_state_latest',
@@ -376,31 +376,31 @@ FROM (
             --   'user',
             -- ]
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.user__ds__day
-              , subq_15.user__ds__week
-              , subq_15.user__ds__month
-              , subq_15.user__ds__quarter
-              , subq_15.user__ds__year
-              , subq_15.user__ds__extract_year
-              , subq_15.user__ds__extract_quarter
-              , subq_15.user__ds__extract_month
-              , subq_15.user__ds__extract_day
-              , subq_15.user__ds__extract_dow
-              , subq_15.user__ds__extract_doy
-              , subq_15.user
-              , subq_15.home_state_latest
-              , subq_15.user__home_state_latest
+              subq_4.ds__day
+              , subq_4.ds__week
+              , subq_4.ds__month
+              , subq_4.ds__quarter
+              , subq_4.ds__year
+              , subq_4.ds__extract_year
+              , subq_4.ds__extract_quarter
+              , subq_4.ds__extract_month
+              , subq_4.ds__extract_day
+              , subq_4.ds__extract_dow
+              , subq_4.ds__extract_doy
+              , subq_4.user__ds__day
+              , subq_4.user__ds__week
+              , subq_4.user__ds__month
+              , subq_4.user__ds__quarter
+              , subq_4.user__ds__year
+              , subq_4.user__ds__extract_year
+              , subq_4.user__ds__extract_quarter
+              , subq_4.user__ds__extract_month
+              , subq_4.user__ds__extract_day
+              , subq_4.user__ds__extract_dow
+              , subq_4.user__ds__extract_doy
+              , subq_4.user
+              , subq_4.home_state_latest
+              , subq_4.user__home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -430,29 +430,29 @@ FROM (
                 , users_latest_src_26000.home_state_latest AS user__home_state_latest
                 , users_latest_src_26000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_26000
-            ) subq_15
-          ) subq_16
+            ) subq_4
+          ) subq_5
           ON
-            subq_14.user = subq_16.user
-        ) subq_17
-      ) subq_18
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_13.listing = subq_18.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_13.metric_time__day >= subq_18.window_start__day
+            subq_2.metric_time__day >= subq_7.window_start__day
           ) AND (
             (
-              subq_13.metric_time__day < subq_18.window_end__day
+              subq_2.metric_time__day < subq_7.window_end__day
             ) OR (
-              subq_18.window_end__day IS NULL
+              subq_7.window_end__day IS NULL
             )
           )
         )
-    ) subq_19
-  ) subq_20
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-) subq_21
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_35.metric_time__day AS metric_time__day
-  , subq_40.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_35.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_35
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_40
+) subq_18
 ON
   (
-    subq_35.listing = subq_40.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_35.metric_time__day >= subq_40.window_start__day
+      subq_13.metric_time__day >= subq_18.window_start__day
     ) AND (
       (
-        subq_35.metric_time__day < subq_40.window_end__day
+        subq_13.metric_time__day < subq_18.window_end__day
       ) OR (
-        subq_40.window_end__day IS NULL
+        subq_18.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_35.metric_time__day
-  , subq_40.user__home_state_latest
+  subq_13.metric_time__day
+  , subq_18.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , subq_13.listing__lux_listing__is_confirmed_lux
-  , subq_13.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__lux_listing__is_confirmed_lux
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-    , SUM(subq_12.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__lux_listing__is_confirmed_lux', 'metric_time__day']
     SELECT
-      subq_11.metric_time__day
-      , subq_11.listing__lux_listing__is_confirmed_lux
-      , subq_11.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__lux_listing__is_confirmed_lux
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_5.metric_time__day AS metric_time__day
-        , subq_10.lux_listing__window_start__day AS listing__lux_listing__window_start__day
-        , subq_10.lux_listing__window_end__day AS listing__lux_listing__window_end__day
-        , subq_5.listing AS listing
-        , subq_10.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-        , subq_5.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
+        , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.listing
-          , subq_4.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.ds__day AS metric_time__day
-            , subq_3.ds__week AS metric_time__week
-            , subq_3.ds__month AS metric_time__month
-            , subq_3.ds__quarter AS metric_time__quarter
-            , subq_3.ds__year AS metric_time__year
-            , subq_3.ds__extract_year AS metric_time__extract_year
-            , subq_3.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_3.ds__extract_month AS metric_time__extract_month
-            , subq_3.ds__extract_day AS metric_time__extract_day
-            , subq_3.ds__extract_dow AS metric_time__extract_dow
-            , subq_3.ds__extract_doy AS metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.user
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.booking__user
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,45 +211,45 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_3
-        ) subq_4
-      ) subq_5
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
         SELECT
-          subq_9.lux_listing__window_start__day
-          , subq_9.lux_listing__window_end__day
-          , subq_9.listing
-          , subq_9.lux_listing__is_confirmed_lux
+          subq_6.lux_listing__window_start__day
+          , subq_6.lux_listing__window_end__day
+          , subq_6.listing
+          , subq_6.lux_listing__is_confirmed_lux
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_8.window_start__day AS lux_listing__window_start__day
-            , subq_8.window_start__week AS lux_listing__window_start__week
-            , subq_8.window_start__month AS lux_listing__window_start__month
-            , subq_8.window_start__quarter AS lux_listing__window_start__quarter
-            , subq_8.window_start__year AS lux_listing__window_start__year
-            , subq_8.window_start__extract_year AS lux_listing__window_start__extract_year
-            , subq_8.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
-            , subq_8.window_start__extract_month AS lux_listing__window_start__extract_month
-            , subq_8.window_start__extract_day AS lux_listing__window_start__extract_day
-            , subq_8.window_start__extract_dow AS lux_listing__window_start__extract_dow
-            , subq_8.window_start__extract_doy AS lux_listing__window_start__extract_doy
-            , subq_8.window_end__day AS lux_listing__window_end__day
-            , subq_8.window_end__week AS lux_listing__window_end__week
-            , subq_8.window_end__month AS lux_listing__window_end__month
-            , subq_8.window_end__quarter AS lux_listing__window_end__quarter
-            , subq_8.window_end__year AS lux_listing__window_end__year
-            , subq_8.window_end__extract_year AS lux_listing__window_end__extract_year
-            , subq_8.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
-            , subq_8.window_end__extract_month AS lux_listing__window_end__extract_month
-            , subq_8.window_end__extract_day AS lux_listing__window_end__extract_day
-            , subq_8.window_end__extract_dow AS lux_listing__window_end__extract_dow
-            , subq_8.window_end__extract_doy AS lux_listing__window_end__extract_doy
-            , subq_6.listing AS listing
-            , subq_6.lux_listing AS lux_listing
-            , subq_6.listing__lux_listing AS listing__lux_listing
-            , subq_8.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            subq_5.window_start__day AS lux_listing__window_start__day
+            , subq_5.window_start__week AS lux_listing__window_start__week
+            , subq_5.window_start__month AS lux_listing__window_start__month
+            , subq_5.window_start__quarter AS lux_listing__window_start__quarter
+            , subq_5.window_start__year AS lux_listing__window_start__year
+            , subq_5.window_start__extract_year AS lux_listing__window_start__extract_year
+            , subq_5.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
+            , subq_5.window_start__extract_month AS lux_listing__window_start__extract_month
+            , subq_5.window_start__extract_day AS lux_listing__window_start__extract_day
+            , subq_5.window_start__extract_dow AS lux_listing__window_start__extract_dow
+            , subq_5.window_start__extract_doy AS lux_listing__window_start__extract_doy
+            , subq_5.window_end__day AS lux_listing__window_end__day
+            , subq_5.window_end__week AS lux_listing__window_end__week
+            , subq_5.window_end__month AS lux_listing__window_end__month
+            , subq_5.window_end__quarter AS lux_listing__window_end__quarter
+            , subq_5.window_end__year AS lux_listing__window_end__year
+            , subq_5.window_end__extract_year AS lux_listing__window_end__extract_year
+            , subq_5.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
+            , subq_5.window_end__extract_month AS lux_listing__window_end__extract_month
+            , subq_5.window_end__extract_day AS lux_listing__window_end__extract_day
+            , subq_5.window_end__extract_dow AS lux_listing__window_end__extract_dow
+            , subq_5.window_end__extract_doy AS lux_listing__window_end__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.lux_listing AS lux_listing
+            , subq_3.listing__lux_listing AS listing__lux_listing
+            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT
@@ -257,7 +257,7 @@ FROM (
               , lux_listing_mapping_src_26000.lux_listing_id AS lux_listing
               , lux_listing_mapping_src_26000.lux_listing_id AS listing__lux_listing
             FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_26000
-          ) subq_6
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'is_confirmed_lux',
@@ -309,53 +309,53 @@ FROM (
             --   'lux_listing',
             -- ]
             SELECT
-              subq_7.window_start__day
-              , subq_7.window_start__week
-              , subq_7.window_start__month
-              , subq_7.window_start__quarter
-              , subq_7.window_start__year
-              , subq_7.window_start__extract_year
-              , subq_7.window_start__extract_quarter
-              , subq_7.window_start__extract_month
-              , subq_7.window_start__extract_day
-              , subq_7.window_start__extract_dow
-              , subq_7.window_start__extract_doy
-              , subq_7.window_end__day
-              , subq_7.window_end__week
-              , subq_7.window_end__month
-              , subq_7.window_end__quarter
-              , subq_7.window_end__year
-              , subq_7.window_end__extract_year
-              , subq_7.window_end__extract_quarter
-              , subq_7.window_end__extract_month
-              , subq_7.window_end__extract_day
-              , subq_7.window_end__extract_dow
-              , subq_7.window_end__extract_doy
-              , subq_7.lux_listing__window_start__day
-              , subq_7.lux_listing__window_start__week
-              , subq_7.lux_listing__window_start__month
-              , subq_7.lux_listing__window_start__quarter
-              , subq_7.lux_listing__window_start__year
-              , subq_7.lux_listing__window_start__extract_year
-              , subq_7.lux_listing__window_start__extract_quarter
-              , subq_7.lux_listing__window_start__extract_month
-              , subq_7.lux_listing__window_start__extract_day
-              , subq_7.lux_listing__window_start__extract_dow
-              , subq_7.lux_listing__window_start__extract_doy
-              , subq_7.lux_listing__window_end__day
-              , subq_7.lux_listing__window_end__week
-              , subq_7.lux_listing__window_end__month
-              , subq_7.lux_listing__window_end__quarter
-              , subq_7.lux_listing__window_end__year
-              , subq_7.lux_listing__window_end__extract_year
-              , subq_7.lux_listing__window_end__extract_quarter
-              , subq_7.lux_listing__window_end__extract_month
-              , subq_7.lux_listing__window_end__extract_day
-              , subq_7.lux_listing__window_end__extract_dow
-              , subq_7.lux_listing__window_end__extract_doy
-              , subq_7.lux_listing
-              , subq_7.is_confirmed_lux
-              , subq_7.lux_listing__is_confirmed_lux
+              subq_4.window_start__day
+              , subq_4.window_start__week
+              , subq_4.window_start__month
+              , subq_4.window_start__quarter
+              , subq_4.window_start__year
+              , subq_4.window_start__extract_year
+              , subq_4.window_start__extract_quarter
+              , subq_4.window_start__extract_month
+              , subq_4.window_start__extract_day
+              , subq_4.window_start__extract_dow
+              , subq_4.window_start__extract_doy
+              , subq_4.window_end__day
+              , subq_4.window_end__week
+              , subq_4.window_end__month
+              , subq_4.window_end__quarter
+              , subq_4.window_end__year
+              , subq_4.window_end__extract_year
+              , subq_4.window_end__extract_quarter
+              , subq_4.window_end__extract_month
+              , subq_4.window_end__extract_day
+              , subq_4.window_end__extract_dow
+              , subq_4.window_end__extract_doy
+              , subq_4.lux_listing__window_start__day
+              , subq_4.lux_listing__window_start__week
+              , subq_4.lux_listing__window_start__month
+              , subq_4.lux_listing__window_start__quarter
+              , subq_4.lux_listing__window_start__year
+              , subq_4.lux_listing__window_start__extract_year
+              , subq_4.lux_listing__window_start__extract_quarter
+              , subq_4.lux_listing__window_start__extract_month
+              , subq_4.lux_listing__window_start__extract_day
+              , subq_4.lux_listing__window_start__extract_dow
+              , subq_4.lux_listing__window_start__extract_doy
+              , subq_4.lux_listing__window_end__day
+              , subq_4.lux_listing__window_end__week
+              , subq_4.lux_listing__window_end__month
+              , subq_4.lux_listing__window_end__quarter
+              , subq_4.lux_listing__window_end__year
+              , subq_4.lux_listing__window_end__extract_year
+              , subq_4.lux_listing__window_end__extract_quarter
+              , subq_4.lux_listing__window_end__extract_month
+              , subq_4.lux_listing__window_end__extract_day
+              , subq_4.lux_listing__window_end__extract_dow
+              , subq_4.lux_listing__window_end__extract_doy
+              , subq_4.lux_listing
+              , subq_4.is_confirmed_lux
+              , subq_4.lux_listing__is_confirmed_lux
             FROM (
               -- Read Elements From Semantic Model 'lux_listings'
               SELECT
@@ -407,29 +407,29 @@ FROM (
                 , lux_listings_src_26000.is_confirmed_lux AS lux_listing__is_confirmed_lux
                 , lux_listings_src_26000.lux_listing_id AS lux_listing
               FROM ***************************.dim_lux_listings lux_listings_src_26000
-            ) subq_7
-          ) subq_8
+            ) subq_4
+          ) subq_5
           ON
-            subq_6.lux_listing = subq_8.lux_listing
-        ) subq_9
-      ) subq_10
+            subq_3.lux_listing = subq_5.lux_listing
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_5.listing = subq_10.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_5.metric_time__day >= subq_10.lux_listing__window_start__day
+            subq_2.metric_time__day >= subq_7.lux_listing__window_start__day
           ) AND (
             (
-              subq_5.metric_time__day < subq_10.lux_listing__window_end__day
+              subq_2.metric_time__day < subq_7.lux_listing__window_end__day
             ) OR (
-              subq_10.lux_listing__window_end__day IS NULL
+              subq_7.lux_listing__window_end__day IS NULL
             )
           )
         )
-    ) subq_11
-  ) subq_12
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-) subq_13
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time__day AS metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_19.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_19
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_24
+) subq_18
 ON
   (
-    subq_19.listing = subq_24.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
+      subq_13.metric_time__day >= subq_18.lux_listing__window_start__day
     ) AND (
       (
-        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
+        subq_13.metric_time__day < subq_18.lux_listing__window_end__day
       ) OR (
-        subq_24.lux_listing__window_end__day IS NULL
+        subq_18.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_19.metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux
+  subq_13.metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0.sql
@@ -1,93 +1,93 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.account_id__customer_id__customer_name
-  , subq_17.txn_count
+  subq_12.account_id__customer_id__customer_name
+  , subq_12.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.account_id__customer_id__customer_name
-    , SUM(subq_16.txn_count) AS txn_count
+    subq_11.account_id__customer_id__customer_name
+    , SUM(subq_11.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_15.account_id__customer_id__customer_name
-      , subq_15.txn_count
+      subq_10.account_id__customer_id__customer_name
+      , subq_10.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_7.ds_partitioned__day AS ds_partitioned__day
-        , subq_14.ds_partitioned__day AS account_id__ds_partitioned__day
-        , subq_7.account_id AS account_id
-        , subq_14.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_7.txn_count AS txn_count
+        subq_2.ds_partitioned__day AS ds_partitioned__day
+        , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.account_id AS account_id
+        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_6.ds_partitioned__day
-          , subq_6.account_id
-          , subq_6.txn_count
+          subq_1.ds_partitioned__day
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds_partitioned__day
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.ds_partitioned__extract_year
-            , subq_5.ds_partitioned__extract_quarter
-            , subq_5.ds_partitioned__extract_month
-            , subq_5.ds_partitioned__extract_day
-            , subq_5.ds_partitioned__extract_dow
-            , subq_5.ds_partitioned__extract_doy
-            , subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.account_id__ds_partitioned__day
-            , subq_5.account_id__ds_partitioned__week
-            , subq_5.account_id__ds_partitioned__month
-            , subq_5.account_id__ds_partitioned__quarter
-            , subq_5.account_id__ds_partitioned__year
-            , subq_5.account_id__ds_partitioned__extract_year
-            , subq_5.account_id__ds_partitioned__extract_quarter
-            , subq_5.account_id__ds_partitioned__extract_month
-            , subq_5.account_id__ds_partitioned__extract_day
-            , subq_5.account_id__ds_partitioned__extract_dow
-            , subq_5.account_id__ds_partitioned__extract_doy
-            , subq_5.account_id__ds__day
-            , subq_5.account_id__ds__week
-            , subq_5.account_id__ds__month
-            , subq_5.account_id__ds__quarter
-            , subq_5.account_id__ds__year
-            , subq_5.account_id__ds__extract_year
-            , subq_5.account_id__ds__extract_quarter
-            , subq_5.account_id__ds__extract_month
-            , subq_5.account_id__ds__extract_day
-            , subq_5.account_id__ds__extract_dow
-            , subq_5.account_id__ds__extract_doy
-            , subq_5.ds__day AS metric_time__day
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.ds__extract_year AS metric_time__extract_year
-            , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_5.ds__extract_month AS metric_time__extract_month
-            , subq_5.ds__extract_day AS metric_time__extract_day
-            , subq_5.ds__extract_dow AS metric_time__extract_dow
-            , subq_5.ds__extract_doy AS metric_time__extract_doy
-            , subq_5.account_id
-            , subq_5.account_month
-            , subq_5.account_id__account_month
-            , subq_5.txn_count
+            subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.account_id__ds_partitioned__day
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds_partitioned__extract_year
+            , subq_0.account_id__ds_partitioned__extract_quarter
+            , subq_0.account_id__ds_partitioned__extract_month
+            , subq_0.account_id__ds_partitioned__extract_day
+            , subq_0.account_id__ds_partitioned__extract_dow
+            , subq_0.account_id__ds_partitioned__extract_doy
+            , subq_0.account_id__ds__day
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.account_id__ds__extract_year
+            , subq_0.account_id__ds__extract_quarter
+            , subq_0.account_id__ds__extract_month
+            , subq_0.account_id__ds__extract_day
+            , subq_0.account_id__ds__extract_dow
+            , subq_0.account_id__ds__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
@@ -140,151 +140,151 @@ FROM (
               , account_month_txns_src_22000.account_month AS account_id__account_month
               , account_month_txns_src_22000.account_id
             FROM ***************************.account_month_txns account_month_txns_src_22000
-          ) subq_5
-        ) subq_6
-      ) subq_7
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_13.ds_partitioned__day
-          , subq_13.account_id
-          , subq_13.customer_id__customer_name
+          subq_8.ds_partitioned__day
+          , subq_8.account_id
+          , subq_8.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_9.ds_partitioned__day AS ds_partitioned__day
-            , subq_9.ds_partitioned__week AS ds_partitioned__week
-            , subq_9.ds_partitioned__month AS ds_partitioned__month
-            , subq_9.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_9.ds_partitioned__year AS ds_partitioned__year
-            , subq_9.ds_partitioned__extract_year AS ds_partitioned__extract_year
-            , subq_9.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-            , subq_9.ds_partitioned__extract_month AS ds_partitioned__extract_month
-            , subq_9.ds_partitioned__extract_day AS ds_partitioned__extract_day
-            , subq_9.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-            , subq_9.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-            , subq_9.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-            , subq_9.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_9.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_9.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_9.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_9.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-            , subq_9.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-            , subq_9.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-            , subq_9.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-            , subq_9.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-            , subq_9.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-            , subq_9.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-            , subq_9.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-            , subq_9.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-            , subq_9.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-            , subq_9.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-            , subq_9.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-            , subq_9.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-            , subq_9.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-            , subq_9.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-            , subq_9.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-            , subq_9.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
-            , subq_9.metric_time__month AS metric_time__month
-            , subq_9.metric_time__quarter AS metric_time__quarter
-            , subq_9.metric_time__year AS metric_time__year
-            , subq_9.metric_time__extract_year AS metric_time__extract_year
-            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_9.metric_time__extract_month AS metric_time__extract_month
-            , subq_9.metric_time__extract_day AS metric_time__extract_day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_12.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_12.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_12.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_12.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_12.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_12.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_12.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_12.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_12.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_12.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_12.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_12.metric_time__day AS customer_id__metric_time__day
-            , subq_12.metric_time__week AS customer_id__metric_time__week
-            , subq_12.metric_time__month AS customer_id__metric_time__month
-            , subq_12.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_12.metric_time__year AS customer_id__metric_time__year
-            , subq_12.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_12.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_12.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_12.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_12.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_12.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-            , subq_9.account_id AS account_id
-            , subq_9.customer_id AS customer_id
-            , subq_9.account_id__customer_id AS account_id__customer_id
-            , subq_9.bridge_account__account_id AS bridge_account__account_id
-            , subq_9.bridge_account__customer_id AS bridge_account__customer_id
-            , subq_9.extra_dim AS extra_dim
-            , subq_9.account_id__extra_dim AS account_id__extra_dim
-            , subq_9.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_12.customer_name AS customer_id__customer_name
-            , subq_12.customer_atomic_weight AS customer_id__customer_atomic_weight
-            , subq_9.account_customer_combos AS account_customer_combos
+            subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_4.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+            , subq_4.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+            , subq_4.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+            , subq_4.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+            , subq_4.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+            , subq_4.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+            , subq_4.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+            , subq_4.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+            , subq_4.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+            , subq_4.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+            , subq_4.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+            , subq_4.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+            , subq_4.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+            , subq_4.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+            , subq_4.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+            , subq_4.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+            , subq_4.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.account_id AS account_id
+            , subq_4.customer_id AS customer_id
+            , subq_4.account_id__customer_id AS account_id__customer_id
+            , subq_4.bridge_account__account_id AS bridge_account__account_id
+            , subq_4.bridge_account__customer_id AS bridge_account__customer_id
+            , subq_4.extra_dim AS extra_dim
+            , subq_4.account_id__extra_dim AS account_id__extra_dim
+            , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
+            , subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'
             SELECT
-              subq_8.ds_partitioned__day
-              , subq_8.ds_partitioned__week
-              , subq_8.ds_partitioned__month
-              , subq_8.ds_partitioned__quarter
-              , subq_8.ds_partitioned__year
-              , subq_8.ds_partitioned__extract_year
-              , subq_8.ds_partitioned__extract_quarter
-              , subq_8.ds_partitioned__extract_month
-              , subq_8.ds_partitioned__extract_day
-              , subq_8.ds_partitioned__extract_dow
-              , subq_8.ds_partitioned__extract_doy
-              , subq_8.account_id__ds_partitioned__day
-              , subq_8.account_id__ds_partitioned__week
-              , subq_8.account_id__ds_partitioned__month
-              , subq_8.account_id__ds_partitioned__quarter
-              , subq_8.account_id__ds_partitioned__year
-              , subq_8.account_id__ds_partitioned__extract_year
-              , subq_8.account_id__ds_partitioned__extract_quarter
-              , subq_8.account_id__ds_partitioned__extract_month
-              , subq_8.account_id__ds_partitioned__extract_day
-              , subq_8.account_id__ds_partitioned__extract_dow
-              , subq_8.account_id__ds_partitioned__extract_doy
-              , subq_8.bridge_account__ds_partitioned__day
-              , subq_8.bridge_account__ds_partitioned__week
-              , subq_8.bridge_account__ds_partitioned__month
-              , subq_8.bridge_account__ds_partitioned__quarter
-              , subq_8.bridge_account__ds_partitioned__year
-              , subq_8.bridge_account__ds_partitioned__extract_year
-              , subq_8.bridge_account__ds_partitioned__extract_quarter
-              , subq_8.bridge_account__ds_partitioned__extract_month
-              , subq_8.bridge_account__ds_partitioned__extract_day
-              , subq_8.bridge_account__ds_partitioned__extract_dow
-              , subq_8.bridge_account__ds_partitioned__extract_doy
-              , subq_8.ds_partitioned__day AS metric_time__day
-              , subq_8.ds_partitioned__week AS metric_time__week
-              , subq_8.ds_partitioned__month AS metric_time__month
-              , subq_8.ds_partitioned__quarter AS metric_time__quarter
-              , subq_8.ds_partitioned__year AS metric_time__year
-              , subq_8.ds_partitioned__extract_year AS metric_time__extract_year
-              , subq_8.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-              , subq_8.ds_partitioned__extract_month AS metric_time__extract_month
-              , subq_8.ds_partitioned__extract_day AS metric_time__extract_day
-              , subq_8.ds_partitioned__extract_dow AS metric_time__extract_dow
-              , subq_8.ds_partitioned__extract_doy AS metric_time__extract_doy
-              , subq_8.account_id
-              , subq_8.customer_id
-              , subq_8.account_id__customer_id
-              , subq_8.bridge_account__account_id
-              , subq_8.bridge_account__customer_id
-              , subq_8.extra_dim
-              , subq_8.account_id__extra_dim
-              , subq_8.bridge_account__extra_dim
-              , subq_8.account_customer_combos
+              subq_3.ds_partitioned__day
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.ds_partitioned__extract_year
+              , subq_3.ds_partitioned__extract_quarter
+              , subq_3.ds_partitioned__extract_month
+              , subq_3.ds_partitioned__extract_day
+              , subq_3.ds_partitioned__extract_dow
+              , subq_3.ds_partitioned__extract_doy
+              , subq_3.account_id__ds_partitioned__day
+              , subq_3.account_id__ds_partitioned__week
+              , subq_3.account_id__ds_partitioned__month
+              , subq_3.account_id__ds_partitioned__quarter
+              , subq_3.account_id__ds_partitioned__year
+              , subq_3.account_id__ds_partitioned__extract_year
+              , subq_3.account_id__ds_partitioned__extract_quarter
+              , subq_3.account_id__ds_partitioned__extract_month
+              , subq_3.account_id__ds_partitioned__extract_day
+              , subq_3.account_id__ds_partitioned__extract_dow
+              , subq_3.account_id__ds_partitioned__extract_doy
+              , subq_3.bridge_account__ds_partitioned__day
+              , subq_3.bridge_account__ds_partitioned__week
+              , subq_3.bridge_account__ds_partitioned__month
+              , subq_3.bridge_account__ds_partitioned__quarter
+              , subq_3.bridge_account__ds_partitioned__year
+              , subq_3.bridge_account__ds_partitioned__extract_year
+              , subq_3.bridge_account__ds_partitioned__extract_quarter
+              , subq_3.bridge_account__ds_partitioned__extract_month
+              , subq_3.bridge_account__ds_partitioned__extract_day
+              , subq_3.bridge_account__ds_partitioned__extract_dow
+              , subq_3.bridge_account__ds_partitioned__extract_doy
+              , subq_3.ds_partitioned__day AS metric_time__day
+              , subq_3.ds_partitioned__week AS metric_time__week
+              , subq_3.ds_partitioned__month AS metric_time__month
+              , subq_3.ds_partitioned__quarter AS metric_time__quarter
+              , subq_3.ds_partitioned__year AS metric_time__year
+              , subq_3.ds_partitioned__extract_year AS metric_time__extract_year
+              , subq_3.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+              , subq_3.ds_partitioned__extract_month AS metric_time__extract_month
+              , subq_3.ds_partitioned__extract_day AS metric_time__extract_day
+              , subq_3.ds_partitioned__extract_dow AS metric_time__extract_dow
+              , subq_3.ds_partitioned__extract_doy AS metric_time__extract_doy
+              , subq_3.account_id
+              , subq_3.customer_id
+              , subq_3.account_id__customer_id
+              , subq_3.bridge_account__account_id
+              , subq_3.bridge_account__customer_id
+              , subq_3.extra_dim
+              , subq_3.account_id__extra_dim
+              , subq_3.bridge_account__extra_dim
+              , subq_3.account_customer_combos
             FROM (
               -- Read Elements From Semantic Model 'bridge_table'
               SELECT
@@ -331,8 +331,8 @@ FROM (
                 , bridge_table_src_22000.account_id AS bridge_account__account_id
                 , bridge_table_src_22000.customer_id AS bridge_account__customer_id
               FROM ***************************.bridge_table bridge_table_src_22000
-            ) subq_8
-          ) subq_9
+            ) subq_3
+          ) subq_4
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'customer_name',
@@ -375,86 +375,86 @@ FROM (
             --   'customer_id',
             -- ]
             SELECT
-              subq_11.ds_partitioned__day
-              , subq_11.ds_partitioned__week
-              , subq_11.ds_partitioned__month
-              , subq_11.ds_partitioned__quarter
-              , subq_11.ds_partitioned__year
-              , subq_11.ds_partitioned__extract_year
-              , subq_11.ds_partitioned__extract_quarter
-              , subq_11.ds_partitioned__extract_month
-              , subq_11.ds_partitioned__extract_day
-              , subq_11.ds_partitioned__extract_dow
-              , subq_11.ds_partitioned__extract_doy
-              , subq_11.customer_id__ds_partitioned__day
-              , subq_11.customer_id__ds_partitioned__week
-              , subq_11.customer_id__ds_partitioned__month
-              , subq_11.customer_id__ds_partitioned__quarter
-              , subq_11.customer_id__ds_partitioned__year
-              , subq_11.customer_id__ds_partitioned__extract_year
-              , subq_11.customer_id__ds_partitioned__extract_quarter
-              , subq_11.customer_id__ds_partitioned__extract_month
-              , subq_11.customer_id__ds_partitioned__extract_day
-              , subq_11.customer_id__ds_partitioned__extract_dow
-              , subq_11.customer_id__ds_partitioned__extract_doy
-              , subq_11.metric_time__day
-              , subq_11.metric_time__week
-              , subq_11.metric_time__month
-              , subq_11.metric_time__quarter
-              , subq_11.metric_time__year
-              , subq_11.metric_time__extract_year
-              , subq_11.metric_time__extract_quarter
-              , subq_11.metric_time__extract_month
-              , subq_11.metric_time__extract_day
-              , subq_11.metric_time__extract_dow
-              , subq_11.metric_time__extract_doy
-              , subq_11.customer_id
-              , subq_11.customer_name
-              , subq_11.customer_atomic_weight
-              , subq_11.customer_id__customer_name
-              , subq_11.customer_id__customer_atomic_weight
+              subq_6.ds_partitioned__day
+              , subq_6.ds_partitioned__week
+              , subq_6.ds_partitioned__month
+              , subq_6.ds_partitioned__quarter
+              , subq_6.ds_partitioned__year
+              , subq_6.ds_partitioned__extract_year
+              , subq_6.ds_partitioned__extract_quarter
+              , subq_6.ds_partitioned__extract_month
+              , subq_6.ds_partitioned__extract_day
+              , subq_6.ds_partitioned__extract_dow
+              , subq_6.ds_partitioned__extract_doy
+              , subq_6.customer_id__ds_partitioned__day
+              , subq_6.customer_id__ds_partitioned__week
+              , subq_6.customer_id__ds_partitioned__month
+              , subq_6.customer_id__ds_partitioned__quarter
+              , subq_6.customer_id__ds_partitioned__year
+              , subq_6.customer_id__ds_partitioned__extract_year
+              , subq_6.customer_id__ds_partitioned__extract_quarter
+              , subq_6.customer_id__ds_partitioned__extract_month
+              , subq_6.customer_id__ds_partitioned__extract_day
+              , subq_6.customer_id__ds_partitioned__extract_dow
+              , subq_6.customer_id__ds_partitioned__extract_doy
+              , subq_6.metric_time__day
+              , subq_6.metric_time__week
+              , subq_6.metric_time__month
+              , subq_6.metric_time__quarter
+              , subq_6.metric_time__year
+              , subq_6.metric_time__extract_year
+              , subq_6.metric_time__extract_quarter
+              , subq_6.metric_time__extract_month
+              , subq_6.metric_time__extract_day
+              , subq_6.metric_time__extract_dow
+              , subq_6.metric_time__extract_doy
+              , subq_6.customer_id
+              , subq_6.customer_name
+              , subq_6.customer_atomic_weight
+              , subq_6.customer_id__customer_name
+              , subq_6.customer_id__customer_atomic_weight
             FROM (
               -- Metric Time Dimension 'ds_partitioned'
               SELECT
-                subq_10.ds_partitioned__day
-                , subq_10.ds_partitioned__week
-                , subq_10.ds_partitioned__month
-                , subq_10.ds_partitioned__quarter
-                , subq_10.ds_partitioned__year
-                , subq_10.ds_partitioned__extract_year
-                , subq_10.ds_partitioned__extract_quarter
-                , subq_10.ds_partitioned__extract_month
-                , subq_10.ds_partitioned__extract_day
-                , subq_10.ds_partitioned__extract_dow
-                , subq_10.ds_partitioned__extract_doy
-                , subq_10.customer_id__ds_partitioned__day
-                , subq_10.customer_id__ds_partitioned__week
-                , subq_10.customer_id__ds_partitioned__month
-                , subq_10.customer_id__ds_partitioned__quarter
-                , subq_10.customer_id__ds_partitioned__year
-                , subq_10.customer_id__ds_partitioned__extract_year
-                , subq_10.customer_id__ds_partitioned__extract_quarter
-                , subq_10.customer_id__ds_partitioned__extract_month
-                , subq_10.customer_id__ds_partitioned__extract_day
-                , subq_10.customer_id__ds_partitioned__extract_dow
-                , subq_10.customer_id__ds_partitioned__extract_doy
-                , subq_10.ds_partitioned__day AS metric_time__day
-                , subq_10.ds_partitioned__week AS metric_time__week
-                , subq_10.ds_partitioned__month AS metric_time__month
-                , subq_10.ds_partitioned__quarter AS metric_time__quarter
-                , subq_10.ds_partitioned__year AS metric_time__year
-                , subq_10.ds_partitioned__extract_year AS metric_time__extract_year
-                , subq_10.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                , subq_10.ds_partitioned__extract_month AS metric_time__extract_month
-                , subq_10.ds_partitioned__extract_day AS metric_time__extract_day
-                , subq_10.ds_partitioned__extract_dow AS metric_time__extract_dow
-                , subq_10.ds_partitioned__extract_doy AS metric_time__extract_doy
-                , subq_10.customer_id
-                , subq_10.customer_name
-                , subq_10.customer_atomic_weight
-                , subq_10.customer_id__customer_name
-                , subq_10.customer_id__customer_atomic_weight
-                , subq_10.customers
+                subq_5.ds_partitioned__day
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.ds_partitioned__extract_year
+                , subq_5.ds_partitioned__extract_quarter
+                , subq_5.ds_partitioned__extract_month
+                , subq_5.ds_partitioned__extract_day
+                , subq_5.ds_partitioned__extract_dow
+                , subq_5.ds_partitioned__extract_doy
+                , subq_5.customer_id__ds_partitioned__day
+                , subq_5.customer_id__ds_partitioned__week
+                , subq_5.customer_id__ds_partitioned__month
+                , subq_5.customer_id__ds_partitioned__quarter
+                , subq_5.customer_id__ds_partitioned__year
+                , subq_5.customer_id__ds_partitioned__extract_year
+                , subq_5.customer_id__ds_partitioned__extract_quarter
+                , subq_5.customer_id__ds_partitioned__extract_month
+                , subq_5.customer_id__ds_partitioned__extract_day
+                , subq_5.customer_id__ds_partitioned__extract_dow
+                , subq_5.customer_id__ds_partitioned__extract_doy
+                , subq_5.ds_partitioned__day AS metric_time__day
+                , subq_5.ds_partitioned__week AS metric_time__week
+                , subq_5.ds_partitioned__month AS metric_time__month
+                , subq_5.ds_partitioned__quarter AS metric_time__quarter
+                , subq_5.ds_partitioned__year AS metric_time__year
+                , subq_5.ds_partitioned__extract_year AS metric_time__extract_year
+                , subq_5.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                , subq_5.ds_partitioned__extract_month AS metric_time__extract_month
+                , subq_5.ds_partitioned__extract_day AS metric_time__extract_day
+                , subq_5.ds_partitioned__extract_dow AS metric_time__extract_dow
+                , subq_5.ds_partitioned__extract_doy AS metric_time__extract_doy
+                , subq_5.customer_id
+                , subq_5.customer_name
+                , subq_5.customer_atomic_weight
+                , subq_5.customer_id__customer_name
+                , subq_5.customer_id__customer_atomic_weight
+                , subq_5.customers
               FROM (
                 -- Read Elements From Semantic Model 'customer_table'
                 SELECT
@@ -487,25 +487,25 @@ FROM (
                   , EXTRACT(doy FROM customer_table_src_22000.ds_partitioned) AS customer_id__ds_partitioned__extract_doy
                   , customer_table_src_22000.customer_id
                 FROM ***************************.customer_table customer_table_src_22000
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_5
+            ) subq_6
+          ) subq_7
           ON
             (
-              subq_9.customer_id = subq_12.customer_id
+              subq_4.customer_id = subq_7.customer_id
             ) AND (
-              subq_9.ds_partitioned__day = subq_12.ds_partitioned__day
+              subq_4.ds_partitioned__day = subq_7.ds_partitioned__day
             )
-        ) subq_13
-      ) subq_14
+        ) subq_8
+      ) subq_9
       ON
         (
-          subq_7.account_id = subq_14.account_id
+          subq_2.account_id = subq_9.account_id
         ) AND (
-          subq_7.ds_partitioned__day = subq_14.ds_partitioned__day
+          subq_2.ds_partitioned__day = subq_9.ds_partitioned__day
         )
-    ) subq_15
-  ) subq_16
+    ) subq_10
+  ) subq_11
   GROUP BY
-    subq_16.account_id__customer_id__customer_name
-) subq_17
+    subq_11.account_id__customer_id__customer_name
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_22.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_32
+) subq_22
 ON
   (
-    account_month_txns_src_22000.account_id = subq_32.account_id
+    account_month_txns_src_22000.account_id = subq_22.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_22.ds_partitioned__day
   )
 GROUP BY
-  subq_32.customer_id__customer_name
+  subq_22.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,221 +1,221 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_9.bookings) AS bookings
-  , MAX(subq_15.listings) AS listings
+  MAX(subq_5.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.bookings
+    subq_4.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_7.bookings) AS bookings
+      SUM(subq_3.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings',]
       SELECT
-        subq_6.bookings
+        subq_2.bookings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_5.ds__day
-          , subq_5.ds__week
-          , subq_5.ds__month
-          , subq_5.ds__quarter
-          , subq_5.ds__year
-          , subq_5.ds__extract_year
-          , subq_5.ds__extract_quarter
-          , subq_5.ds__extract_month
-          , subq_5.ds__extract_day
-          , subq_5.ds__extract_dow
-          , subq_5.ds__extract_doy
-          , subq_5.ds_partitioned__day
-          , subq_5.ds_partitioned__week
-          , subq_5.ds_partitioned__month
-          , subq_5.ds_partitioned__quarter
-          , subq_5.ds_partitioned__year
-          , subq_5.ds_partitioned__extract_year
-          , subq_5.ds_partitioned__extract_quarter
-          , subq_5.ds_partitioned__extract_month
-          , subq_5.ds_partitioned__extract_day
-          , subq_5.ds_partitioned__extract_dow
-          , subq_5.ds_partitioned__extract_doy
-          , subq_5.paid_at__day
-          , subq_5.paid_at__week
-          , subq_5.paid_at__month
-          , subq_5.paid_at__quarter
-          , subq_5.paid_at__year
-          , subq_5.paid_at__extract_year
-          , subq_5.paid_at__extract_quarter
-          , subq_5.paid_at__extract_month
-          , subq_5.paid_at__extract_day
-          , subq_5.paid_at__extract_dow
-          , subq_5.paid_at__extract_doy
-          , subq_5.booking__ds__day
-          , subq_5.booking__ds__week
-          , subq_5.booking__ds__month
-          , subq_5.booking__ds__quarter
-          , subq_5.booking__ds__year
-          , subq_5.booking__ds__extract_year
-          , subq_5.booking__ds__extract_quarter
-          , subq_5.booking__ds__extract_month
-          , subq_5.booking__ds__extract_day
-          , subq_5.booking__ds__extract_dow
-          , subq_5.booking__ds__extract_doy
-          , subq_5.booking__ds_partitioned__day
-          , subq_5.booking__ds_partitioned__week
-          , subq_5.booking__ds_partitioned__month
-          , subq_5.booking__ds_partitioned__quarter
-          , subq_5.booking__ds_partitioned__year
-          , subq_5.booking__ds_partitioned__extract_year
-          , subq_5.booking__ds_partitioned__extract_quarter
-          , subq_5.booking__ds_partitioned__extract_month
-          , subq_5.booking__ds_partitioned__extract_day
-          , subq_5.booking__ds_partitioned__extract_dow
-          , subq_5.booking__ds_partitioned__extract_doy
-          , subq_5.booking__paid_at__day
-          , subq_5.booking__paid_at__week
-          , subq_5.booking__paid_at__month
-          , subq_5.booking__paid_at__quarter
-          , subq_5.booking__paid_at__year
-          , subq_5.booking__paid_at__extract_year
-          , subq_5.booking__paid_at__extract_quarter
-          , subq_5.booking__paid_at__extract_month
-          , subq_5.booking__paid_at__extract_day
-          , subq_5.booking__paid_at__extract_dow
-          , subq_5.booking__paid_at__extract_doy
-          , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
-          , subq_5.listing
-          , subq_5.guest
-          , subq_5.host
-          , subq_5.booking__listing
-          , subq_5.booking__guest
-          , subq_5.booking__host
-          , subq_5.is_instant
-          , subq_5.booking__is_instant
-          , subq_5.bookings
-          , subq_5.instant_bookings
-          , subq_5.booking_value
-          , subq_5.max_booking_value
-          , subq_5.min_booking_value
-          , subq_5.bookers
-          , subq_5.average_booking_value
-          , subq_5.referred_bookings
-          , subq_5.median_booking_value
-          , subq_5.booking_value_p99
-          , subq_5.discrete_booking_value_p99
-          , subq_5.approximate_continuous_booking_value_p99
-          , subq_5.approximate_discrete_booking_value_p99
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds_partitioned__day
+          , subq_1.ds_partitioned__week
+          , subq_1.ds_partitioned__month
+          , subq_1.ds_partitioned__quarter
+          , subq_1.ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy
+          , subq_1.paid_at__day
+          , subq_1.paid_at__week
+          , subq_1.paid_at__month
+          , subq_1.paid_at__quarter
+          , subq_1.paid_at__year
+          , subq_1.paid_at__extract_year
+          , subq_1.paid_at__extract_quarter
+          , subq_1.paid_at__extract_month
+          , subq_1.paid_at__extract_day
+          , subq_1.paid_at__extract_dow
+          , subq_1.paid_at__extract_doy
+          , subq_1.booking__ds__day
+          , subq_1.booking__ds__week
+          , subq_1.booking__ds__month
+          , subq_1.booking__ds__quarter
+          , subq_1.booking__ds__year
+          , subq_1.booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month
+          , subq_1.booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day
+          , subq_1.booking__paid_at__week
+          , subq_1.booking__paid_at__month
+          , subq_1.booking__paid_at__quarter
+          , subq_1.booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy
+          , subq_1.metric_time__day
+          , subq_1.metric_time__week
+          , subq_1.metric_time__month
+          , subq_1.metric_time__quarter
+          , subq_1.metric_time__year
+          , subq_1.metric_time__extract_year
+          , subq_1.metric_time__extract_quarter
+          , subq_1.metric_time__extract_month
+          , subq_1.metric_time__extract_day
+          , subq_1.metric_time__extract_dow
+          , subq_1.metric_time__extract_doy
+          , subq_1.listing
+          , subq_1.guest
+          , subq_1.host
+          , subq_1.booking__listing
+          , subq_1.booking__guest
+          , subq_1.booking__host
+          , subq_1.is_instant
+          , subq_1.booking__is_instant
+          , subq_1.bookings
+          , subq_1.instant_bookings
+          , subq_1.booking_value
+          , subq_1.max_booking_value
+          , subq_1.min_booking_value
+          , subq_1.bookers
+          , subq_1.average_booking_value
+          , subq_1.referred_bookings
+          , subq_1.median_booking_value
+          , subq_1.booking_value_p99
+          , subq_1.discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds__day
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds__extract_year
-            , subq_4.ds__extract_quarter
-            , subq_4.ds__extract_month
-            , subq_4.ds__extract_day
-            , subq_4.ds__extract_dow
-            , subq_4.ds__extract_doy
-            , subq_4.ds_partitioned__day
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.ds_partitioned__extract_year
-            , subq_4.ds_partitioned__extract_quarter
-            , subq_4.ds_partitioned__extract_month
-            , subq_4.ds_partitioned__extract_day
-            , subq_4.ds_partitioned__extract_dow
-            , subq_4.ds_partitioned__extract_doy
-            , subq_4.paid_at__day
-            , subq_4.paid_at__week
-            , subq_4.paid_at__month
-            , subq_4.paid_at__quarter
-            , subq_4.paid_at__year
-            , subq_4.paid_at__extract_year
-            , subq_4.paid_at__extract_quarter
-            , subq_4.paid_at__extract_month
-            , subq_4.paid_at__extract_day
-            , subq_4.paid_at__extract_dow
-            , subq_4.paid_at__extract_doy
-            , subq_4.booking__ds__day
-            , subq_4.booking__ds__week
-            , subq_4.booking__ds__month
-            , subq_4.booking__ds__quarter
-            , subq_4.booking__ds__year
-            , subq_4.booking__ds__extract_year
-            , subq_4.booking__ds__extract_quarter
-            , subq_4.booking__ds__extract_month
-            , subq_4.booking__ds__extract_day
-            , subq_4.booking__ds__extract_dow
-            , subq_4.booking__ds__extract_doy
-            , subq_4.booking__ds_partitioned__day
-            , subq_4.booking__ds_partitioned__week
-            , subq_4.booking__ds_partitioned__month
-            , subq_4.booking__ds_partitioned__quarter
-            , subq_4.booking__ds_partitioned__year
-            , subq_4.booking__ds_partitioned__extract_year
-            , subq_4.booking__ds_partitioned__extract_quarter
-            , subq_4.booking__ds_partitioned__extract_month
-            , subq_4.booking__ds_partitioned__extract_day
-            , subq_4.booking__ds_partitioned__extract_dow
-            , subq_4.booking__ds_partitioned__extract_doy
-            , subq_4.booking__paid_at__day
-            , subq_4.booking__paid_at__week
-            , subq_4.booking__paid_at__month
-            , subq_4.booking__paid_at__quarter
-            , subq_4.booking__paid_at__year
-            , subq_4.booking__paid_at__extract_year
-            , subq_4.booking__paid_at__extract_quarter
-            , subq_4.booking__paid_at__extract_month
-            , subq_4.booking__paid_at__extract_day
-            , subq_4.booking__paid_at__extract_dow
-            , subq_4.booking__paid_at__extract_doy
-            , subq_4.ds__day AS metric_time__day
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.ds__extract_year AS metric_time__extract_year
-            , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_4.ds__extract_month AS metric_time__extract_month
-            , subq_4.ds__extract_day AS metric_time__extract_day
-            , subq_4.ds__extract_dow AS metric_time__extract_dow
-            , subq_4.ds__extract_doy AS metric_time__extract_doy
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.booking__listing
-            , subq_4.booking__guest
-            , subq_4.booking__host
-            , subq_4.is_instant
-            , subq_4.booking__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
-            , subq_4.median_booking_value
-            , subq_4.booking_value_p99
-            , subq_4.discrete_booking_value_p99
-            , subq_4.approximate_continuous_booking_value_p99
-            , subq_4.approximate_discrete_booking_value_p99
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -308,165 +308,165 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_4
-        ) subq_5
-        WHERE subq_5.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_0
+        ) subq_1
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_2
+    ) subq_3
+  ) subq_4
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_14.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_13.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements: ['listings',]
       SELECT
-        subq_12.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_11.ds__day
-          , subq_11.ds__week
-          , subq_11.ds__month
-          , subq_11.ds__quarter
-          , subq_11.ds__year
-          , subq_11.ds__extract_year
-          , subq_11.ds__extract_quarter
-          , subq_11.ds__extract_month
-          , subq_11.ds__extract_day
-          , subq_11.ds__extract_dow
-          , subq_11.ds__extract_doy
-          , subq_11.created_at__day
-          , subq_11.created_at__week
-          , subq_11.created_at__month
-          , subq_11.created_at__quarter
-          , subq_11.created_at__year
-          , subq_11.created_at__extract_year
-          , subq_11.created_at__extract_quarter
-          , subq_11.created_at__extract_month
-          , subq_11.created_at__extract_day
-          , subq_11.created_at__extract_dow
-          , subq_11.created_at__extract_doy
-          , subq_11.listing__ds__day
-          , subq_11.listing__ds__week
-          , subq_11.listing__ds__month
-          , subq_11.listing__ds__quarter
-          , subq_11.listing__ds__year
-          , subq_11.listing__ds__extract_year
-          , subq_11.listing__ds__extract_quarter
-          , subq_11.listing__ds__extract_month
-          , subq_11.listing__ds__extract_day
-          , subq_11.listing__ds__extract_dow
-          , subq_11.listing__ds__extract_doy
-          , subq_11.listing__created_at__day
-          , subq_11.listing__created_at__week
-          , subq_11.listing__created_at__month
-          , subq_11.listing__created_at__quarter
-          , subq_11.listing__created_at__year
-          , subq_11.listing__created_at__extract_year
-          , subq_11.listing__created_at__extract_quarter
-          , subq_11.listing__created_at__extract_month
-          , subq_11.listing__created_at__extract_day
-          , subq_11.listing__created_at__extract_dow
-          , subq_11.listing__created_at__extract_doy
-          , subq_11.metric_time__day
-          , subq_11.metric_time__week
-          , subq_11.metric_time__month
-          , subq_11.metric_time__quarter
-          , subq_11.metric_time__year
-          , subq_11.metric_time__extract_year
-          , subq_11.metric_time__extract_quarter
-          , subq_11.metric_time__extract_month
-          , subq_11.metric_time__extract_day
-          , subq_11.metric_time__extract_dow
-          , subq_11.metric_time__extract_doy
-          , subq_11.listing
-          , subq_11.user
-          , subq_11.listing__user
-          , subq_11.country_latest
-          , subq_11.is_lux_latest
-          , subq_11.capacity_latest
-          , subq_11.listing__country_latest
-          , subq_11.listing__is_lux_latest
-          , subq_11.listing__capacity_latest
-          , subq_11.listings
-          , subq_11.largest_listing
-          , subq_11.smallest_listing
+          subq_7.ds__day
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.ds__extract_year
+          , subq_7.ds__extract_quarter
+          , subq_7.ds__extract_month
+          , subq_7.ds__extract_day
+          , subq_7.ds__extract_dow
+          , subq_7.ds__extract_doy
+          , subq_7.created_at__day
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.created_at__extract_year
+          , subq_7.created_at__extract_quarter
+          , subq_7.created_at__extract_month
+          , subq_7.created_at__extract_day
+          , subq_7.created_at__extract_dow
+          , subq_7.created_at__extract_doy
+          , subq_7.listing__ds__day
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__ds__extract_year
+          , subq_7.listing__ds__extract_quarter
+          , subq_7.listing__ds__extract_month
+          , subq_7.listing__ds__extract_day
+          , subq_7.listing__ds__extract_dow
+          , subq_7.listing__ds__extract_doy
+          , subq_7.listing__created_at__day
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.listing__created_at__extract_year
+          , subq_7.listing__created_at__extract_quarter
+          , subq_7.listing__created_at__extract_month
+          , subq_7.listing__created_at__extract_day
+          , subq_7.listing__created_at__extract_dow
+          , subq_7.listing__created_at__extract_doy
+          , subq_7.metric_time__day
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.created_at__day
-            , subq_10.created_at__week
-            , subq_10.created_at__month
-            , subq_10.created_at__quarter
-            , subq_10.created_at__year
-            , subq_10.created_at__extract_year
-            , subq_10.created_at__extract_quarter
-            , subq_10.created_at__extract_month
-            , subq_10.created_at__extract_day
-            , subq_10.created_at__extract_dow
-            , subq_10.created_at__extract_doy
-            , subq_10.listing__ds__day
-            , subq_10.listing__ds__week
-            , subq_10.listing__ds__month
-            , subq_10.listing__ds__quarter
-            , subq_10.listing__ds__year
-            , subq_10.listing__ds__extract_year
-            , subq_10.listing__ds__extract_quarter
-            , subq_10.listing__ds__extract_month
-            , subq_10.listing__ds__extract_day
-            , subq_10.listing__ds__extract_dow
-            , subq_10.listing__ds__extract_doy
-            , subq_10.listing__created_at__day
-            , subq_10.listing__created_at__week
-            , subq_10.listing__created_at__month
-            , subq_10.listing__created_at__quarter
-            , subq_10.listing__created_at__year
-            , subq_10.listing__created_at__extract_year
-            , subq_10.listing__created_at__extract_quarter
-            , subq_10.listing__created_at__extract_month
-            , subq_10.listing__created_at__extract_day
-            , subq_10.listing__created_at__extract_dow
-            , subq_10.listing__created_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.user
-            , subq_10.listing__user
-            , subq_10.country_latest
-            , subq_10.is_lux_latest
-            , subq_10.capacity_latest
-            , subq_10.listing__country_latest
-            , subq_10.listing__is_lux_latest
-            , subq_10.listing__capacity_latest
-            , subq_10.listings
-            , subq_10.largest_listing
-            , subq_10.smallest_listing
+            subq_6.ds__day
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds__extract_year
+            , subq_6.ds__extract_quarter
+            , subq_6.ds__extract_month
+            , subq_6.ds__extract_day
+            , subq_6.ds__extract_dow
+            , subq_6.ds__extract_doy
+            , subq_6.created_at__day
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.created_at__extract_year
+            , subq_6.created_at__extract_quarter
+            , subq_6.created_at__extract_month
+            , subq_6.created_at__extract_day
+            , subq_6.created_at__extract_dow
+            , subq_6.created_at__extract_doy
+            , subq_6.listing__ds__day
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__ds__extract_year
+            , subq_6.listing__ds__extract_quarter
+            , subq_6.listing__ds__extract_month
+            , subq_6.listing__ds__extract_day
+            , subq_6.listing__ds__extract_dow
+            , subq_6.listing__ds__extract_doy
+            , subq_6.listing__created_at__day
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.listing__created_at__extract_year
+            , subq_6.listing__created_at__extract_quarter
+            , subq_6.listing__created_at__extract_month
+            , subq_6.listing__created_at__extract_day
+            , subq_6.listing__created_at__extract_dow
+            , subq_6.listing__created_at__extract_doy
+            , subq_6.ds__day AS metric_time__day
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.ds__extract_year AS metric_time__extract_year
+            , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_6.ds__extract_month AS metric_time__extract_month
+            , subq_6.ds__extract_day AS metric_time__extract_day
+            , subq_6.ds__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__extract_doy AS metric_time__extract_doy
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -527,10 +527,10 @@ CROSS JOIN (
               , listings_latest_src_28000.user_id AS user
               , listings_latest_src_28000.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_28000
-          ) subq_10
-        ) subq_11
-        WHERE subq_11.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
-      ) subq_12
-    ) subq_13
-  ) subq_14
-) subq_15
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+      ) subq_8
+    ) subq_9
+  ) subq_10
+) subq_11

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_25.bookings) AS bookings
-  , MAX(subq_31.listings) AS listings
+  MAX(subq_17.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_25
+) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_31
+) subq_23

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_15.metric_time__day
-  , CAST(subq_15.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_15.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_13.metric_time__day
+  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day) AS metric_time__day
-    , MAX(subq_9.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_14.booking_value) AS booking_value
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
+    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_12.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.metric_time__day
-      , subq_8.booking_value AS booking_value_with_is_instant_constraint
+      subq_6.metric_time__day
+      , subq_6.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_7.metric_time__day
-        , SUM(subq_7.booking_value) AS booking_value
+        subq_5.metric_time__day
+        , SUM(subq_5.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_6.metric_time__day
-          , subq_6.booking_value
+          subq_4.metric_time__day
+          , subq_4.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_5.metric_time__day
-            , subq_5.booking__is_instant
-            , subq_5.booking_value
+            subq_3.metric_time__day
+            , subq_3.booking__is_instant
+            , subq_3.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_4.metric_time__day
-              , subq_4.booking__is_instant
-              , subq_4.booking_value
+              subq_2.metric_time__day
+              , subq_2.booking__is_instant
+              , subq_2.booking_value
             FROM (
               -- Constrain Output with WHERE
               SELECT
-                subq_3.ds__day
-                , subq_3.ds__week
-                , subq_3.ds__month
-                , subq_3.ds__quarter
-                , subq_3.ds__year
-                , subq_3.ds__extract_year
-                , subq_3.ds__extract_quarter
-                , subq_3.ds__extract_month
-                , subq_3.ds__extract_day
-                , subq_3.ds__extract_dow
-                , subq_3.ds__extract_doy
-                , subq_3.ds_partitioned__day
-                , subq_3.ds_partitioned__week
-                , subq_3.ds_partitioned__month
-                , subq_3.ds_partitioned__quarter
-                , subq_3.ds_partitioned__year
-                , subq_3.ds_partitioned__extract_year
-                , subq_3.ds_partitioned__extract_quarter
-                , subq_3.ds_partitioned__extract_month
-                , subq_3.ds_partitioned__extract_day
-                , subq_3.ds_partitioned__extract_dow
-                , subq_3.ds_partitioned__extract_doy
-                , subq_3.paid_at__day
-                , subq_3.paid_at__week
-                , subq_3.paid_at__month
-                , subq_3.paid_at__quarter
-                , subq_3.paid_at__year
-                , subq_3.paid_at__extract_year
-                , subq_3.paid_at__extract_quarter
-                , subq_3.paid_at__extract_month
-                , subq_3.paid_at__extract_day
-                , subq_3.paid_at__extract_dow
-                , subq_3.paid_at__extract_doy
-                , subq_3.booking__ds__day
-                , subq_3.booking__ds__week
-                , subq_3.booking__ds__month
-                , subq_3.booking__ds__quarter
-                , subq_3.booking__ds__year
-                , subq_3.booking__ds__extract_year
-                , subq_3.booking__ds__extract_quarter
-                , subq_3.booking__ds__extract_month
-                , subq_3.booking__ds__extract_day
-                , subq_3.booking__ds__extract_dow
-                , subq_3.booking__ds__extract_doy
-                , subq_3.booking__ds_partitioned__day
-                , subq_3.booking__ds_partitioned__week
-                , subq_3.booking__ds_partitioned__month
-                , subq_3.booking__ds_partitioned__quarter
-                , subq_3.booking__ds_partitioned__year
-                , subq_3.booking__ds_partitioned__extract_year
-                , subq_3.booking__ds_partitioned__extract_quarter
-                , subq_3.booking__ds_partitioned__extract_month
-                , subq_3.booking__ds_partitioned__extract_day
-                , subq_3.booking__ds_partitioned__extract_dow
-                , subq_3.booking__ds_partitioned__extract_doy
-                , subq_3.booking__paid_at__day
-                , subq_3.booking__paid_at__week
-                , subq_3.booking__paid_at__month
-                , subq_3.booking__paid_at__quarter
-                , subq_3.booking__paid_at__year
-                , subq_3.booking__paid_at__extract_year
-                , subq_3.booking__paid_at__extract_quarter
-                , subq_3.booking__paid_at__extract_month
-                , subq_3.booking__paid_at__extract_day
-                , subq_3.booking__paid_at__extract_dow
-                , subq_3.booking__paid_at__extract_doy
-                , subq_3.metric_time__day
-                , subq_3.metric_time__week
-                , subq_3.metric_time__month
-                , subq_3.metric_time__quarter
-                , subq_3.metric_time__year
-                , subq_3.metric_time__extract_year
-                , subq_3.metric_time__extract_quarter
-                , subq_3.metric_time__extract_month
-                , subq_3.metric_time__extract_day
-                , subq_3.metric_time__extract_dow
-                , subq_3.metric_time__extract_doy
-                , subq_3.listing
-                , subq_3.guest
-                , subq_3.host
-                , subq_3.booking__listing
-                , subq_3.booking__guest
-                , subq_3.booking__host
-                , subq_3.is_instant
-                , subq_3.booking__is_instant
-                , subq_3.bookings
-                , subq_3.instant_bookings
-                , subq_3.booking_value
-                , subq_3.max_booking_value
-                , subq_3.min_booking_value
-                , subq_3.bookers
-                , subq_3.average_booking_value
-                , subq_3.referred_bookings
-                , subq_3.median_booking_value
-                , subq_3.booking_value_p99
-                , subq_3.discrete_booking_value_p99
-                , subq_3.approximate_continuous_booking_value_p99
-                , subq_3.approximate_discrete_booking_value_p99
+                subq_1.ds__day
+                , subq_1.ds__week
+                , subq_1.ds__month
+                , subq_1.ds__quarter
+                , subq_1.ds__year
+                , subq_1.ds__extract_year
+                , subq_1.ds__extract_quarter
+                , subq_1.ds__extract_month
+                , subq_1.ds__extract_day
+                , subq_1.ds__extract_dow
+                , subq_1.ds__extract_doy
+                , subq_1.ds_partitioned__day
+                , subq_1.ds_partitioned__week
+                , subq_1.ds_partitioned__month
+                , subq_1.ds_partitioned__quarter
+                , subq_1.ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy
+                , subq_1.paid_at__day
+                , subq_1.paid_at__week
+                , subq_1.paid_at__month
+                , subq_1.paid_at__quarter
+                , subq_1.paid_at__year
+                , subq_1.paid_at__extract_year
+                , subq_1.paid_at__extract_quarter
+                , subq_1.paid_at__extract_month
+                , subq_1.paid_at__extract_day
+                , subq_1.paid_at__extract_dow
+                , subq_1.paid_at__extract_doy
+                , subq_1.booking__ds__day
+                , subq_1.booking__ds__week
+                , subq_1.booking__ds__month
+                , subq_1.booking__ds__quarter
+                , subq_1.booking__ds__year
+                , subq_1.booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month
+                , subq_1.booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day
+                , subq_1.booking__paid_at__week
+                , subq_1.booking__paid_at__month
+                , subq_1.booking__paid_at__quarter
+                , subq_1.booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy
+                , subq_1.metric_time__day
+                , subq_1.metric_time__week
+                , subq_1.metric_time__month
+                , subq_1.metric_time__quarter
+                , subq_1.metric_time__year
+                , subq_1.metric_time__extract_year
+                , subq_1.metric_time__extract_quarter
+                , subq_1.metric_time__extract_month
+                , subq_1.metric_time__extract_day
+                , subq_1.metric_time__extract_dow
+                , subq_1.metric_time__extract_doy
+                , subq_1.listing
+                , subq_1.guest
+                , subq_1.host
+                , subq_1.booking__listing
+                , subq_1.booking__guest
+                , subq_1.booking__host
+                , subq_1.is_instant
+                , subq_1.booking__is_instant
+                , subq_1.bookings
+                , subq_1.instant_bookings
+                , subq_1.booking_value
+                , subq_1.max_booking_value
+                , subq_1.min_booking_value
+                , subq_1.bookers
+                , subq_1.average_booking_value
+                , subq_1.referred_bookings
+                , subq_1.median_booking_value
+                , subq_1.booking_value_p99
+                , subq_1.discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99
               FROM (
                 -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_2.ds__day
-                  , subq_2.ds__week
-                  , subq_2.ds__month
-                  , subq_2.ds__quarter
-                  , subq_2.ds__year
-                  , subq_2.ds__extract_year
-                  , subq_2.ds__extract_quarter
-                  , subq_2.ds__extract_month
-                  , subq_2.ds__extract_day
-                  , subq_2.ds__extract_dow
-                  , subq_2.ds__extract_doy
-                  , subq_2.ds_partitioned__day
-                  , subq_2.ds_partitioned__week
-                  , subq_2.ds_partitioned__month
-                  , subq_2.ds_partitioned__quarter
-                  , subq_2.ds_partitioned__year
-                  , subq_2.ds_partitioned__extract_year
-                  , subq_2.ds_partitioned__extract_quarter
-                  , subq_2.ds_partitioned__extract_month
-                  , subq_2.ds_partitioned__extract_day
-                  , subq_2.ds_partitioned__extract_dow
-                  , subq_2.ds_partitioned__extract_doy
-                  , subq_2.paid_at__day
-                  , subq_2.paid_at__week
-                  , subq_2.paid_at__month
-                  , subq_2.paid_at__quarter
-                  , subq_2.paid_at__year
-                  , subq_2.paid_at__extract_year
-                  , subq_2.paid_at__extract_quarter
-                  , subq_2.paid_at__extract_month
-                  , subq_2.paid_at__extract_day
-                  , subq_2.paid_at__extract_dow
-                  , subq_2.paid_at__extract_doy
-                  , subq_2.booking__ds__day
-                  , subq_2.booking__ds__week
-                  , subq_2.booking__ds__month
-                  , subq_2.booking__ds__quarter
-                  , subq_2.booking__ds__year
-                  , subq_2.booking__ds__extract_year
-                  , subq_2.booking__ds__extract_quarter
-                  , subq_2.booking__ds__extract_month
-                  , subq_2.booking__ds__extract_day
-                  , subq_2.booking__ds__extract_dow
-                  , subq_2.booking__ds__extract_doy
-                  , subq_2.booking__ds_partitioned__day
-                  , subq_2.booking__ds_partitioned__week
-                  , subq_2.booking__ds_partitioned__month
-                  , subq_2.booking__ds_partitioned__quarter
-                  , subq_2.booking__ds_partitioned__year
-                  , subq_2.booking__ds_partitioned__extract_year
-                  , subq_2.booking__ds_partitioned__extract_quarter
-                  , subq_2.booking__ds_partitioned__extract_month
-                  , subq_2.booking__ds_partitioned__extract_day
-                  , subq_2.booking__ds_partitioned__extract_dow
-                  , subq_2.booking__ds_partitioned__extract_doy
-                  , subq_2.booking__paid_at__day
-                  , subq_2.booking__paid_at__week
-                  , subq_2.booking__paid_at__month
-                  , subq_2.booking__paid_at__quarter
-                  , subq_2.booking__paid_at__year
-                  , subq_2.booking__paid_at__extract_year
-                  , subq_2.booking__paid_at__extract_quarter
-                  , subq_2.booking__paid_at__extract_month
-                  , subq_2.booking__paid_at__extract_day
-                  , subq_2.booking__paid_at__extract_dow
-                  , subq_2.booking__paid_at__extract_doy
-                  , subq_2.ds__day AS metric_time__day
-                  , subq_2.ds__week AS metric_time__week
-                  , subq_2.ds__month AS metric_time__month
-                  , subq_2.ds__quarter AS metric_time__quarter
-                  , subq_2.ds__year AS metric_time__year
-                  , subq_2.ds__extract_year AS metric_time__extract_year
-                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_2.ds__extract_month AS metric_time__extract_month
-                  , subq_2.ds__extract_day AS metric_time__extract_day
-                  , subq_2.ds__extract_dow AS metric_time__extract_dow
-                  , subq_2.ds__extract_doy AS metric_time__extract_doy
-                  , subq_2.listing
-                  , subq_2.guest
-                  , subq_2.host
-                  , subq_2.booking__listing
-                  , subq_2.booking__guest
-                  , subq_2.booking__host
-                  , subq_2.is_instant
-                  , subq_2.booking__is_instant
-                  , subq_2.bookings
-                  , subq_2.instant_bookings
-                  , subq_2.booking_value
-                  , subq_2.max_booking_value
-                  , subq_2.min_booking_value
-                  , subq_2.bookers
-                  , subq_2.average_booking_value
-                  , subq_2.referred_bookings
-                  , subq_2.median_booking_value
-                  , subq_2.booking_value_p99
-                  , subq_2.discrete_booking_value_p99
-                  , subq_2.approximate_continuous_booking_value_p99
-                  , subq_2.approximate_discrete_booking_value_p99
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
                 FROM (
                   -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
@@ -329,134 +329,134 @@ FROM (
                     , bookings_source_src_28000.guest_id AS booking__guest
                     , bookings_source_src_28000.host_id AS booking__host
                   FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_2
-              ) subq_3
+                ) subq_0
+              ) subq_1
               WHERE booking__is_instant
-            ) subq_4
-          ) subq_5
+            ) subq_2
+          ) subq_3
           WHERE booking__is_instant
-        ) subq_6
-      ) subq_7
+        ) subq_4
+      ) subq_5
       GROUP BY
-        subq_7.metric_time__day
-    ) subq_8
-  ) subq_9
+        subq_5.metric_time__day
+    ) subq_6
+  ) subq_7
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_13.metric_time__day
-      , subq_13.booking_value
+      subq_11.metric_time__day
+      , subq_11.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day
-        , SUM(subq_12.booking_value) AS booking_value
+        subq_10.metric_time__day
+        , SUM(subq_10.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_11.metric_time__day
-          , subq_11.booking_value
+          subq_9.metric_time__day
+          , subq_9.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.ds_partitioned__day
-            , subq_10.ds_partitioned__week
-            , subq_10.ds_partitioned__month
-            , subq_10.ds_partitioned__quarter
-            , subq_10.ds_partitioned__year
-            , subq_10.ds_partitioned__extract_year
-            , subq_10.ds_partitioned__extract_quarter
-            , subq_10.ds_partitioned__extract_month
-            , subq_10.ds_partitioned__extract_day
-            , subq_10.ds_partitioned__extract_dow
-            , subq_10.ds_partitioned__extract_doy
-            , subq_10.paid_at__day
-            , subq_10.paid_at__week
-            , subq_10.paid_at__month
-            , subq_10.paid_at__quarter
-            , subq_10.paid_at__year
-            , subq_10.paid_at__extract_year
-            , subq_10.paid_at__extract_quarter
-            , subq_10.paid_at__extract_month
-            , subq_10.paid_at__extract_day
-            , subq_10.paid_at__extract_dow
-            , subq_10.paid_at__extract_doy
-            , subq_10.booking__ds__day
-            , subq_10.booking__ds__week
-            , subq_10.booking__ds__month
-            , subq_10.booking__ds__quarter
-            , subq_10.booking__ds__year
-            , subq_10.booking__ds__extract_year
-            , subq_10.booking__ds__extract_quarter
-            , subq_10.booking__ds__extract_month
-            , subq_10.booking__ds__extract_day
-            , subq_10.booking__ds__extract_dow
-            , subq_10.booking__ds__extract_doy
-            , subq_10.booking__ds_partitioned__day
-            , subq_10.booking__ds_partitioned__week
-            , subq_10.booking__ds_partitioned__month
-            , subq_10.booking__ds_partitioned__quarter
-            , subq_10.booking__ds_partitioned__year
-            , subq_10.booking__ds_partitioned__extract_year
-            , subq_10.booking__ds_partitioned__extract_quarter
-            , subq_10.booking__ds_partitioned__extract_month
-            , subq_10.booking__ds_partitioned__extract_day
-            , subq_10.booking__ds_partitioned__extract_dow
-            , subq_10.booking__ds_partitioned__extract_doy
-            , subq_10.booking__paid_at__day
-            , subq_10.booking__paid_at__week
-            , subq_10.booking__paid_at__month
-            , subq_10.booking__paid_at__quarter
-            , subq_10.booking__paid_at__year
-            , subq_10.booking__paid_at__extract_year
-            , subq_10.booking__paid_at__extract_quarter
-            , subq_10.booking__paid_at__extract_month
-            , subq_10.booking__paid_at__extract_day
-            , subq_10.booking__paid_at__extract_dow
-            , subq_10.booking__paid_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.guest
-            , subq_10.host
-            , subq_10.booking__listing
-            , subq_10.booking__guest
-            , subq_10.booking__host
-            , subq_10.is_instant
-            , subq_10.booking__is_instant
-            , subq_10.bookings
-            , subq_10.instant_bookings
-            , subq_10.booking_value
-            , subq_10.max_booking_value
-            , subq_10.min_booking_value
-            , subq_10.bookers
-            , subq_10.average_booking_value
-            , subq_10.referred_bookings
-            , subq_10.median_booking_value
-            , subq_10.booking_value_p99
-            , subq_10.discrete_booking_value_p99
-            , subq_10.approximate_continuous_booking_value_p99
-            , subq_10.approximate_discrete_booking_value_p99
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +549,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_10
-        ) subq_11
-      ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
       GROUP BY
-        subq_12.metric_time__day
-    ) subq_13
-  ) subq_14
+        subq_10.metric_time__day
+    ) subq_11
+  ) subq_12
   ON
-    subq_9.metric_time__day = subq_14.metric_time__day
+    subq_7.metric_time__day = subq_12.metric_time__day
   GROUP BY
-    COALESCE(subq_9.metric_time__day, subq_14.metric_time__day)
-) subq_15
+    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_30.booking_value) AS booking_value
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_26.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_21
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_21
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_30
+  ) subq_26
   ON
-    subq_25.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_26.metric_time__day
   GROUP BY
-    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
+) subq_27

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
+  subq_7.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.metric_time__day
-    , subq_8.bookings AS delayed_bookings
+    subq_6.metric_time__day
+    , subq_6.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -323,15 +323,15 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE NOT booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE NOT booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
-) subq_9
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_9
     WHERE NOT booking__is_instant
-  ) subq_15
+  ) subq_11
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_19
+) subq_15

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_through_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_21.metric_time__day
-  , subq_21.listing__user__home_state_latest
-  , subq_21.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__user__home_state_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-    , SUM(subq_20.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__user__home_state_latest', 'metric_time__day']
     SELECT
-      subq_19.metric_time__day
-      , subq_19.listing__user__home_state_latest
-      , subq_19.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__user__home_state_latest
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_13.metric_time__day AS metric_time__day
-        , subq_18.window_start__day AS listing__window_start__day
-        , subq_18.window_end__day AS listing__window_end__day
-        , subq_13.listing AS listing
-        , subq_18.user__home_state_latest AS listing__user__home_state_latest
-        , subq_13.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.window_start__day AS listing__window_start__day
+        , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.user__home_state_latest AS listing__user__home_state_latest
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_12.metric_time__day
-          , subq_12.listing
-          , subq_12.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds__day
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds__extract_year
-            , subq_11.ds__extract_quarter
-            , subq_11.ds__extract_month
-            , subq_11.ds__extract_day
-            , subq_11.ds__extract_dow
-            , subq_11.ds__extract_doy
-            , subq_11.ds_partitioned__day
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.ds_partitioned__extract_year
-            , subq_11.ds_partitioned__extract_quarter
-            , subq_11.ds_partitioned__extract_month
-            , subq_11.ds_partitioned__extract_day
-            , subq_11.ds_partitioned__extract_dow
-            , subq_11.ds_partitioned__extract_doy
-            , subq_11.paid_at__day
-            , subq_11.paid_at__week
-            , subq_11.paid_at__month
-            , subq_11.paid_at__quarter
-            , subq_11.paid_at__year
-            , subq_11.paid_at__extract_year
-            , subq_11.paid_at__extract_quarter
-            , subq_11.paid_at__extract_month
-            , subq_11.paid_at__extract_day
-            , subq_11.paid_at__extract_dow
-            , subq_11.paid_at__extract_doy
-            , subq_11.booking__ds__day
-            , subq_11.booking__ds__week
-            , subq_11.booking__ds__month
-            , subq_11.booking__ds__quarter
-            , subq_11.booking__ds__year
-            , subq_11.booking__ds__extract_year
-            , subq_11.booking__ds__extract_quarter
-            , subq_11.booking__ds__extract_month
-            , subq_11.booking__ds__extract_day
-            , subq_11.booking__ds__extract_dow
-            , subq_11.booking__ds__extract_doy
-            , subq_11.booking__ds_partitioned__day
-            , subq_11.booking__ds_partitioned__week
-            , subq_11.booking__ds_partitioned__month
-            , subq_11.booking__ds_partitioned__quarter
-            , subq_11.booking__ds_partitioned__year
-            , subq_11.booking__ds_partitioned__extract_year
-            , subq_11.booking__ds_partitioned__extract_quarter
-            , subq_11.booking__ds_partitioned__extract_month
-            , subq_11.booking__ds_partitioned__extract_day
-            , subq_11.booking__ds_partitioned__extract_dow
-            , subq_11.booking__ds_partitioned__extract_doy
-            , subq_11.booking__paid_at__day
-            , subq_11.booking__paid_at__week
-            , subq_11.booking__paid_at__month
-            , subq_11.booking__paid_at__quarter
-            , subq_11.booking__paid_at__year
-            , subq_11.booking__paid_at__extract_year
-            , subq_11.booking__paid_at__extract_quarter
-            , subq_11.booking__paid_at__extract_month
-            , subq_11.booking__paid_at__extract_day
-            , subq_11.booking__paid_at__extract_dow
-            , subq_11.booking__paid_at__extract_doy
-            , subq_11.ds__day AS metric_time__day
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.ds__extract_year AS metric_time__extract_year
-            , subq_11.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_11.ds__extract_month AS metric_time__extract_month
-            , subq_11.ds__extract_day AS metric_time__extract_day
-            , subq_11.ds__extract_dow AS metric_time__extract_dow
-            , subq_11.ds__extract_doy AS metric_time__extract_doy
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.user
-            , subq_11.booking__listing
-            , subq_11.booking__guest
-            , subq_11.booking__host
-            , subq_11.booking__user
-            , subq_11.is_instant
-            , subq_11.booking__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,84 +211,84 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
         SELECT
-          subq_17.window_start__day
-          , subq_17.window_end__day
-          , subq_17.listing
-          , subq_17.user__home_state_latest
+          subq_6.window_start__day
+          , subq_6.window_end__day
+          , subq_6.listing
+          , subq_6.user__home_state_latest
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.window_start__day AS window_start__day
-            , subq_14.window_start__week AS window_start__week
-            , subq_14.window_start__month AS window_start__month
-            , subq_14.window_start__quarter AS window_start__quarter
-            , subq_14.window_start__year AS window_start__year
-            , subq_14.window_start__extract_year AS window_start__extract_year
-            , subq_14.window_start__extract_quarter AS window_start__extract_quarter
-            , subq_14.window_start__extract_month AS window_start__extract_month
-            , subq_14.window_start__extract_day AS window_start__extract_day
-            , subq_14.window_start__extract_dow AS window_start__extract_dow
-            , subq_14.window_start__extract_doy AS window_start__extract_doy
-            , subq_14.window_end__day AS window_end__day
-            , subq_14.window_end__week AS window_end__week
-            , subq_14.window_end__month AS window_end__month
-            , subq_14.window_end__quarter AS window_end__quarter
-            , subq_14.window_end__year AS window_end__year
-            , subq_14.window_end__extract_year AS window_end__extract_year
-            , subq_14.window_end__extract_quarter AS window_end__extract_quarter
-            , subq_14.window_end__extract_month AS window_end__extract_month
-            , subq_14.window_end__extract_day AS window_end__extract_day
-            , subq_14.window_end__extract_dow AS window_end__extract_dow
-            , subq_14.window_end__extract_doy AS window_end__extract_doy
-            , subq_14.listing__window_start__day AS listing__window_start__day
-            , subq_14.listing__window_start__week AS listing__window_start__week
-            , subq_14.listing__window_start__month AS listing__window_start__month
-            , subq_14.listing__window_start__quarter AS listing__window_start__quarter
-            , subq_14.listing__window_start__year AS listing__window_start__year
-            , subq_14.listing__window_start__extract_year AS listing__window_start__extract_year
-            , subq_14.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
-            , subq_14.listing__window_start__extract_month AS listing__window_start__extract_month
-            , subq_14.listing__window_start__extract_day AS listing__window_start__extract_day
-            , subq_14.listing__window_start__extract_dow AS listing__window_start__extract_dow
-            , subq_14.listing__window_start__extract_doy AS listing__window_start__extract_doy
-            , subq_14.listing__window_end__day AS listing__window_end__day
-            , subq_14.listing__window_end__week AS listing__window_end__week
-            , subq_14.listing__window_end__month AS listing__window_end__month
-            , subq_14.listing__window_end__quarter AS listing__window_end__quarter
-            , subq_14.listing__window_end__year AS listing__window_end__year
-            , subq_14.listing__window_end__extract_year AS listing__window_end__extract_year
-            , subq_14.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
-            , subq_14.listing__window_end__extract_month AS listing__window_end__extract_month
-            , subq_14.listing__window_end__extract_day AS listing__window_end__extract_day
-            , subq_14.listing__window_end__extract_dow AS listing__window_end__extract_dow
-            , subq_14.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_16.ds__day AS user__ds__day
-            , subq_16.ds__week AS user__ds__week
-            , subq_16.ds__month AS user__ds__month
-            , subq_16.ds__quarter AS user__ds__quarter
-            , subq_16.ds__year AS user__ds__year
-            , subq_16.ds__extract_year AS user__ds__extract_year
-            , subq_16.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_16.ds__extract_month AS user__ds__extract_month
-            , subq_16.ds__extract_day AS user__ds__extract_day
-            , subq_16.ds__extract_dow AS user__ds__extract_dow
-            , subq_16.ds__extract_doy AS user__ds__extract_doy
-            , subq_14.listing AS listing
-            , subq_14.user AS user
-            , subq_14.listing__user AS listing__user
-            , subq_14.country AS country
-            , subq_14.is_lux AS is_lux
-            , subq_14.capacity AS capacity
-            , subq_14.listing__country AS listing__country
-            , subq_14.listing__is_lux AS listing__is_lux
-            , subq_14.listing__capacity AS listing__capacity
-            , subq_16.home_state_latest AS user__home_state_latest
+            subq_3.window_start__day AS window_start__day
+            , subq_3.window_start__week AS window_start__week
+            , subq_3.window_start__month AS window_start__month
+            , subq_3.window_start__quarter AS window_start__quarter
+            , subq_3.window_start__year AS window_start__year
+            , subq_3.window_start__extract_year AS window_start__extract_year
+            , subq_3.window_start__extract_quarter AS window_start__extract_quarter
+            , subq_3.window_start__extract_month AS window_start__extract_month
+            , subq_3.window_start__extract_day AS window_start__extract_day
+            , subq_3.window_start__extract_dow AS window_start__extract_dow
+            , subq_3.window_start__extract_doy AS window_start__extract_doy
+            , subq_3.window_end__day AS window_end__day
+            , subq_3.window_end__week AS window_end__week
+            , subq_3.window_end__month AS window_end__month
+            , subq_3.window_end__quarter AS window_end__quarter
+            , subq_3.window_end__year AS window_end__year
+            , subq_3.window_end__extract_year AS window_end__extract_year
+            , subq_3.window_end__extract_quarter AS window_end__extract_quarter
+            , subq_3.window_end__extract_month AS window_end__extract_month
+            , subq_3.window_end__extract_day AS window_end__extract_day
+            , subq_3.window_end__extract_dow AS window_end__extract_dow
+            , subq_3.window_end__extract_doy AS window_end__extract_doy
+            , subq_3.listing__window_start__day AS listing__window_start__day
+            , subq_3.listing__window_start__week AS listing__window_start__week
+            , subq_3.listing__window_start__month AS listing__window_start__month
+            , subq_3.listing__window_start__quarter AS listing__window_start__quarter
+            , subq_3.listing__window_start__year AS listing__window_start__year
+            , subq_3.listing__window_start__extract_year AS listing__window_start__extract_year
+            , subq_3.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+            , subq_3.listing__window_start__extract_month AS listing__window_start__extract_month
+            , subq_3.listing__window_start__extract_day AS listing__window_start__extract_day
+            , subq_3.listing__window_start__extract_dow AS listing__window_start__extract_dow
+            , subq_3.listing__window_start__extract_doy AS listing__window_start__extract_doy
+            , subq_3.listing__window_end__day AS listing__window_end__day
+            , subq_3.listing__window_end__week AS listing__window_end__week
+            , subq_3.listing__window_end__month AS listing__window_end__month
+            , subq_3.listing__window_end__quarter AS listing__window_end__quarter
+            , subq_3.listing__window_end__year AS listing__window_end__year
+            , subq_3.listing__window_end__extract_year AS listing__window_end__extract_year
+            , subq_3.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+            , subq_3.listing__window_end__extract_month AS listing__window_end__extract_month
+            , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
+            , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
+            , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.user AS user
+            , subq_3.listing__user AS listing__user
+            , subq_3.country AS country
+            , subq_3.is_lux AS is_lux
+            , subq_3.capacity AS capacity
+            , subq_3.listing__country AS listing__country
+            , subq_3.listing__is_lux AS listing__is_lux
+            , subq_3.listing__capacity AS listing__capacity
+            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT
@@ -346,7 +346,7 @@ FROM (
               , listings_src_26000.user_id AS user
               , listings_src_26000.user_id AS listing__user
             FROM ***************************.dim_listings listings_src_26000
-          ) subq_14
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'home_state_latest',
@@ -376,31 +376,31 @@ FROM (
             --   'user',
             -- ]
             SELECT
-              subq_15.ds__day
-              , subq_15.ds__week
-              , subq_15.ds__month
-              , subq_15.ds__quarter
-              , subq_15.ds__year
-              , subq_15.ds__extract_year
-              , subq_15.ds__extract_quarter
-              , subq_15.ds__extract_month
-              , subq_15.ds__extract_day
-              , subq_15.ds__extract_dow
-              , subq_15.ds__extract_doy
-              , subq_15.user__ds__day
-              , subq_15.user__ds__week
-              , subq_15.user__ds__month
-              , subq_15.user__ds__quarter
-              , subq_15.user__ds__year
-              , subq_15.user__ds__extract_year
-              , subq_15.user__ds__extract_quarter
-              , subq_15.user__ds__extract_month
-              , subq_15.user__ds__extract_day
-              , subq_15.user__ds__extract_dow
-              , subq_15.user__ds__extract_doy
-              , subq_15.user
-              , subq_15.home_state_latest
-              , subq_15.user__home_state_latest
+              subq_4.ds__day
+              , subq_4.ds__week
+              , subq_4.ds__month
+              , subq_4.ds__quarter
+              , subq_4.ds__year
+              , subq_4.ds__extract_year
+              , subq_4.ds__extract_quarter
+              , subq_4.ds__extract_month
+              , subq_4.ds__extract_day
+              , subq_4.ds__extract_dow
+              , subq_4.ds__extract_doy
+              , subq_4.user__ds__day
+              , subq_4.user__ds__week
+              , subq_4.user__ds__month
+              , subq_4.user__ds__quarter
+              , subq_4.user__ds__year
+              , subq_4.user__ds__extract_year
+              , subq_4.user__ds__extract_quarter
+              , subq_4.user__ds__extract_month
+              , subq_4.user__ds__extract_day
+              , subq_4.user__ds__extract_dow
+              , subq_4.user__ds__extract_doy
+              , subq_4.user
+              , subq_4.home_state_latest
+              , subq_4.user__home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -430,29 +430,29 @@ FROM (
                 , users_latest_src_26000.home_state_latest AS user__home_state_latest
                 , users_latest_src_26000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_26000
-            ) subq_15
-          ) subq_16
+            ) subq_4
+          ) subq_5
           ON
-            subq_14.user = subq_16.user
-        ) subq_17
-      ) subq_18
+            subq_3.user = subq_5.user
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_13.listing = subq_18.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_13.metric_time__day >= subq_18.window_start__day
+            subq_2.metric_time__day >= subq_7.window_start__day
           ) AND (
             (
-              subq_13.metric_time__day < subq_18.window_end__day
+              subq_2.metric_time__day < subq_7.window_end__day
             ) OR (
-              subq_18.window_end__day IS NULL
+              subq_7.window_end__day IS NULL
             )
           )
         )
-    ) subq_19
-  ) subq_20
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_20.metric_time__day
-    , subq_20.listing__user__home_state_latest
-) subq_21
+    subq_9.metric_time__day
+    , subq_9.listing__user__home_state_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_35.metric_time__day AS metric_time__day
-  , subq_40.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_35.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_35
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_40
+) subq_18
 ON
   (
-    subq_35.listing = subq_40.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_35.metric_time__day >= subq_40.window_start__day
+      subq_13.metric_time__day >= subq_18.window_start__day
     ) AND (
       (
-        subq_35.metric_time__day < subq_40.window_end__day
+        subq_13.metric_time__day < subq_18.window_end__day
       ) OR (
-        subq_40.window_end__day IS NULL
+        subq_18.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_35.metric_time__day
-  , subq_40.user__home_state_latest
+  subq_13.metric_time__day
+  , subq_18.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_to_scd_dimension__plan0.sql
@@ -1,130 +1,130 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , subq_13.listing__lux_listing__is_confirmed_lux
-  , subq_13.bookings
+  subq_10.metric_time__day
+  , subq_10.listing__lux_listing__is_confirmed_lux
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-    , SUM(subq_12.bookings) AS bookings
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__lux_listing__is_confirmed_lux', 'metric_time__day']
     SELECT
-      subq_11.metric_time__day
-      , subq_11.listing__lux_listing__is_confirmed_lux
-      , subq_11.bookings
+      subq_8.metric_time__day
+      , subq_8.listing__lux_listing__is_confirmed_lux
+      , subq_8.bookings
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_5.metric_time__day AS metric_time__day
-        , subq_10.lux_listing__window_start__day AS listing__lux_listing__window_start__day
-        , subq_10.lux_listing__window_end__day AS listing__lux_listing__window_end__day
-        , subq_5.listing AS listing
-        , subq_10.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-        , subq_5.bookings AS bookings
+        subq_2.metric_time__day AS metric_time__day
+        , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
+        , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.listing AS listing
+        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+        , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.listing
-          , subq_4.bookings
+          subq_1.metric_time__day
+          , subq_1.listing
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.ds__day AS metric_time__day
-            , subq_3.ds__week AS metric_time__week
-            , subq_3.ds__month AS metric_time__month
-            , subq_3.ds__quarter AS metric_time__quarter
-            , subq_3.ds__year AS metric_time__year
-            , subq_3.ds__extract_year AS metric_time__extract_year
-            , subq_3.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_3.ds__extract_month AS metric_time__extract_month
-            , subq_3.ds__extract_day AS metric_time__extract_day
-            , subq_3.ds__extract_dow AS metric_time__extract_dow
-            , subq_3.ds__extract_doy AS metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.user
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.booking__user
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.user
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.booking__user
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -211,45 +211,45 @@ FROM (
               , bookings_source_src_26000.host_id AS booking__host
               , bookings_source_src_26000.guest_id AS booking__user
             FROM ***************************.fct_bookings bookings_source_src_26000
-          ) subq_3
-        ) subq_4
-      ) subq_5
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
         SELECT
-          subq_9.lux_listing__window_start__day
-          , subq_9.lux_listing__window_end__day
-          , subq_9.listing
-          , subq_9.lux_listing__is_confirmed_lux
+          subq_6.lux_listing__window_start__day
+          , subq_6.lux_listing__window_end__day
+          , subq_6.listing
+          , subq_6.lux_listing__is_confirmed_lux
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_8.window_start__day AS lux_listing__window_start__day
-            , subq_8.window_start__week AS lux_listing__window_start__week
-            , subq_8.window_start__month AS lux_listing__window_start__month
-            , subq_8.window_start__quarter AS lux_listing__window_start__quarter
-            , subq_8.window_start__year AS lux_listing__window_start__year
-            , subq_8.window_start__extract_year AS lux_listing__window_start__extract_year
-            , subq_8.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
-            , subq_8.window_start__extract_month AS lux_listing__window_start__extract_month
-            , subq_8.window_start__extract_day AS lux_listing__window_start__extract_day
-            , subq_8.window_start__extract_dow AS lux_listing__window_start__extract_dow
-            , subq_8.window_start__extract_doy AS lux_listing__window_start__extract_doy
-            , subq_8.window_end__day AS lux_listing__window_end__day
-            , subq_8.window_end__week AS lux_listing__window_end__week
-            , subq_8.window_end__month AS lux_listing__window_end__month
-            , subq_8.window_end__quarter AS lux_listing__window_end__quarter
-            , subq_8.window_end__year AS lux_listing__window_end__year
-            , subq_8.window_end__extract_year AS lux_listing__window_end__extract_year
-            , subq_8.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
-            , subq_8.window_end__extract_month AS lux_listing__window_end__extract_month
-            , subq_8.window_end__extract_day AS lux_listing__window_end__extract_day
-            , subq_8.window_end__extract_dow AS lux_listing__window_end__extract_dow
-            , subq_8.window_end__extract_doy AS lux_listing__window_end__extract_doy
-            , subq_6.listing AS listing
-            , subq_6.lux_listing AS lux_listing
-            , subq_6.listing__lux_listing AS listing__lux_listing
-            , subq_8.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            subq_5.window_start__day AS lux_listing__window_start__day
+            , subq_5.window_start__week AS lux_listing__window_start__week
+            , subq_5.window_start__month AS lux_listing__window_start__month
+            , subq_5.window_start__quarter AS lux_listing__window_start__quarter
+            , subq_5.window_start__year AS lux_listing__window_start__year
+            , subq_5.window_start__extract_year AS lux_listing__window_start__extract_year
+            , subq_5.window_start__extract_quarter AS lux_listing__window_start__extract_quarter
+            , subq_5.window_start__extract_month AS lux_listing__window_start__extract_month
+            , subq_5.window_start__extract_day AS lux_listing__window_start__extract_day
+            , subq_5.window_start__extract_dow AS lux_listing__window_start__extract_dow
+            , subq_5.window_start__extract_doy AS lux_listing__window_start__extract_doy
+            , subq_5.window_end__day AS lux_listing__window_end__day
+            , subq_5.window_end__week AS lux_listing__window_end__week
+            , subq_5.window_end__month AS lux_listing__window_end__month
+            , subq_5.window_end__quarter AS lux_listing__window_end__quarter
+            , subq_5.window_end__year AS lux_listing__window_end__year
+            , subq_5.window_end__extract_year AS lux_listing__window_end__extract_year
+            , subq_5.window_end__extract_quarter AS lux_listing__window_end__extract_quarter
+            , subq_5.window_end__extract_month AS lux_listing__window_end__extract_month
+            , subq_5.window_end__extract_day AS lux_listing__window_end__extract_day
+            , subq_5.window_end__extract_dow AS lux_listing__window_end__extract_dow
+            , subq_5.window_end__extract_doy AS lux_listing__window_end__extract_doy
+            , subq_3.listing AS listing
+            , subq_3.lux_listing AS lux_listing
+            , subq_3.listing__lux_listing AS listing__lux_listing
+            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT
@@ -257,7 +257,7 @@ FROM (
               , lux_listing_mapping_src_26000.lux_listing_id AS lux_listing
               , lux_listing_mapping_src_26000.lux_listing_id AS listing__lux_listing
             FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_26000
-          ) subq_6
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'is_confirmed_lux',
@@ -309,53 +309,53 @@ FROM (
             --   'lux_listing',
             -- ]
             SELECT
-              subq_7.window_start__day
-              , subq_7.window_start__week
-              , subq_7.window_start__month
-              , subq_7.window_start__quarter
-              , subq_7.window_start__year
-              , subq_7.window_start__extract_year
-              , subq_7.window_start__extract_quarter
-              , subq_7.window_start__extract_month
-              , subq_7.window_start__extract_day
-              , subq_7.window_start__extract_dow
-              , subq_7.window_start__extract_doy
-              , subq_7.window_end__day
-              , subq_7.window_end__week
-              , subq_7.window_end__month
-              , subq_7.window_end__quarter
-              , subq_7.window_end__year
-              , subq_7.window_end__extract_year
-              , subq_7.window_end__extract_quarter
-              , subq_7.window_end__extract_month
-              , subq_7.window_end__extract_day
-              , subq_7.window_end__extract_dow
-              , subq_7.window_end__extract_doy
-              , subq_7.lux_listing__window_start__day
-              , subq_7.lux_listing__window_start__week
-              , subq_7.lux_listing__window_start__month
-              , subq_7.lux_listing__window_start__quarter
-              , subq_7.lux_listing__window_start__year
-              , subq_7.lux_listing__window_start__extract_year
-              , subq_7.lux_listing__window_start__extract_quarter
-              , subq_7.lux_listing__window_start__extract_month
-              , subq_7.lux_listing__window_start__extract_day
-              , subq_7.lux_listing__window_start__extract_dow
-              , subq_7.lux_listing__window_start__extract_doy
-              , subq_7.lux_listing__window_end__day
-              , subq_7.lux_listing__window_end__week
-              , subq_7.lux_listing__window_end__month
-              , subq_7.lux_listing__window_end__quarter
-              , subq_7.lux_listing__window_end__year
-              , subq_7.lux_listing__window_end__extract_year
-              , subq_7.lux_listing__window_end__extract_quarter
-              , subq_7.lux_listing__window_end__extract_month
-              , subq_7.lux_listing__window_end__extract_day
-              , subq_7.lux_listing__window_end__extract_dow
-              , subq_7.lux_listing__window_end__extract_doy
-              , subq_7.lux_listing
-              , subq_7.is_confirmed_lux
-              , subq_7.lux_listing__is_confirmed_lux
+              subq_4.window_start__day
+              , subq_4.window_start__week
+              , subq_4.window_start__month
+              , subq_4.window_start__quarter
+              , subq_4.window_start__year
+              , subq_4.window_start__extract_year
+              , subq_4.window_start__extract_quarter
+              , subq_4.window_start__extract_month
+              , subq_4.window_start__extract_day
+              , subq_4.window_start__extract_dow
+              , subq_4.window_start__extract_doy
+              , subq_4.window_end__day
+              , subq_4.window_end__week
+              , subq_4.window_end__month
+              , subq_4.window_end__quarter
+              , subq_4.window_end__year
+              , subq_4.window_end__extract_year
+              , subq_4.window_end__extract_quarter
+              , subq_4.window_end__extract_month
+              , subq_4.window_end__extract_day
+              , subq_4.window_end__extract_dow
+              , subq_4.window_end__extract_doy
+              , subq_4.lux_listing__window_start__day
+              , subq_4.lux_listing__window_start__week
+              , subq_4.lux_listing__window_start__month
+              , subq_4.lux_listing__window_start__quarter
+              , subq_4.lux_listing__window_start__year
+              , subq_4.lux_listing__window_start__extract_year
+              , subq_4.lux_listing__window_start__extract_quarter
+              , subq_4.lux_listing__window_start__extract_month
+              , subq_4.lux_listing__window_start__extract_day
+              , subq_4.lux_listing__window_start__extract_dow
+              , subq_4.lux_listing__window_start__extract_doy
+              , subq_4.lux_listing__window_end__day
+              , subq_4.lux_listing__window_end__week
+              , subq_4.lux_listing__window_end__month
+              , subq_4.lux_listing__window_end__quarter
+              , subq_4.lux_listing__window_end__year
+              , subq_4.lux_listing__window_end__extract_year
+              , subq_4.lux_listing__window_end__extract_quarter
+              , subq_4.lux_listing__window_end__extract_month
+              , subq_4.lux_listing__window_end__extract_day
+              , subq_4.lux_listing__window_end__extract_dow
+              , subq_4.lux_listing__window_end__extract_doy
+              , subq_4.lux_listing
+              , subq_4.is_confirmed_lux
+              , subq_4.lux_listing__is_confirmed_lux
             FROM (
               -- Read Elements From Semantic Model 'lux_listings'
               SELECT
@@ -407,29 +407,29 @@ FROM (
                 , lux_listings_src_26000.is_confirmed_lux AS lux_listing__is_confirmed_lux
                 , lux_listings_src_26000.lux_listing_id AS lux_listing
               FROM ***************************.dim_lux_listings lux_listings_src_26000
-            ) subq_7
-          ) subq_8
+            ) subq_4
+          ) subq_5
           ON
-            subq_6.lux_listing = subq_8.lux_listing
-        ) subq_9
-      ) subq_10
+            subq_3.lux_listing = subq_5.lux_listing
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_5.listing = subq_10.listing
+          subq_2.listing = subq_7.listing
         ) AND (
           (
-            subq_5.metric_time__day >= subq_10.lux_listing__window_start__day
+            subq_2.metric_time__day >= subq_7.lux_listing__window_start__day
           ) AND (
             (
-              subq_5.metric_time__day < subq_10.lux_listing__window_end__day
+              subq_2.metric_time__day < subq_7.lux_listing__window_end__day
             ) OR (
-              subq_10.lux_listing__window_end__day IS NULL
+              subq_7.lux_listing__window_end__day IS NULL
             )
           )
         )
-    ) subq_11
-  ) subq_12
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_12.metric_time__day
-    , subq_12.listing__lux_listing__is_confirmed_lux
-) subq_13
+    subq_9.metric_time__day
+    , subq_9.listing__lux_listing__is_confirmed_lux
+) subq_10

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time__day AS metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_19.bookings) AS bookings
+  subq_13.metric_time__day AS metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_13.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_19
+) subq_13
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_24
+) subq_18
 ON
   (
-    subq_19.listing = subq_24.listing
+    subq_13.listing = subq_18.listing
   ) AND (
     (
-      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
+      subq_13.metric_time__day >= subq_18.lux_listing__window_start__day
     ) AND (
       (
-        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
+        subq_13.metric_time__day < subq_18.lux_listing__window_end__day
       ) OR (
-        subq_24.lux_listing__window_end__day IS NULL
+        subq_18.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_19.metric_time__day
-  , subq_24.lux_listing__is_confirmed_lux
+  subq_13.metric_time__day
+  , subq_18.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multihop_node__plan0.sql
@@ -1,93 +1,93 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.account_id__customer_id__customer_name
-  , subq_17.txn_count
+  subq_12.account_id__customer_id__customer_name
+  , subq_12.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_16.account_id__customer_id__customer_name
-    , SUM(subq_16.txn_count) AS txn_count
+    subq_11.account_id__customer_id__customer_name
+    , SUM(subq_11.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements: ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_15.account_id__customer_id__customer_name
-      , subq_15.txn_count
+      subq_10.account_id__customer_id__customer_name
+      , subq_10.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_7.ds_partitioned__day AS ds_partitioned__day
-        , subq_14.ds_partitioned__day AS account_id__ds_partitioned__day
-        , subq_7.account_id AS account_id
-        , subq_14.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_7.txn_count AS txn_count
+        subq_2.ds_partitioned__day AS ds_partitioned__day
+        , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.account_id AS account_id
+        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_6.ds_partitioned__day
-          , subq_6.account_id
-          , subq_6.txn_count
+          subq_1.ds_partitioned__day
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds_partitioned__day
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.ds_partitioned__extract_year
-            , subq_5.ds_partitioned__extract_quarter
-            , subq_5.ds_partitioned__extract_month
-            , subq_5.ds_partitioned__extract_day
-            , subq_5.ds_partitioned__extract_dow
-            , subq_5.ds_partitioned__extract_doy
-            , subq_5.ds__day
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds__extract_year
-            , subq_5.ds__extract_quarter
-            , subq_5.ds__extract_month
-            , subq_5.ds__extract_day
-            , subq_5.ds__extract_dow
-            , subq_5.ds__extract_doy
-            , subq_5.account_id__ds_partitioned__day
-            , subq_5.account_id__ds_partitioned__week
-            , subq_5.account_id__ds_partitioned__month
-            , subq_5.account_id__ds_partitioned__quarter
-            , subq_5.account_id__ds_partitioned__year
-            , subq_5.account_id__ds_partitioned__extract_year
-            , subq_5.account_id__ds_partitioned__extract_quarter
-            , subq_5.account_id__ds_partitioned__extract_month
-            , subq_5.account_id__ds_partitioned__extract_day
-            , subq_5.account_id__ds_partitioned__extract_dow
-            , subq_5.account_id__ds_partitioned__extract_doy
-            , subq_5.account_id__ds__day
-            , subq_5.account_id__ds__week
-            , subq_5.account_id__ds__month
-            , subq_5.account_id__ds__quarter
-            , subq_5.account_id__ds__year
-            , subq_5.account_id__ds__extract_year
-            , subq_5.account_id__ds__extract_quarter
-            , subq_5.account_id__ds__extract_month
-            , subq_5.account_id__ds__extract_day
-            , subq_5.account_id__ds__extract_dow
-            , subq_5.account_id__ds__extract_doy
-            , subq_5.ds__day AS metric_time__day
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.ds__extract_year AS metric_time__extract_year
-            , subq_5.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_5.ds__extract_month AS metric_time__extract_month
-            , subq_5.ds__extract_day AS metric_time__extract_day
-            , subq_5.ds__extract_dow AS metric_time__extract_dow
-            , subq_5.ds__extract_doy AS metric_time__extract_doy
-            , subq_5.account_id
-            , subq_5.account_month
-            , subq_5.account_id__account_month
-            , subq_5.txn_count
+            subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.account_id__ds_partitioned__day
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds_partitioned__extract_year
+            , subq_0.account_id__ds_partitioned__extract_quarter
+            , subq_0.account_id__ds_partitioned__extract_month
+            , subq_0.account_id__ds_partitioned__extract_day
+            , subq_0.account_id__ds_partitioned__extract_dow
+            , subq_0.account_id__ds_partitioned__extract_doy
+            , subq_0.account_id__ds__day
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.account_id__ds__extract_year
+            , subq_0.account_id__ds__extract_quarter
+            , subq_0.account_id__ds__extract_month
+            , subq_0.account_id__ds__extract_day
+            , subq_0.account_id__ds__extract_dow
+            , subq_0.account_id__ds__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
@@ -140,151 +140,151 @@ FROM (
               , account_month_txns_src_22000.account_month AS account_id__account_month
               , account_month_txns_src_22000.account_id
             FROM ***************************.account_month_txns account_month_txns_src_22000
-          ) subq_5
-        ) subq_6
-      ) subq_7
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements: ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
         SELECT
-          subq_13.ds_partitioned__day
-          , subq_13.account_id
-          , subq_13.customer_id__customer_name
+          subq_8.ds_partitioned__day
+          , subq_8.account_id
+          , subq_8.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_9.ds_partitioned__day AS ds_partitioned__day
-            , subq_9.ds_partitioned__week AS ds_partitioned__week
-            , subq_9.ds_partitioned__month AS ds_partitioned__month
-            , subq_9.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_9.ds_partitioned__year AS ds_partitioned__year
-            , subq_9.ds_partitioned__extract_year AS ds_partitioned__extract_year
-            , subq_9.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-            , subq_9.ds_partitioned__extract_month AS ds_partitioned__extract_month
-            , subq_9.ds_partitioned__extract_day AS ds_partitioned__extract_day
-            , subq_9.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-            , subq_9.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-            , subq_9.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
-            , subq_9.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_9.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_9.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_9.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_9.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
-            , subq_9.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
-            , subq_9.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
-            , subq_9.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
-            , subq_9.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
-            , subq_9.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
-            , subq_9.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
-            , subq_9.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
-            , subq_9.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
-            , subq_9.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
-            , subq_9.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
-            , subq_9.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
-            , subq_9.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
-            , subq_9.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
-            , subq_9.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
-            , subq_9.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
-            , subq_9.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
-            , subq_9.metric_time__month AS metric_time__month
-            , subq_9.metric_time__quarter AS metric_time__quarter
-            , subq_9.metric_time__year AS metric_time__year
-            , subq_9.metric_time__extract_year AS metric_time__extract_year
-            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_9.metric_time__extract_month AS metric_time__extract_month
-            , subq_9.metric_time__extract_day AS metric_time__extract_day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_12.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_12.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_12.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_12.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_12.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_12.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_12.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_12.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_12.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_12.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_12.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_12.metric_time__day AS customer_id__metric_time__day
-            , subq_12.metric_time__week AS customer_id__metric_time__week
-            , subq_12.metric_time__month AS customer_id__metric_time__month
-            , subq_12.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_12.metric_time__year AS customer_id__metric_time__year
-            , subq_12.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_12.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_12.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_12.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_12.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_12.metric_time__extract_doy AS customer_id__metric_time__extract_doy
-            , subq_9.account_id AS account_id
-            , subq_9.customer_id AS customer_id
-            , subq_9.account_id__customer_id AS account_id__customer_id
-            , subq_9.bridge_account__account_id AS bridge_account__account_id
-            , subq_9.bridge_account__customer_id AS bridge_account__customer_id
-            , subq_9.extra_dim AS extra_dim
-            , subq_9.account_id__extra_dim AS account_id__extra_dim
-            , subq_9.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_12.customer_name AS customer_id__customer_name
-            , subq_12.customer_atomic_weight AS customer_id__customer_atomic_weight
-            , subq_9.account_customer_combos AS account_customer_combos
+            subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.account_id__ds_partitioned__day AS account_id__ds_partitioned__day
+            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_4.account_id__ds_partitioned__extract_year AS account_id__ds_partitioned__extract_year
+            , subq_4.account_id__ds_partitioned__extract_quarter AS account_id__ds_partitioned__extract_quarter
+            , subq_4.account_id__ds_partitioned__extract_month AS account_id__ds_partitioned__extract_month
+            , subq_4.account_id__ds_partitioned__extract_day AS account_id__ds_partitioned__extract_day
+            , subq_4.account_id__ds_partitioned__extract_dow AS account_id__ds_partitioned__extract_dow
+            , subq_4.account_id__ds_partitioned__extract_doy AS account_id__ds_partitioned__extract_doy
+            , subq_4.bridge_account__ds_partitioned__day AS bridge_account__ds_partitioned__day
+            , subq_4.bridge_account__ds_partitioned__week AS bridge_account__ds_partitioned__week
+            , subq_4.bridge_account__ds_partitioned__month AS bridge_account__ds_partitioned__month
+            , subq_4.bridge_account__ds_partitioned__quarter AS bridge_account__ds_partitioned__quarter
+            , subq_4.bridge_account__ds_partitioned__year AS bridge_account__ds_partitioned__year
+            , subq_4.bridge_account__ds_partitioned__extract_year AS bridge_account__ds_partitioned__extract_year
+            , subq_4.bridge_account__ds_partitioned__extract_quarter AS bridge_account__ds_partitioned__extract_quarter
+            , subq_4.bridge_account__ds_partitioned__extract_month AS bridge_account__ds_partitioned__extract_month
+            , subq_4.bridge_account__ds_partitioned__extract_day AS bridge_account__ds_partitioned__extract_day
+            , subq_4.bridge_account__ds_partitioned__extract_dow AS bridge_account__ds_partitioned__extract_dow
+            , subq_4.bridge_account__ds_partitioned__extract_doy AS bridge_account__ds_partitioned__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.account_id AS account_id
+            , subq_4.customer_id AS customer_id
+            , subq_4.account_id__customer_id AS account_id__customer_id
+            , subq_4.bridge_account__account_id AS bridge_account__account_id
+            , subq_4.bridge_account__customer_id AS bridge_account__customer_id
+            , subq_4.extra_dim AS extra_dim
+            , subq_4.account_id__extra_dim AS account_id__extra_dim
+            , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
+            , subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'
             SELECT
-              subq_8.ds_partitioned__day
-              , subq_8.ds_partitioned__week
-              , subq_8.ds_partitioned__month
-              , subq_8.ds_partitioned__quarter
-              , subq_8.ds_partitioned__year
-              , subq_8.ds_partitioned__extract_year
-              , subq_8.ds_partitioned__extract_quarter
-              , subq_8.ds_partitioned__extract_month
-              , subq_8.ds_partitioned__extract_day
-              , subq_8.ds_partitioned__extract_dow
-              , subq_8.ds_partitioned__extract_doy
-              , subq_8.account_id__ds_partitioned__day
-              , subq_8.account_id__ds_partitioned__week
-              , subq_8.account_id__ds_partitioned__month
-              , subq_8.account_id__ds_partitioned__quarter
-              , subq_8.account_id__ds_partitioned__year
-              , subq_8.account_id__ds_partitioned__extract_year
-              , subq_8.account_id__ds_partitioned__extract_quarter
-              , subq_8.account_id__ds_partitioned__extract_month
-              , subq_8.account_id__ds_partitioned__extract_day
-              , subq_8.account_id__ds_partitioned__extract_dow
-              , subq_8.account_id__ds_partitioned__extract_doy
-              , subq_8.bridge_account__ds_partitioned__day
-              , subq_8.bridge_account__ds_partitioned__week
-              , subq_8.bridge_account__ds_partitioned__month
-              , subq_8.bridge_account__ds_partitioned__quarter
-              , subq_8.bridge_account__ds_partitioned__year
-              , subq_8.bridge_account__ds_partitioned__extract_year
-              , subq_8.bridge_account__ds_partitioned__extract_quarter
-              , subq_8.bridge_account__ds_partitioned__extract_month
-              , subq_8.bridge_account__ds_partitioned__extract_day
-              , subq_8.bridge_account__ds_partitioned__extract_dow
-              , subq_8.bridge_account__ds_partitioned__extract_doy
-              , subq_8.ds_partitioned__day AS metric_time__day
-              , subq_8.ds_partitioned__week AS metric_time__week
-              , subq_8.ds_partitioned__month AS metric_time__month
-              , subq_8.ds_partitioned__quarter AS metric_time__quarter
-              , subq_8.ds_partitioned__year AS metric_time__year
-              , subq_8.ds_partitioned__extract_year AS metric_time__extract_year
-              , subq_8.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-              , subq_8.ds_partitioned__extract_month AS metric_time__extract_month
-              , subq_8.ds_partitioned__extract_day AS metric_time__extract_day
-              , subq_8.ds_partitioned__extract_dow AS metric_time__extract_dow
-              , subq_8.ds_partitioned__extract_doy AS metric_time__extract_doy
-              , subq_8.account_id
-              , subq_8.customer_id
-              , subq_8.account_id__customer_id
-              , subq_8.bridge_account__account_id
-              , subq_8.bridge_account__customer_id
-              , subq_8.extra_dim
-              , subq_8.account_id__extra_dim
-              , subq_8.bridge_account__extra_dim
-              , subq_8.account_customer_combos
+              subq_3.ds_partitioned__day
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.ds_partitioned__extract_year
+              , subq_3.ds_partitioned__extract_quarter
+              , subq_3.ds_partitioned__extract_month
+              , subq_3.ds_partitioned__extract_day
+              , subq_3.ds_partitioned__extract_dow
+              , subq_3.ds_partitioned__extract_doy
+              , subq_3.account_id__ds_partitioned__day
+              , subq_3.account_id__ds_partitioned__week
+              , subq_3.account_id__ds_partitioned__month
+              , subq_3.account_id__ds_partitioned__quarter
+              , subq_3.account_id__ds_partitioned__year
+              , subq_3.account_id__ds_partitioned__extract_year
+              , subq_3.account_id__ds_partitioned__extract_quarter
+              , subq_3.account_id__ds_partitioned__extract_month
+              , subq_3.account_id__ds_partitioned__extract_day
+              , subq_3.account_id__ds_partitioned__extract_dow
+              , subq_3.account_id__ds_partitioned__extract_doy
+              , subq_3.bridge_account__ds_partitioned__day
+              , subq_3.bridge_account__ds_partitioned__week
+              , subq_3.bridge_account__ds_partitioned__month
+              , subq_3.bridge_account__ds_partitioned__quarter
+              , subq_3.bridge_account__ds_partitioned__year
+              , subq_3.bridge_account__ds_partitioned__extract_year
+              , subq_3.bridge_account__ds_partitioned__extract_quarter
+              , subq_3.bridge_account__ds_partitioned__extract_month
+              , subq_3.bridge_account__ds_partitioned__extract_day
+              , subq_3.bridge_account__ds_partitioned__extract_dow
+              , subq_3.bridge_account__ds_partitioned__extract_doy
+              , subq_3.ds_partitioned__day AS metric_time__day
+              , subq_3.ds_partitioned__week AS metric_time__week
+              , subq_3.ds_partitioned__month AS metric_time__month
+              , subq_3.ds_partitioned__quarter AS metric_time__quarter
+              , subq_3.ds_partitioned__year AS metric_time__year
+              , subq_3.ds_partitioned__extract_year AS metric_time__extract_year
+              , subq_3.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+              , subq_3.ds_partitioned__extract_month AS metric_time__extract_month
+              , subq_3.ds_partitioned__extract_day AS metric_time__extract_day
+              , subq_3.ds_partitioned__extract_dow AS metric_time__extract_dow
+              , subq_3.ds_partitioned__extract_doy AS metric_time__extract_doy
+              , subq_3.account_id
+              , subq_3.customer_id
+              , subq_3.account_id__customer_id
+              , subq_3.bridge_account__account_id
+              , subq_3.bridge_account__customer_id
+              , subq_3.extra_dim
+              , subq_3.account_id__extra_dim
+              , subq_3.bridge_account__extra_dim
+              , subq_3.account_customer_combos
             FROM (
               -- Read Elements From Semantic Model 'bridge_table'
               SELECT
@@ -331,8 +331,8 @@ FROM (
                 , bridge_table_src_22000.account_id AS bridge_account__account_id
                 , bridge_table_src_22000.customer_id AS bridge_account__customer_id
               FROM ***************************.bridge_table bridge_table_src_22000
-            ) subq_8
-          ) subq_9
+            ) subq_3
+          ) subq_4
           LEFT OUTER JOIN (
             -- Pass Only Elements: [
             --   'customer_name',
@@ -375,86 +375,86 @@ FROM (
             --   'customer_id',
             -- ]
             SELECT
-              subq_11.ds_partitioned__day
-              , subq_11.ds_partitioned__week
-              , subq_11.ds_partitioned__month
-              , subq_11.ds_partitioned__quarter
-              , subq_11.ds_partitioned__year
-              , subq_11.ds_partitioned__extract_year
-              , subq_11.ds_partitioned__extract_quarter
-              , subq_11.ds_partitioned__extract_month
-              , subq_11.ds_partitioned__extract_day
-              , subq_11.ds_partitioned__extract_dow
-              , subq_11.ds_partitioned__extract_doy
-              , subq_11.customer_id__ds_partitioned__day
-              , subq_11.customer_id__ds_partitioned__week
-              , subq_11.customer_id__ds_partitioned__month
-              , subq_11.customer_id__ds_partitioned__quarter
-              , subq_11.customer_id__ds_partitioned__year
-              , subq_11.customer_id__ds_partitioned__extract_year
-              , subq_11.customer_id__ds_partitioned__extract_quarter
-              , subq_11.customer_id__ds_partitioned__extract_month
-              , subq_11.customer_id__ds_partitioned__extract_day
-              , subq_11.customer_id__ds_partitioned__extract_dow
-              , subq_11.customer_id__ds_partitioned__extract_doy
-              , subq_11.metric_time__day
-              , subq_11.metric_time__week
-              , subq_11.metric_time__month
-              , subq_11.metric_time__quarter
-              , subq_11.metric_time__year
-              , subq_11.metric_time__extract_year
-              , subq_11.metric_time__extract_quarter
-              , subq_11.metric_time__extract_month
-              , subq_11.metric_time__extract_day
-              , subq_11.metric_time__extract_dow
-              , subq_11.metric_time__extract_doy
-              , subq_11.customer_id
-              , subq_11.customer_name
-              , subq_11.customer_atomic_weight
-              , subq_11.customer_id__customer_name
-              , subq_11.customer_id__customer_atomic_weight
+              subq_6.ds_partitioned__day
+              , subq_6.ds_partitioned__week
+              , subq_6.ds_partitioned__month
+              , subq_6.ds_partitioned__quarter
+              , subq_6.ds_partitioned__year
+              , subq_6.ds_partitioned__extract_year
+              , subq_6.ds_partitioned__extract_quarter
+              , subq_6.ds_partitioned__extract_month
+              , subq_6.ds_partitioned__extract_day
+              , subq_6.ds_partitioned__extract_dow
+              , subq_6.ds_partitioned__extract_doy
+              , subq_6.customer_id__ds_partitioned__day
+              , subq_6.customer_id__ds_partitioned__week
+              , subq_6.customer_id__ds_partitioned__month
+              , subq_6.customer_id__ds_partitioned__quarter
+              , subq_6.customer_id__ds_partitioned__year
+              , subq_6.customer_id__ds_partitioned__extract_year
+              , subq_6.customer_id__ds_partitioned__extract_quarter
+              , subq_6.customer_id__ds_partitioned__extract_month
+              , subq_6.customer_id__ds_partitioned__extract_day
+              , subq_6.customer_id__ds_partitioned__extract_dow
+              , subq_6.customer_id__ds_partitioned__extract_doy
+              , subq_6.metric_time__day
+              , subq_6.metric_time__week
+              , subq_6.metric_time__month
+              , subq_6.metric_time__quarter
+              , subq_6.metric_time__year
+              , subq_6.metric_time__extract_year
+              , subq_6.metric_time__extract_quarter
+              , subq_6.metric_time__extract_month
+              , subq_6.metric_time__extract_day
+              , subq_6.metric_time__extract_dow
+              , subq_6.metric_time__extract_doy
+              , subq_6.customer_id
+              , subq_6.customer_name
+              , subq_6.customer_atomic_weight
+              , subq_6.customer_id__customer_name
+              , subq_6.customer_id__customer_atomic_weight
             FROM (
               -- Metric Time Dimension 'ds_partitioned'
               SELECT
-                subq_10.ds_partitioned__day
-                , subq_10.ds_partitioned__week
-                , subq_10.ds_partitioned__month
-                , subq_10.ds_partitioned__quarter
-                , subq_10.ds_partitioned__year
-                , subq_10.ds_partitioned__extract_year
-                , subq_10.ds_partitioned__extract_quarter
-                , subq_10.ds_partitioned__extract_month
-                , subq_10.ds_partitioned__extract_day
-                , subq_10.ds_partitioned__extract_dow
-                , subq_10.ds_partitioned__extract_doy
-                , subq_10.customer_id__ds_partitioned__day
-                , subq_10.customer_id__ds_partitioned__week
-                , subq_10.customer_id__ds_partitioned__month
-                , subq_10.customer_id__ds_partitioned__quarter
-                , subq_10.customer_id__ds_partitioned__year
-                , subq_10.customer_id__ds_partitioned__extract_year
-                , subq_10.customer_id__ds_partitioned__extract_quarter
-                , subq_10.customer_id__ds_partitioned__extract_month
-                , subq_10.customer_id__ds_partitioned__extract_day
-                , subq_10.customer_id__ds_partitioned__extract_dow
-                , subq_10.customer_id__ds_partitioned__extract_doy
-                , subq_10.ds_partitioned__day AS metric_time__day
-                , subq_10.ds_partitioned__week AS metric_time__week
-                , subq_10.ds_partitioned__month AS metric_time__month
-                , subq_10.ds_partitioned__quarter AS metric_time__quarter
-                , subq_10.ds_partitioned__year AS metric_time__year
-                , subq_10.ds_partitioned__extract_year AS metric_time__extract_year
-                , subq_10.ds_partitioned__extract_quarter AS metric_time__extract_quarter
-                , subq_10.ds_partitioned__extract_month AS metric_time__extract_month
-                , subq_10.ds_partitioned__extract_day AS metric_time__extract_day
-                , subq_10.ds_partitioned__extract_dow AS metric_time__extract_dow
-                , subq_10.ds_partitioned__extract_doy AS metric_time__extract_doy
-                , subq_10.customer_id
-                , subq_10.customer_name
-                , subq_10.customer_atomic_weight
-                , subq_10.customer_id__customer_name
-                , subq_10.customer_id__customer_atomic_weight
-                , subq_10.customers
+                subq_5.ds_partitioned__day
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.ds_partitioned__extract_year
+                , subq_5.ds_partitioned__extract_quarter
+                , subq_5.ds_partitioned__extract_month
+                , subq_5.ds_partitioned__extract_day
+                , subq_5.ds_partitioned__extract_dow
+                , subq_5.ds_partitioned__extract_doy
+                , subq_5.customer_id__ds_partitioned__day
+                , subq_5.customer_id__ds_partitioned__week
+                , subq_5.customer_id__ds_partitioned__month
+                , subq_5.customer_id__ds_partitioned__quarter
+                , subq_5.customer_id__ds_partitioned__year
+                , subq_5.customer_id__ds_partitioned__extract_year
+                , subq_5.customer_id__ds_partitioned__extract_quarter
+                , subq_5.customer_id__ds_partitioned__extract_month
+                , subq_5.customer_id__ds_partitioned__extract_day
+                , subq_5.customer_id__ds_partitioned__extract_dow
+                , subq_5.customer_id__ds_partitioned__extract_doy
+                , subq_5.ds_partitioned__day AS metric_time__day
+                , subq_5.ds_partitioned__week AS metric_time__week
+                , subq_5.ds_partitioned__month AS metric_time__month
+                , subq_5.ds_partitioned__quarter AS metric_time__quarter
+                , subq_5.ds_partitioned__year AS metric_time__year
+                , subq_5.ds_partitioned__extract_year AS metric_time__extract_year
+                , subq_5.ds_partitioned__extract_quarter AS metric_time__extract_quarter
+                , subq_5.ds_partitioned__extract_month AS metric_time__extract_month
+                , subq_5.ds_partitioned__extract_day AS metric_time__extract_day
+                , subq_5.ds_partitioned__extract_dow AS metric_time__extract_dow
+                , subq_5.ds_partitioned__extract_doy AS metric_time__extract_doy
+                , subq_5.customer_id
+                , subq_5.customer_name
+                , subq_5.customer_atomic_weight
+                , subq_5.customer_id__customer_name
+                , subq_5.customer_id__customer_atomic_weight
+                , subq_5.customers
               FROM (
                 -- Read Elements From Semantic Model 'customer_table'
                 SELECT
@@ -487,25 +487,25 @@ FROM (
                   , EXTRACT(doy FROM customer_table_src_22000.ds_partitioned) AS customer_id__ds_partitioned__extract_doy
                   , customer_table_src_22000.customer_id
                 FROM ***************************.customer_table customer_table_src_22000
-              ) subq_10
-            ) subq_11
-          ) subq_12
+              ) subq_5
+            ) subq_6
+          ) subq_7
           ON
             (
-              subq_9.customer_id = subq_12.customer_id
+              subq_4.customer_id = subq_7.customer_id
             ) AND (
-              subq_9.ds_partitioned__day = subq_12.ds_partitioned__day
+              subq_4.ds_partitioned__day = subq_7.ds_partitioned__day
             )
-        ) subq_13
-      ) subq_14
+        ) subq_8
+      ) subq_9
       ON
         (
-          subq_7.account_id = subq_14.account_id
+          subq_2.account_id = subq_9.account_id
         ) AND (
-          subq_7.ds_partitioned__day = subq_14.ds_partitioned__day
+          subq_2.ds_partitioned__day = subq_9.ds_partitioned__day
         )
-    ) subq_15
-  ) subq_16
+    ) subq_10
+  ) subq_11
   GROUP BY
-    subq_16.account_id__customer_id__customer_name
-) subq_17
+    subq_11.account_id__customer_id__customer_name
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_22.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_32
+) subq_22
 ON
   (
-    account_month_txns_src_22000.account_id = subq_32.account_id
+    account_month_txns_src_22000.account_id = subq_22.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_22.ds_partitioned__day
   )
 GROUP BY
-  subq_32.customer_id__customer_name
+  subq_22.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,221 +1,221 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_9.bookings) AS bookings
-  , MAX(subq_15.listings) AS listings
+  MAX(subq_5.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_8.bookings
+    subq_4.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_7.bookings) AS bookings
+      SUM(subq_3.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings',]
       SELECT
-        subq_6.bookings
+        subq_2.bookings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_5.ds__day
-          , subq_5.ds__week
-          , subq_5.ds__month
-          , subq_5.ds__quarter
-          , subq_5.ds__year
-          , subq_5.ds__extract_year
-          , subq_5.ds__extract_quarter
-          , subq_5.ds__extract_month
-          , subq_5.ds__extract_day
-          , subq_5.ds__extract_dow
-          , subq_5.ds__extract_doy
-          , subq_5.ds_partitioned__day
-          , subq_5.ds_partitioned__week
-          , subq_5.ds_partitioned__month
-          , subq_5.ds_partitioned__quarter
-          , subq_5.ds_partitioned__year
-          , subq_5.ds_partitioned__extract_year
-          , subq_5.ds_partitioned__extract_quarter
-          , subq_5.ds_partitioned__extract_month
-          , subq_5.ds_partitioned__extract_day
-          , subq_5.ds_partitioned__extract_dow
-          , subq_5.ds_partitioned__extract_doy
-          , subq_5.paid_at__day
-          , subq_5.paid_at__week
-          , subq_5.paid_at__month
-          , subq_5.paid_at__quarter
-          , subq_5.paid_at__year
-          , subq_5.paid_at__extract_year
-          , subq_5.paid_at__extract_quarter
-          , subq_5.paid_at__extract_month
-          , subq_5.paid_at__extract_day
-          , subq_5.paid_at__extract_dow
-          , subq_5.paid_at__extract_doy
-          , subq_5.booking__ds__day
-          , subq_5.booking__ds__week
-          , subq_5.booking__ds__month
-          , subq_5.booking__ds__quarter
-          , subq_5.booking__ds__year
-          , subq_5.booking__ds__extract_year
-          , subq_5.booking__ds__extract_quarter
-          , subq_5.booking__ds__extract_month
-          , subq_5.booking__ds__extract_day
-          , subq_5.booking__ds__extract_dow
-          , subq_5.booking__ds__extract_doy
-          , subq_5.booking__ds_partitioned__day
-          , subq_5.booking__ds_partitioned__week
-          , subq_5.booking__ds_partitioned__month
-          , subq_5.booking__ds_partitioned__quarter
-          , subq_5.booking__ds_partitioned__year
-          , subq_5.booking__ds_partitioned__extract_year
-          , subq_5.booking__ds_partitioned__extract_quarter
-          , subq_5.booking__ds_partitioned__extract_month
-          , subq_5.booking__ds_partitioned__extract_day
-          , subq_5.booking__ds_partitioned__extract_dow
-          , subq_5.booking__ds_partitioned__extract_doy
-          , subq_5.booking__paid_at__day
-          , subq_5.booking__paid_at__week
-          , subq_5.booking__paid_at__month
-          , subq_5.booking__paid_at__quarter
-          , subq_5.booking__paid_at__year
-          , subq_5.booking__paid_at__extract_year
-          , subq_5.booking__paid_at__extract_quarter
-          , subq_5.booking__paid_at__extract_month
-          , subq_5.booking__paid_at__extract_day
-          , subq_5.booking__paid_at__extract_dow
-          , subq_5.booking__paid_at__extract_doy
-          , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
-          , subq_5.listing
-          , subq_5.guest
-          , subq_5.host
-          , subq_5.booking__listing
-          , subq_5.booking__guest
-          , subq_5.booking__host
-          , subq_5.is_instant
-          , subq_5.booking__is_instant
-          , subq_5.bookings
-          , subq_5.instant_bookings
-          , subq_5.booking_value
-          , subq_5.max_booking_value
-          , subq_5.min_booking_value
-          , subq_5.bookers
-          , subq_5.average_booking_value
-          , subq_5.referred_bookings
-          , subq_5.median_booking_value
-          , subq_5.booking_value_p99
-          , subq_5.discrete_booking_value_p99
-          , subq_5.approximate_continuous_booking_value_p99
-          , subq_5.approximate_discrete_booking_value_p99
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds_partitioned__day
+          , subq_1.ds_partitioned__week
+          , subq_1.ds_partitioned__month
+          , subq_1.ds_partitioned__quarter
+          , subq_1.ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy
+          , subq_1.paid_at__day
+          , subq_1.paid_at__week
+          , subq_1.paid_at__month
+          , subq_1.paid_at__quarter
+          , subq_1.paid_at__year
+          , subq_1.paid_at__extract_year
+          , subq_1.paid_at__extract_quarter
+          , subq_1.paid_at__extract_month
+          , subq_1.paid_at__extract_day
+          , subq_1.paid_at__extract_dow
+          , subq_1.paid_at__extract_doy
+          , subq_1.booking__ds__day
+          , subq_1.booking__ds__week
+          , subq_1.booking__ds__month
+          , subq_1.booking__ds__quarter
+          , subq_1.booking__ds__year
+          , subq_1.booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month
+          , subq_1.booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day
+          , subq_1.booking__paid_at__week
+          , subq_1.booking__paid_at__month
+          , subq_1.booking__paid_at__quarter
+          , subq_1.booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy
+          , subq_1.metric_time__day
+          , subq_1.metric_time__week
+          , subq_1.metric_time__month
+          , subq_1.metric_time__quarter
+          , subq_1.metric_time__year
+          , subq_1.metric_time__extract_year
+          , subq_1.metric_time__extract_quarter
+          , subq_1.metric_time__extract_month
+          , subq_1.metric_time__extract_day
+          , subq_1.metric_time__extract_dow
+          , subq_1.metric_time__extract_doy
+          , subq_1.listing
+          , subq_1.guest
+          , subq_1.host
+          , subq_1.booking__listing
+          , subq_1.booking__guest
+          , subq_1.booking__host
+          , subq_1.is_instant
+          , subq_1.booking__is_instant
+          , subq_1.bookings
+          , subq_1.instant_bookings
+          , subq_1.booking_value
+          , subq_1.max_booking_value
+          , subq_1.min_booking_value
+          , subq_1.bookers
+          , subq_1.average_booking_value
+          , subq_1.referred_bookings
+          , subq_1.median_booking_value
+          , subq_1.booking_value_p99
+          , subq_1.discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds__day
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds__extract_year
-            , subq_4.ds__extract_quarter
-            , subq_4.ds__extract_month
-            , subq_4.ds__extract_day
-            , subq_4.ds__extract_dow
-            , subq_4.ds__extract_doy
-            , subq_4.ds_partitioned__day
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.ds_partitioned__extract_year
-            , subq_4.ds_partitioned__extract_quarter
-            , subq_4.ds_partitioned__extract_month
-            , subq_4.ds_partitioned__extract_day
-            , subq_4.ds_partitioned__extract_dow
-            , subq_4.ds_partitioned__extract_doy
-            , subq_4.paid_at__day
-            , subq_4.paid_at__week
-            , subq_4.paid_at__month
-            , subq_4.paid_at__quarter
-            , subq_4.paid_at__year
-            , subq_4.paid_at__extract_year
-            , subq_4.paid_at__extract_quarter
-            , subq_4.paid_at__extract_month
-            , subq_4.paid_at__extract_day
-            , subq_4.paid_at__extract_dow
-            , subq_4.paid_at__extract_doy
-            , subq_4.booking__ds__day
-            , subq_4.booking__ds__week
-            , subq_4.booking__ds__month
-            , subq_4.booking__ds__quarter
-            , subq_4.booking__ds__year
-            , subq_4.booking__ds__extract_year
-            , subq_4.booking__ds__extract_quarter
-            , subq_4.booking__ds__extract_month
-            , subq_4.booking__ds__extract_day
-            , subq_4.booking__ds__extract_dow
-            , subq_4.booking__ds__extract_doy
-            , subq_4.booking__ds_partitioned__day
-            , subq_4.booking__ds_partitioned__week
-            , subq_4.booking__ds_partitioned__month
-            , subq_4.booking__ds_partitioned__quarter
-            , subq_4.booking__ds_partitioned__year
-            , subq_4.booking__ds_partitioned__extract_year
-            , subq_4.booking__ds_partitioned__extract_quarter
-            , subq_4.booking__ds_partitioned__extract_month
-            , subq_4.booking__ds_partitioned__extract_day
-            , subq_4.booking__ds_partitioned__extract_dow
-            , subq_4.booking__ds_partitioned__extract_doy
-            , subq_4.booking__paid_at__day
-            , subq_4.booking__paid_at__week
-            , subq_4.booking__paid_at__month
-            , subq_4.booking__paid_at__quarter
-            , subq_4.booking__paid_at__year
-            , subq_4.booking__paid_at__extract_year
-            , subq_4.booking__paid_at__extract_quarter
-            , subq_4.booking__paid_at__extract_month
-            , subq_4.booking__paid_at__extract_day
-            , subq_4.booking__paid_at__extract_dow
-            , subq_4.booking__paid_at__extract_doy
-            , subq_4.ds__day AS metric_time__day
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.ds__extract_year AS metric_time__extract_year
-            , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_4.ds__extract_month AS metric_time__extract_month
-            , subq_4.ds__extract_day AS metric_time__extract_day
-            , subq_4.ds__extract_dow AS metric_time__extract_dow
-            , subq_4.ds__extract_doy AS metric_time__extract_doy
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.booking__listing
-            , subq_4.booking__guest
-            , subq_4.booking__host
-            , subq_4.is_instant
-            , subq_4.booking__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
-            , subq_4.median_booking_value
-            , subq_4.booking_value_p99
-            , subq_4.discrete_booking_value_p99
-            , subq_4.approximate_continuous_booking_value_p99
-            , subq_4.approximate_discrete_booking_value_p99
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -308,165 +308,165 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_4
-        ) subq_5
-        WHERE subq_5.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_0
+        ) subq_1
+        WHERE subq_1.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+      ) subq_2
+    ) subq_3
+  ) subq_4
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_14.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_13.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements: ['listings',]
       SELECT
-        subq_12.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_11.ds__day
-          , subq_11.ds__week
-          , subq_11.ds__month
-          , subq_11.ds__quarter
-          , subq_11.ds__year
-          , subq_11.ds__extract_year
-          , subq_11.ds__extract_quarter
-          , subq_11.ds__extract_month
-          , subq_11.ds__extract_day
-          , subq_11.ds__extract_dow
-          , subq_11.ds__extract_doy
-          , subq_11.created_at__day
-          , subq_11.created_at__week
-          , subq_11.created_at__month
-          , subq_11.created_at__quarter
-          , subq_11.created_at__year
-          , subq_11.created_at__extract_year
-          , subq_11.created_at__extract_quarter
-          , subq_11.created_at__extract_month
-          , subq_11.created_at__extract_day
-          , subq_11.created_at__extract_dow
-          , subq_11.created_at__extract_doy
-          , subq_11.listing__ds__day
-          , subq_11.listing__ds__week
-          , subq_11.listing__ds__month
-          , subq_11.listing__ds__quarter
-          , subq_11.listing__ds__year
-          , subq_11.listing__ds__extract_year
-          , subq_11.listing__ds__extract_quarter
-          , subq_11.listing__ds__extract_month
-          , subq_11.listing__ds__extract_day
-          , subq_11.listing__ds__extract_dow
-          , subq_11.listing__ds__extract_doy
-          , subq_11.listing__created_at__day
-          , subq_11.listing__created_at__week
-          , subq_11.listing__created_at__month
-          , subq_11.listing__created_at__quarter
-          , subq_11.listing__created_at__year
-          , subq_11.listing__created_at__extract_year
-          , subq_11.listing__created_at__extract_quarter
-          , subq_11.listing__created_at__extract_month
-          , subq_11.listing__created_at__extract_day
-          , subq_11.listing__created_at__extract_dow
-          , subq_11.listing__created_at__extract_doy
-          , subq_11.metric_time__day
-          , subq_11.metric_time__week
-          , subq_11.metric_time__month
-          , subq_11.metric_time__quarter
-          , subq_11.metric_time__year
-          , subq_11.metric_time__extract_year
-          , subq_11.metric_time__extract_quarter
-          , subq_11.metric_time__extract_month
-          , subq_11.metric_time__extract_day
-          , subq_11.metric_time__extract_dow
-          , subq_11.metric_time__extract_doy
-          , subq_11.listing
-          , subq_11.user
-          , subq_11.listing__user
-          , subq_11.country_latest
-          , subq_11.is_lux_latest
-          , subq_11.capacity_latest
-          , subq_11.listing__country_latest
-          , subq_11.listing__is_lux_latest
-          , subq_11.listing__capacity_latest
-          , subq_11.listings
-          , subq_11.largest_listing
-          , subq_11.smallest_listing
+          subq_7.ds__day
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.ds__extract_year
+          , subq_7.ds__extract_quarter
+          , subq_7.ds__extract_month
+          , subq_7.ds__extract_day
+          , subq_7.ds__extract_dow
+          , subq_7.ds__extract_doy
+          , subq_7.created_at__day
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.created_at__extract_year
+          , subq_7.created_at__extract_quarter
+          , subq_7.created_at__extract_month
+          , subq_7.created_at__extract_day
+          , subq_7.created_at__extract_dow
+          , subq_7.created_at__extract_doy
+          , subq_7.listing__ds__day
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__ds__extract_year
+          , subq_7.listing__ds__extract_quarter
+          , subq_7.listing__ds__extract_month
+          , subq_7.listing__ds__extract_day
+          , subq_7.listing__ds__extract_dow
+          , subq_7.listing__ds__extract_doy
+          , subq_7.listing__created_at__day
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.listing__created_at__extract_year
+          , subq_7.listing__created_at__extract_quarter
+          , subq_7.listing__created_at__extract_month
+          , subq_7.listing__created_at__extract_day
+          , subq_7.listing__created_at__extract_dow
+          , subq_7.listing__created_at__extract_doy
+          , subq_7.metric_time__day
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_10.ds__day
-            , subq_10.ds__week
-            , subq_10.ds__month
-            , subq_10.ds__quarter
-            , subq_10.ds__year
-            , subq_10.ds__extract_year
-            , subq_10.ds__extract_quarter
-            , subq_10.ds__extract_month
-            , subq_10.ds__extract_day
-            , subq_10.ds__extract_dow
-            , subq_10.ds__extract_doy
-            , subq_10.created_at__day
-            , subq_10.created_at__week
-            , subq_10.created_at__month
-            , subq_10.created_at__quarter
-            , subq_10.created_at__year
-            , subq_10.created_at__extract_year
-            , subq_10.created_at__extract_quarter
-            , subq_10.created_at__extract_month
-            , subq_10.created_at__extract_day
-            , subq_10.created_at__extract_dow
-            , subq_10.created_at__extract_doy
-            , subq_10.listing__ds__day
-            , subq_10.listing__ds__week
-            , subq_10.listing__ds__month
-            , subq_10.listing__ds__quarter
-            , subq_10.listing__ds__year
-            , subq_10.listing__ds__extract_year
-            , subq_10.listing__ds__extract_quarter
-            , subq_10.listing__ds__extract_month
-            , subq_10.listing__ds__extract_day
-            , subq_10.listing__ds__extract_dow
-            , subq_10.listing__ds__extract_doy
-            , subq_10.listing__created_at__day
-            , subq_10.listing__created_at__week
-            , subq_10.listing__created_at__month
-            , subq_10.listing__created_at__quarter
-            , subq_10.listing__created_at__year
-            , subq_10.listing__created_at__extract_year
-            , subq_10.listing__created_at__extract_quarter
-            , subq_10.listing__created_at__extract_month
-            , subq_10.listing__created_at__extract_day
-            , subq_10.listing__created_at__extract_dow
-            , subq_10.listing__created_at__extract_doy
-            , subq_10.ds__day AS metric_time__day
-            , subq_10.ds__week AS metric_time__week
-            , subq_10.ds__month AS metric_time__month
-            , subq_10.ds__quarter AS metric_time__quarter
-            , subq_10.ds__year AS metric_time__year
-            , subq_10.ds__extract_year AS metric_time__extract_year
-            , subq_10.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_10.ds__extract_month AS metric_time__extract_month
-            , subq_10.ds__extract_day AS metric_time__extract_day
-            , subq_10.ds__extract_dow AS metric_time__extract_dow
-            , subq_10.ds__extract_doy AS metric_time__extract_doy
-            , subq_10.listing
-            , subq_10.user
-            , subq_10.listing__user
-            , subq_10.country_latest
-            , subq_10.is_lux_latest
-            , subq_10.capacity_latest
-            , subq_10.listing__country_latest
-            , subq_10.listing__is_lux_latest
-            , subq_10.listing__capacity_latest
-            , subq_10.listings
-            , subq_10.largest_listing
-            , subq_10.smallest_listing
+            subq_6.ds__day
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds__extract_year
+            , subq_6.ds__extract_quarter
+            , subq_6.ds__extract_month
+            , subq_6.ds__extract_day
+            , subq_6.ds__extract_dow
+            , subq_6.ds__extract_doy
+            , subq_6.created_at__day
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.created_at__extract_year
+            , subq_6.created_at__extract_quarter
+            , subq_6.created_at__extract_month
+            , subq_6.created_at__extract_day
+            , subq_6.created_at__extract_dow
+            , subq_6.created_at__extract_doy
+            , subq_6.listing__ds__day
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__ds__extract_year
+            , subq_6.listing__ds__extract_quarter
+            , subq_6.listing__ds__extract_month
+            , subq_6.listing__ds__extract_day
+            , subq_6.listing__ds__extract_dow
+            , subq_6.listing__ds__extract_doy
+            , subq_6.listing__created_at__day
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.listing__created_at__extract_year
+            , subq_6.listing__created_at__extract_quarter
+            , subq_6.listing__created_at__extract_month
+            , subq_6.listing__created_at__extract_day
+            , subq_6.listing__created_at__extract_dow
+            , subq_6.listing__created_at__extract_doy
+            , subq_6.ds__day AS metric_time__day
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.ds__extract_year AS metric_time__extract_year
+            , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_6.ds__extract_month AS metric_time__extract_month
+            , subq_6.ds__extract_day AS metric_time__extract_day
+            , subq_6.ds__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__extract_doy AS metric_time__extract_doy
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -527,10 +527,10 @@ CROSS JOIN (
               , listings_latest_src_28000.user_id AS user
               , listings_latest_src_28000.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_28000
-          ) subq_10
-        ) subq_11
-        WHERE subq_11.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-      ) subq_12
-    ) subq_13
-  ) subq_14
-) subq_15
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+      ) subq_8
+    ) subq_9
+  ) subq_10
+) subq_11

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_25.bookings) AS bookings
-  , MAX(subq_31.listings) AS listings
+  MAX(subq_17.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-) subq_25
+) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-) subq_31
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_9.metric_time__day
-    , subq_9.bookings
+    subq_7.metric_time__day
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_7.metric_time__day AS metric_time__day
-      , subq_6.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_8.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_8
-      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_7
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+      WHERE subq_6.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.bookings) AS bookings
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.bookings
+          subq_2.metric_time__day
+          , subq_2.bookings
         FROM (
           -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.max_booking_value
-            , subq_3.min_booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
-            , subq_3.referred_bookings
-            , subq_3.median_booking_value
-            , subq_3.booking_value_p99
-            , subq_3.discrete_booking_value_p99
-            , subq_3.approximate_continuous_booking_value_p99
-            , subq_3.approximate_discrete_booking_value_p99
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.ds_partitioned__day
+            , subq_1.ds_partitioned__week
+            , subq_1.ds_partitioned__month
+            , subq_1.ds_partitioned__quarter
+            , subq_1.ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy
+            , subq_1.paid_at__day
+            , subq_1.paid_at__week
+            , subq_1.paid_at__month
+            , subq_1.paid_at__quarter
+            , subq_1.paid_at__year
+            , subq_1.paid_at__extract_year
+            , subq_1.paid_at__extract_quarter
+            , subq_1.paid_at__extract_month
+            , subq_1.paid_at__extract_day
+            , subq_1.paid_at__extract_dow
+            , subq_1.paid_at__extract_doy
+            , subq_1.booking__ds__day
+            , subq_1.booking__ds__week
+            , subq_1.booking__ds__month
+            , subq_1.booking__ds__quarter
+            , subq_1.booking__ds__year
+            , subq_1.booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month
+            , subq_1.booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day
+            , subq_1.booking__paid_at__week
+            , subq_1.booking__paid_at__month
+            , subq_1.booking__paid_at__quarter
+            , subq_1.booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.listing
+            , subq_1.guest
+            , subq_1.host
+            , subq_1.booking__listing
+            , subq_1.booking__guest
+            , subq_1.booking__host
+            , subq_1.is_instant
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+            , subq_1.instant_bookings
+            , subq_1.booking_value
+            , subq_1.max_booking_value
+            , subq_1.min_booking_value
+            , subq_1.bookers
+            , subq_1.average_booking_value
+            , subq_1.referred_bookings
+            , subq_1.median_booking_value
+            , subq_1.booking_value_p99
+            , subq_1.discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.ds_partitioned__day
-              , subq_2.ds_partitioned__week
-              , subq_2.ds_partitioned__month
-              , subq_2.ds_partitioned__quarter
-              , subq_2.ds_partitioned__year
-              , subq_2.ds_partitioned__extract_year
-              , subq_2.ds_partitioned__extract_quarter
-              , subq_2.ds_partitioned__extract_month
-              , subq_2.ds_partitioned__extract_day
-              , subq_2.ds_partitioned__extract_dow
-              , subq_2.ds_partitioned__extract_doy
-              , subq_2.paid_at__day
-              , subq_2.paid_at__week
-              , subq_2.paid_at__month
-              , subq_2.paid_at__quarter
-              , subq_2.paid_at__year
-              , subq_2.paid_at__extract_year
-              , subq_2.paid_at__extract_quarter
-              , subq_2.paid_at__extract_month
-              , subq_2.paid_at__extract_day
-              , subq_2.paid_at__extract_dow
-              , subq_2.paid_at__extract_doy
-              , subq_2.booking__ds__day
-              , subq_2.booking__ds__week
-              , subq_2.booking__ds__month
-              , subq_2.booking__ds__quarter
-              , subq_2.booking__ds__year
-              , subq_2.booking__ds__extract_year
-              , subq_2.booking__ds__extract_quarter
-              , subq_2.booking__ds__extract_month
-              , subq_2.booking__ds__extract_day
-              , subq_2.booking__ds__extract_dow
-              , subq_2.booking__ds__extract_doy
-              , subq_2.booking__ds_partitioned__day
-              , subq_2.booking__ds_partitioned__week
-              , subq_2.booking__ds_partitioned__month
-              , subq_2.booking__ds_partitioned__quarter
-              , subq_2.booking__ds_partitioned__year
-              , subq_2.booking__ds_partitioned__extract_year
-              , subq_2.booking__ds_partitioned__extract_quarter
-              , subq_2.booking__ds_partitioned__extract_month
-              , subq_2.booking__ds_partitioned__extract_day
-              , subq_2.booking__ds_partitioned__extract_dow
-              , subq_2.booking__ds_partitioned__extract_doy
-              , subq_2.booking__paid_at__day
-              , subq_2.booking__paid_at__week
-              , subq_2.booking__paid_at__month
-              , subq_2.booking__paid_at__quarter
-              , subq_2.booking__paid_at__year
-              , subq_2.booking__paid_at__extract_year
-              , subq_2.booking__paid_at__extract_quarter
-              , subq_2.booking__paid_at__extract_month
-              , subq_2.booking__paid_at__extract_day
-              , subq_2.booking__paid_at__extract_dow
-              , subq_2.booking__paid_at__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.listing
-              , subq_2.guest
-              , subq_2.host
-              , subq_2.booking__listing
-              , subq_2.booking__guest
-              , subq_2.booking__host
-              , subq_2.is_instant
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-              , subq_2.instant_bookings
-              , subq_2.booking_value
-              , subq_2.max_booking_value
-              , subq_2.min_booking_value
-              , subq_2.bookers
-              , subq_2.average_booking_value
-              , subq_2.referred_bookings
-              , subq_2.median_booking_value
-              , subq_2.booking_value_p99
-              , subq_2.discrete_booking_value_p99
-              , subq_2.approximate_continuous_booking_value_p99
-              , subq_2.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
               -- Read Elements From Semantic Model 'bookings_source'
               SELECT
@@ -323,16 +323,16 @@ FROM (
                 , bookings_source_src_28000.guest_id AS booking__guest
                 , bookings_source_src_28000.host_id AS booking__host
               FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-        ) subq_4
-      ) subq_5
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_2
+      ) subq_3
       GROUP BY
         metric_time__day
-    ) subq_6
+    ) subq_4
     ON
-      subq_7.metric_time__day = subq_6.metric_time__day
-  ) subq_9
-  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_10
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE subq_7.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_18.metric_time__day AS metric_time__day
-    , subq_17.bookings AS bookings
+    subq_14.metric_time__day AS metric_time__day
+    , subq_13.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_19
+    FROM ***************************.mf_time_spine subq_15
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_16
+    ) subq_12
     GROUP BY
       metric_time__day
-  ) subq_17
+  ) subq_13
   ON
-    subq_18.metric_time__day = subq_17.metric_time__day
-  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_21
+    subq_14.metric_time__day = subq_13.metric_time__day
+  WHERE subq_14.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,216 +1,216 @@
 -- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+  COALESCE(subq_4.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_5.bookings) AS bookings
+    SUM(subq_3.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings',]
     SELECT
-      subq_4.bookings
+      subq_2.bookings
     FROM (
       -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
       SELECT
-        subq_3.ds__day
-        , subq_3.ds__week
-        , subq_3.ds__month
-        , subq_3.ds__quarter
-        , subq_3.ds__year
-        , subq_3.ds__extract_year
-        , subq_3.ds__extract_quarter
-        , subq_3.ds__extract_month
-        , subq_3.ds__extract_day
-        , subq_3.ds__extract_dow
-        , subq_3.ds__extract_doy
-        , subq_3.ds_partitioned__day
-        , subq_3.ds_partitioned__week
-        , subq_3.ds_partitioned__month
-        , subq_3.ds_partitioned__quarter
-        , subq_3.ds_partitioned__year
-        , subq_3.ds_partitioned__extract_year
-        , subq_3.ds_partitioned__extract_quarter
-        , subq_3.ds_partitioned__extract_month
-        , subq_3.ds_partitioned__extract_day
-        , subq_3.ds_partitioned__extract_dow
-        , subq_3.ds_partitioned__extract_doy
-        , subq_3.paid_at__day
-        , subq_3.paid_at__week
-        , subq_3.paid_at__month
-        , subq_3.paid_at__quarter
-        , subq_3.paid_at__year
-        , subq_3.paid_at__extract_year
-        , subq_3.paid_at__extract_quarter
-        , subq_3.paid_at__extract_month
-        , subq_3.paid_at__extract_day
-        , subq_3.paid_at__extract_dow
-        , subq_3.paid_at__extract_doy
-        , subq_3.booking__ds__day
-        , subq_3.booking__ds__week
-        , subq_3.booking__ds__month
-        , subq_3.booking__ds__quarter
-        , subq_3.booking__ds__year
-        , subq_3.booking__ds__extract_year
-        , subq_3.booking__ds__extract_quarter
-        , subq_3.booking__ds__extract_month
-        , subq_3.booking__ds__extract_day
-        , subq_3.booking__ds__extract_dow
-        , subq_3.booking__ds__extract_doy
-        , subq_3.booking__ds_partitioned__day
-        , subq_3.booking__ds_partitioned__week
-        , subq_3.booking__ds_partitioned__month
-        , subq_3.booking__ds_partitioned__quarter
-        , subq_3.booking__ds_partitioned__year
-        , subq_3.booking__ds_partitioned__extract_year
-        , subq_3.booking__ds_partitioned__extract_quarter
-        , subq_3.booking__ds_partitioned__extract_month
-        , subq_3.booking__ds_partitioned__extract_day
-        , subq_3.booking__ds_partitioned__extract_dow
-        , subq_3.booking__ds_partitioned__extract_doy
-        , subq_3.booking__paid_at__day
-        , subq_3.booking__paid_at__week
-        , subq_3.booking__paid_at__month
-        , subq_3.booking__paid_at__quarter
-        , subq_3.booking__paid_at__year
-        , subq_3.booking__paid_at__extract_year
-        , subq_3.booking__paid_at__extract_quarter
-        , subq_3.booking__paid_at__extract_month
-        , subq_3.booking__paid_at__extract_day
-        , subq_3.booking__paid_at__extract_dow
-        , subq_3.booking__paid_at__extract_doy
-        , subq_3.metric_time__day
-        , subq_3.metric_time__week
-        , subq_3.metric_time__month
-        , subq_3.metric_time__quarter
-        , subq_3.metric_time__year
-        , subq_3.metric_time__extract_year
-        , subq_3.metric_time__extract_quarter
-        , subq_3.metric_time__extract_month
-        , subq_3.metric_time__extract_day
-        , subq_3.metric_time__extract_dow
-        , subq_3.metric_time__extract_doy
-        , subq_3.listing
-        , subq_3.guest
-        , subq_3.host
-        , subq_3.booking__listing
-        , subq_3.booking__guest
-        , subq_3.booking__host
-        , subq_3.is_instant
-        , subq_3.booking__is_instant
-        , subq_3.bookings
-        , subq_3.instant_bookings
-        , subq_3.booking_value
-        , subq_3.max_booking_value
-        , subq_3.min_booking_value
-        , subq_3.bookers
-        , subq_3.average_booking_value
-        , subq_3.referred_bookings
-        , subq_3.median_booking_value
-        , subq_3.booking_value_p99
-        , subq_3.discrete_booking_value_p99
-        , subq_3.approximate_continuous_booking_value_p99
-        , subq_3.approximate_discrete_booking_value_p99
+        subq_1.ds__day
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.ds__extract_year
+        , subq_1.ds__extract_quarter
+        , subq_1.ds__extract_month
+        , subq_1.ds__extract_day
+        , subq_1.ds__extract_dow
+        , subq_1.ds__extract_doy
+        , subq_1.ds_partitioned__day
+        , subq_1.ds_partitioned__week
+        , subq_1.ds_partitioned__month
+        , subq_1.ds_partitioned__quarter
+        , subq_1.ds_partitioned__year
+        , subq_1.ds_partitioned__extract_year
+        , subq_1.ds_partitioned__extract_quarter
+        , subq_1.ds_partitioned__extract_month
+        , subq_1.ds_partitioned__extract_day
+        , subq_1.ds_partitioned__extract_dow
+        , subq_1.ds_partitioned__extract_doy
+        , subq_1.paid_at__day
+        , subq_1.paid_at__week
+        , subq_1.paid_at__month
+        , subq_1.paid_at__quarter
+        , subq_1.paid_at__year
+        , subq_1.paid_at__extract_year
+        , subq_1.paid_at__extract_quarter
+        , subq_1.paid_at__extract_month
+        , subq_1.paid_at__extract_day
+        , subq_1.paid_at__extract_dow
+        , subq_1.paid_at__extract_doy
+        , subq_1.booking__ds__day
+        , subq_1.booking__ds__week
+        , subq_1.booking__ds__month
+        , subq_1.booking__ds__quarter
+        , subq_1.booking__ds__year
+        , subq_1.booking__ds__extract_year
+        , subq_1.booking__ds__extract_quarter
+        , subq_1.booking__ds__extract_month
+        , subq_1.booking__ds__extract_day
+        , subq_1.booking__ds__extract_dow
+        , subq_1.booking__ds__extract_doy
+        , subq_1.booking__ds_partitioned__day
+        , subq_1.booking__ds_partitioned__week
+        , subq_1.booking__ds_partitioned__month
+        , subq_1.booking__ds_partitioned__quarter
+        , subq_1.booking__ds_partitioned__year
+        , subq_1.booking__ds_partitioned__extract_year
+        , subq_1.booking__ds_partitioned__extract_quarter
+        , subq_1.booking__ds_partitioned__extract_month
+        , subq_1.booking__ds_partitioned__extract_day
+        , subq_1.booking__ds_partitioned__extract_dow
+        , subq_1.booking__ds_partitioned__extract_doy
+        , subq_1.booking__paid_at__day
+        , subq_1.booking__paid_at__week
+        , subq_1.booking__paid_at__month
+        , subq_1.booking__paid_at__quarter
+        , subq_1.booking__paid_at__year
+        , subq_1.booking__paid_at__extract_year
+        , subq_1.booking__paid_at__extract_quarter
+        , subq_1.booking__paid_at__extract_month
+        , subq_1.booking__paid_at__extract_day
+        , subq_1.booking__paid_at__extract_dow
+        , subq_1.booking__paid_at__extract_doy
+        , subq_1.metric_time__day
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.metric_time__extract_year
+        , subq_1.metric_time__extract_quarter
+        , subq_1.metric_time__extract_month
+        , subq_1.metric_time__extract_day
+        , subq_1.metric_time__extract_dow
+        , subq_1.metric_time__extract_doy
+        , subq_1.listing
+        , subq_1.guest
+        , subq_1.host
+        , subq_1.booking__listing
+        , subq_1.booking__guest
+        , subq_1.booking__host
+        , subq_1.is_instant
+        , subq_1.booking__is_instant
+        , subq_1.bookings
+        , subq_1.instant_bookings
+        , subq_1.booking_value
+        , subq_1.max_booking_value
+        , subq_1.min_booking_value
+        , subq_1.bookers
+        , subq_1.average_booking_value
+        , subq_1.referred_bookings
+        , subq_1.median_booking_value
+        , subq_1.booking_value_p99
+        , subq_1.discrete_booking_value_p99
+        , subq_1.approximate_continuous_booking_value_p99
+        , subq_1.approximate_discrete_booking_value_p99
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_2.ds__day
-          , subq_2.ds__week
-          , subq_2.ds__month
-          , subq_2.ds__quarter
-          , subq_2.ds__year
-          , subq_2.ds__extract_year
-          , subq_2.ds__extract_quarter
-          , subq_2.ds__extract_month
-          , subq_2.ds__extract_day
-          , subq_2.ds__extract_dow
-          , subq_2.ds__extract_doy
-          , subq_2.ds_partitioned__day
-          , subq_2.ds_partitioned__week
-          , subq_2.ds_partitioned__month
-          , subq_2.ds_partitioned__quarter
-          , subq_2.ds_partitioned__year
-          , subq_2.ds_partitioned__extract_year
-          , subq_2.ds_partitioned__extract_quarter
-          , subq_2.ds_partitioned__extract_month
-          , subq_2.ds_partitioned__extract_day
-          , subq_2.ds_partitioned__extract_dow
-          , subq_2.ds_partitioned__extract_doy
-          , subq_2.paid_at__day
-          , subq_2.paid_at__week
-          , subq_2.paid_at__month
-          , subq_2.paid_at__quarter
-          , subq_2.paid_at__year
-          , subq_2.paid_at__extract_year
-          , subq_2.paid_at__extract_quarter
-          , subq_2.paid_at__extract_month
-          , subq_2.paid_at__extract_day
-          , subq_2.paid_at__extract_dow
-          , subq_2.paid_at__extract_doy
-          , subq_2.booking__ds__day
-          , subq_2.booking__ds__week
-          , subq_2.booking__ds__month
-          , subq_2.booking__ds__quarter
-          , subq_2.booking__ds__year
-          , subq_2.booking__ds__extract_year
-          , subq_2.booking__ds__extract_quarter
-          , subq_2.booking__ds__extract_month
-          , subq_2.booking__ds__extract_day
-          , subq_2.booking__ds__extract_dow
-          , subq_2.booking__ds__extract_doy
-          , subq_2.booking__ds_partitioned__day
-          , subq_2.booking__ds_partitioned__week
-          , subq_2.booking__ds_partitioned__month
-          , subq_2.booking__ds_partitioned__quarter
-          , subq_2.booking__ds_partitioned__year
-          , subq_2.booking__ds_partitioned__extract_year
-          , subq_2.booking__ds_partitioned__extract_quarter
-          , subq_2.booking__ds_partitioned__extract_month
-          , subq_2.booking__ds_partitioned__extract_day
-          , subq_2.booking__ds_partitioned__extract_dow
-          , subq_2.booking__ds_partitioned__extract_doy
-          , subq_2.booking__paid_at__day
-          , subq_2.booking__paid_at__week
-          , subq_2.booking__paid_at__month
-          , subq_2.booking__paid_at__quarter
-          , subq_2.booking__paid_at__year
-          , subq_2.booking__paid_at__extract_year
-          , subq_2.booking__paid_at__extract_quarter
-          , subq_2.booking__paid_at__extract_month
-          , subq_2.booking__paid_at__extract_day
-          , subq_2.booking__paid_at__extract_dow
-          , subq_2.booking__paid_at__extract_doy
-          , subq_2.ds__day AS metric_time__day
-          , subq_2.ds__week AS metric_time__week
-          , subq_2.ds__month AS metric_time__month
-          , subq_2.ds__quarter AS metric_time__quarter
-          , subq_2.ds__year AS metric_time__year
-          , subq_2.ds__extract_year AS metric_time__extract_year
-          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_2.ds__extract_month AS metric_time__extract_month
-          , subq_2.ds__extract_day AS metric_time__extract_day
-          , subq_2.ds__extract_dow AS metric_time__extract_dow
-          , subq_2.ds__extract_doy AS metric_time__extract_doy
-          , subq_2.listing
-          , subq_2.guest
-          , subq_2.host
-          , subq_2.booking__listing
-          , subq_2.booking__guest
-          , subq_2.booking__host
-          , subq_2.is_instant
-          , subq_2.booking__is_instant
-          , subq_2.bookings
-          , subq_2.instant_bookings
-          , subq_2.booking_value
-          , subq_2.max_booking_value
-          , subq_2.min_booking_value
-          , subq_2.bookers
-          , subq_2.average_booking_value
-          , subq_2.referred_bookings
-          , subq_2.median_booking_value
-          , subq_2.booking_value_p99
-          , subq_2.discrete_booking_value_p99
-          , subq_2.approximate_continuous_booking_value_p99
-          , subq_2.approximate_discrete_booking_value_p99
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.ds_partitioned__day
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.ds_partitioned__extract_year
+          , subq_0.ds_partitioned__extract_quarter
+          , subq_0.ds_partitioned__extract_month
+          , subq_0.ds_partitioned__extract_day
+          , subq_0.ds_partitioned__extract_dow
+          , subq_0.ds_partitioned__extract_doy
+          , subq_0.paid_at__day
+          , subq_0.paid_at__week
+          , subq_0.paid_at__month
+          , subq_0.paid_at__quarter
+          , subq_0.paid_at__year
+          , subq_0.paid_at__extract_year
+          , subq_0.paid_at__extract_quarter
+          , subq_0.paid_at__extract_month
+          , subq_0.paid_at__extract_day
+          , subq_0.paid_at__extract_dow
+          , subq_0.paid_at__extract_doy
+          , subq_0.booking__ds__day
+          , subq_0.booking__ds__week
+          , subq_0.booking__ds__month
+          , subq_0.booking__ds__quarter
+          , subq_0.booking__ds__year
+          , subq_0.booking__ds__extract_year
+          , subq_0.booking__ds__extract_quarter
+          , subq_0.booking__ds__extract_month
+          , subq_0.booking__ds__extract_day
+          , subq_0.booking__ds__extract_dow
+          , subq_0.booking__ds__extract_doy
+          , subq_0.booking__ds_partitioned__day
+          , subq_0.booking__ds_partitioned__week
+          , subq_0.booking__ds_partitioned__month
+          , subq_0.booking__ds_partitioned__quarter
+          , subq_0.booking__ds_partitioned__year
+          , subq_0.booking__ds_partitioned__extract_year
+          , subq_0.booking__ds_partitioned__extract_quarter
+          , subq_0.booking__ds_partitioned__extract_month
+          , subq_0.booking__ds_partitioned__extract_day
+          , subq_0.booking__ds_partitioned__extract_dow
+          , subq_0.booking__ds_partitioned__extract_doy
+          , subq_0.booking__paid_at__day
+          , subq_0.booking__paid_at__week
+          , subq_0.booking__paid_at__month
+          , subq_0.booking__paid_at__quarter
+          , subq_0.booking__paid_at__year
+          , subq_0.booking__paid_at__extract_year
+          , subq_0.booking__paid_at__extract_quarter
+          , subq_0.booking__paid_at__extract_month
+          , subq_0.booking__paid_at__extract_day
+          , subq_0.booking__paid_at__extract_dow
+          , subq_0.booking__paid_at__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.booking__listing
+          , subq_0.booking__guest
+          , subq_0.booking__host
+          , subq_0.is_instant
+          , subq_0.booking__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
+          , subq_0.referred_bookings
+          , subq_0.median_booking_value
+          , subq_0.booking_value_p99
+          , subq_0.discrete_booking_value_p99
+          , subq_0.approximate_continuous_booking_value_p99
+          , subq_0.approximate_discrete_booking_value_p99
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
           SELECT
@@ -303,9 +303,9 @@ FROM (
             , bookings_source_src_28000.guest_id AS booking__guest
             , bookings_source_src_28000.host_id AS booking__host
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_2
-      ) subq_3
-      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_4
-  ) subq_5
-) subq_6
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_2
+  ) subq_3
+) subq_4

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_13
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings AS bookings
+    subq_7.metric_time__day AS metric_time__day
+    , subq_6.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-  ) subq_9
+      subq_8.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_8
+  ) subq_7
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -329,17 +329,17 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
       metric_time__day
-  ) subq_8
+  ) subq_6
   ON
-    subq_9.metric_time__day = subq_8.metric_time__day
-) subq_11
+    subq_7.metric_time__day = subq_6.metric_time__day
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_22.ds AS metric_time__day
-    , subq_20.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_22
+    subq_18.ds AS metric_time__day
+    , subq_16.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_18
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_11
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_16
   ON
-    subq_22.ds = subq_20.metric_time__day
-) subq_23
+    subq_18.ds = subq_16.metric_time__day
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , subq_11.booking__is_instant
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , subq_9.booking__is_instant
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_10.metric_time__day
-    , subq_10.booking__is_instant
-    , subq_10.bookings
+    subq_8.metric_time__day
+    , subq_8.booking__is_instant
+    , subq_8.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_8.metric_time__day AS metric_time__day
-      , subq_7.booking__is_instant AS booking__is_instant
-      , subq_7.bookings AS bookings
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking__is_instant AS booking__is_instant
+      , subq_5.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_9.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_9
-    ) subq_8
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-        , SUM(subq_6.bookings) AS bookings
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+        , SUM(subq_4.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -333,19 +333,19 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
+      ) subq_4
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_7
+    ) subq_5
     ON
-      subq_8.metric_time__day = subq_7.metric_time__day
-  ) subq_10
+      subq_6.metric_time__day = subq_5.metric_time__day
+  ) subq_8
   WHERE booking__is_instant
-) subq_11
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.ds AS metric_time__day
-      , subq_19.booking__is_instant AS booking__is_instant
-      , subq_19.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_21
+      subq_17.ds AS metric_time__day
+      , subq_15.booking__is_instant AS booking__is_instant
+      , subq_15.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_15
+        ) subq_11
         WHERE booking__is_instant
-      ) subq_17
+      ) subq_13
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_19
+    ) subq_15
     ON
-      subq_21.ds = subq_19.metric_time__day
-  ) subq_22
+      subq_17.ds = subq_15.metric_time__day
+  ) subq_18
   WHERE booking__is_instant
-) subq_23
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_9.metric_time__day
-    , subq_9.bookings
+    subq_7.metric_time__day
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_7.metric_time__day AS metric_time__day
-      , subq_6.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_8.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_8
-      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_7
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+      WHERE subq_6.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.bookings) AS bookings
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.bookings
+          subq_2.metric_time__day
+          , subq_2.bookings
         FROM (
           -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.max_booking_value
-            , subq_3.min_booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
-            , subq_3.referred_bookings
-            , subq_3.median_booking_value
-            , subq_3.booking_value_p99
-            , subq_3.discrete_booking_value_p99
-            , subq_3.approximate_continuous_booking_value_p99
-            , subq_3.approximate_discrete_booking_value_p99
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.ds_partitioned__day
+            , subq_1.ds_partitioned__week
+            , subq_1.ds_partitioned__month
+            , subq_1.ds_partitioned__quarter
+            , subq_1.ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy
+            , subq_1.paid_at__day
+            , subq_1.paid_at__week
+            , subq_1.paid_at__month
+            , subq_1.paid_at__quarter
+            , subq_1.paid_at__year
+            , subq_1.paid_at__extract_year
+            , subq_1.paid_at__extract_quarter
+            , subq_1.paid_at__extract_month
+            , subq_1.paid_at__extract_day
+            , subq_1.paid_at__extract_dow
+            , subq_1.paid_at__extract_doy
+            , subq_1.booking__ds__day
+            , subq_1.booking__ds__week
+            , subq_1.booking__ds__month
+            , subq_1.booking__ds__quarter
+            , subq_1.booking__ds__year
+            , subq_1.booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month
+            , subq_1.booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day
+            , subq_1.booking__paid_at__week
+            , subq_1.booking__paid_at__month
+            , subq_1.booking__paid_at__quarter
+            , subq_1.booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.listing
+            , subq_1.guest
+            , subq_1.host
+            , subq_1.booking__listing
+            , subq_1.booking__guest
+            , subq_1.booking__host
+            , subq_1.is_instant
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+            , subq_1.instant_bookings
+            , subq_1.booking_value
+            , subq_1.max_booking_value
+            , subq_1.min_booking_value
+            , subq_1.bookers
+            , subq_1.average_booking_value
+            , subq_1.referred_bookings
+            , subq_1.median_booking_value
+            , subq_1.booking_value_p99
+            , subq_1.discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.ds_partitioned__day
-              , subq_2.ds_partitioned__week
-              , subq_2.ds_partitioned__month
-              , subq_2.ds_partitioned__quarter
-              , subq_2.ds_partitioned__year
-              , subq_2.ds_partitioned__extract_year
-              , subq_2.ds_partitioned__extract_quarter
-              , subq_2.ds_partitioned__extract_month
-              , subq_2.ds_partitioned__extract_day
-              , subq_2.ds_partitioned__extract_dow
-              , subq_2.ds_partitioned__extract_doy
-              , subq_2.paid_at__day
-              , subq_2.paid_at__week
-              , subq_2.paid_at__month
-              , subq_2.paid_at__quarter
-              , subq_2.paid_at__year
-              , subq_2.paid_at__extract_year
-              , subq_2.paid_at__extract_quarter
-              , subq_2.paid_at__extract_month
-              , subq_2.paid_at__extract_day
-              , subq_2.paid_at__extract_dow
-              , subq_2.paid_at__extract_doy
-              , subq_2.booking__ds__day
-              , subq_2.booking__ds__week
-              , subq_2.booking__ds__month
-              , subq_2.booking__ds__quarter
-              , subq_2.booking__ds__year
-              , subq_2.booking__ds__extract_year
-              , subq_2.booking__ds__extract_quarter
-              , subq_2.booking__ds__extract_month
-              , subq_2.booking__ds__extract_day
-              , subq_2.booking__ds__extract_dow
-              , subq_2.booking__ds__extract_doy
-              , subq_2.booking__ds_partitioned__day
-              , subq_2.booking__ds_partitioned__week
-              , subq_2.booking__ds_partitioned__month
-              , subq_2.booking__ds_partitioned__quarter
-              , subq_2.booking__ds_partitioned__year
-              , subq_2.booking__ds_partitioned__extract_year
-              , subq_2.booking__ds_partitioned__extract_quarter
-              , subq_2.booking__ds_partitioned__extract_month
-              , subq_2.booking__ds_partitioned__extract_day
-              , subq_2.booking__ds_partitioned__extract_dow
-              , subq_2.booking__ds_partitioned__extract_doy
-              , subq_2.booking__paid_at__day
-              , subq_2.booking__paid_at__week
-              , subq_2.booking__paid_at__month
-              , subq_2.booking__paid_at__quarter
-              , subq_2.booking__paid_at__year
-              , subq_2.booking__paid_at__extract_year
-              , subq_2.booking__paid_at__extract_quarter
-              , subq_2.booking__paid_at__extract_month
-              , subq_2.booking__paid_at__extract_day
-              , subq_2.booking__paid_at__extract_dow
-              , subq_2.booking__paid_at__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.listing
-              , subq_2.guest
-              , subq_2.host
-              , subq_2.booking__listing
-              , subq_2.booking__guest
-              , subq_2.booking__host
-              , subq_2.is_instant
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-              , subq_2.instant_bookings
-              , subq_2.booking_value
-              , subq_2.max_booking_value
-              , subq_2.min_booking_value
-              , subq_2.bookers
-              , subq_2.average_booking_value
-              , subq_2.referred_bookings
-              , subq_2.median_booking_value
-              , subq_2.booking_value_p99
-              , subq_2.discrete_booking_value_p99
-              , subq_2.approximate_continuous_booking_value_p99
-              , subq_2.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
               -- Read Elements From Semantic Model 'bookings_source'
               SELECT
@@ -323,16 +323,16 @@ FROM (
                 , bookings_source_src_28000.guest_id AS booking__guest
                 , bookings_source_src_28000.host_id AS booking__host
               FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-        ) subq_4
-      ) subq_5
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_2
+      ) subq_3
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
+        subq_3.metric_time__day
+    ) subq_4
     ON
-      subq_7.metric_time__day = subq_6.metric_time__day
-  ) subq_9
-  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_10
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE subq_7.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_18.metric_time__day AS metric_time__day
-    , subq_17.bookings AS bookings
+    subq_14.metric_time__day AS metric_time__day
+    , subq_13.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_19
+    FROM ***************************.mf_time_spine subq_15
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_16
+    ) subq_12
     GROUP BY
       metric_time__day
-  ) subq_17
+  ) subq_13
   ON
-    subq_18.metric_time__day = subq_17.metric_time__day
-  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_21
+    subq_14.metric_time__day = subq_13.metric_time__day
+  WHERE subq_14.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,216 +1,216 @@
 -- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+  COALESCE(subq_4.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_5.bookings) AS bookings
+    SUM(subq_3.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings',]
     SELECT
-      subq_4.bookings
+      subq_2.bookings
     FROM (
       -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
       SELECT
-        subq_3.ds__day
-        , subq_3.ds__week
-        , subq_3.ds__month
-        , subq_3.ds__quarter
-        , subq_3.ds__year
-        , subq_3.ds__extract_year
-        , subq_3.ds__extract_quarter
-        , subq_3.ds__extract_month
-        , subq_3.ds__extract_day
-        , subq_3.ds__extract_dow
-        , subq_3.ds__extract_doy
-        , subq_3.ds_partitioned__day
-        , subq_3.ds_partitioned__week
-        , subq_3.ds_partitioned__month
-        , subq_3.ds_partitioned__quarter
-        , subq_3.ds_partitioned__year
-        , subq_3.ds_partitioned__extract_year
-        , subq_3.ds_partitioned__extract_quarter
-        , subq_3.ds_partitioned__extract_month
-        , subq_3.ds_partitioned__extract_day
-        , subq_3.ds_partitioned__extract_dow
-        , subq_3.ds_partitioned__extract_doy
-        , subq_3.paid_at__day
-        , subq_3.paid_at__week
-        , subq_3.paid_at__month
-        , subq_3.paid_at__quarter
-        , subq_3.paid_at__year
-        , subq_3.paid_at__extract_year
-        , subq_3.paid_at__extract_quarter
-        , subq_3.paid_at__extract_month
-        , subq_3.paid_at__extract_day
-        , subq_3.paid_at__extract_dow
-        , subq_3.paid_at__extract_doy
-        , subq_3.booking__ds__day
-        , subq_3.booking__ds__week
-        , subq_3.booking__ds__month
-        , subq_3.booking__ds__quarter
-        , subq_3.booking__ds__year
-        , subq_3.booking__ds__extract_year
-        , subq_3.booking__ds__extract_quarter
-        , subq_3.booking__ds__extract_month
-        , subq_3.booking__ds__extract_day
-        , subq_3.booking__ds__extract_dow
-        , subq_3.booking__ds__extract_doy
-        , subq_3.booking__ds_partitioned__day
-        , subq_3.booking__ds_partitioned__week
-        , subq_3.booking__ds_partitioned__month
-        , subq_3.booking__ds_partitioned__quarter
-        , subq_3.booking__ds_partitioned__year
-        , subq_3.booking__ds_partitioned__extract_year
-        , subq_3.booking__ds_partitioned__extract_quarter
-        , subq_3.booking__ds_partitioned__extract_month
-        , subq_3.booking__ds_partitioned__extract_day
-        , subq_3.booking__ds_partitioned__extract_dow
-        , subq_3.booking__ds_partitioned__extract_doy
-        , subq_3.booking__paid_at__day
-        , subq_3.booking__paid_at__week
-        , subq_3.booking__paid_at__month
-        , subq_3.booking__paid_at__quarter
-        , subq_3.booking__paid_at__year
-        , subq_3.booking__paid_at__extract_year
-        , subq_3.booking__paid_at__extract_quarter
-        , subq_3.booking__paid_at__extract_month
-        , subq_3.booking__paid_at__extract_day
-        , subq_3.booking__paid_at__extract_dow
-        , subq_3.booking__paid_at__extract_doy
-        , subq_3.metric_time__day
-        , subq_3.metric_time__week
-        , subq_3.metric_time__month
-        , subq_3.metric_time__quarter
-        , subq_3.metric_time__year
-        , subq_3.metric_time__extract_year
-        , subq_3.metric_time__extract_quarter
-        , subq_3.metric_time__extract_month
-        , subq_3.metric_time__extract_day
-        , subq_3.metric_time__extract_dow
-        , subq_3.metric_time__extract_doy
-        , subq_3.listing
-        , subq_3.guest
-        , subq_3.host
-        , subq_3.booking__listing
-        , subq_3.booking__guest
-        , subq_3.booking__host
-        , subq_3.is_instant
-        , subq_3.booking__is_instant
-        , subq_3.bookings
-        , subq_3.instant_bookings
-        , subq_3.booking_value
-        , subq_3.max_booking_value
-        , subq_3.min_booking_value
-        , subq_3.bookers
-        , subq_3.average_booking_value
-        , subq_3.referred_bookings
-        , subq_3.median_booking_value
-        , subq_3.booking_value_p99
-        , subq_3.discrete_booking_value_p99
-        , subq_3.approximate_continuous_booking_value_p99
-        , subq_3.approximate_discrete_booking_value_p99
+        subq_1.ds__day
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.ds__extract_year
+        , subq_1.ds__extract_quarter
+        , subq_1.ds__extract_month
+        , subq_1.ds__extract_day
+        , subq_1.ds__extract_dow
+        , subq_1.ds__extract_doy
+        , subq_1.ds_partitioned__day
+        , subq_1.ds_partitioned__week
+        , subq_1.ds_partitioned__month
+        , subq_1.ds_partitioned__quarter
+        , subq_1.ds_partitioned__year
+        , subq_1.ds_partitioned__extract_year
+        , subq_1.ds_partitioned__extract_quarter
+        , subq_1.ds_partitioned__extract_month
+        , subq_1.ds_partitioned__extract_day
+        , subq_1.ds_partitioned__extract_dow
+        , subq_1.ds_partitioned__extract_doy
+        , subq_1.paid_at__day
+        , subq_1.paid_at__week
+        , subq_1.paid_at__month
+        , subq_1.paid_at__quarter
+        , subq_1.paid_at__year
+        , subq_1.paid_at__extract_year
+        , subq_1.paid_at__extract_quarter
+        , subq_1.paid_at__extract_month
+        , subq_1.paid_at__extract_day
+        , subq_1.paid_at__extract_dow
+        , subq_1.paid_at__extract_doy
+        , subq_1.booking__ds__day
+        , subq_1.booking__ds__week
+        , subq_1.booking__ds__month
+        , subq_1.booking__ds__quarter
+        , subq_1.booking__ds__year
+        , subq_1.booking__ds__extract_year
+        , subq_1.booking__ds__extract_quarter
+        , subq_1.booking__ds__extract_month
+        , subq_1.booking__ds__extract_day
+        , subq_1.booking__ds__extract_dow
+        , subq_1.booking__ds__extract_doy
+        , subq_1.booking__ds_partitioned__day
+        , subq_1.booking__ds_partitioned__week
+        , subq_1.booking__ds_partitioned__month
+        , subq_1.booking__ds_partitioned__quarter
+        , subq_1.booking__ds_partitioned__year
+        , subq_1.booking__ds_partitioned__extract_year
+        , subq_1.booking__ds_partitioned__extract_quarter
+        , subq_1.booking__ds_partitioned__extract_month
+        , subq_1.booking__ds_partitioned__extract_day
+        , subq_1.booking__ds_partitioned__extract_dow
+        , subq_1.booking__ds_partitioned__extract_doy
+        , subq_1.booking__paid_at__day
+        , subq_1.booking__paid_at__week
+        , subq_1.booking__paid_at__month
+        , subq_1.booking__paid_at__quarter
+        , subq_1.booking__paid_at__year
+        , subq_1.booking__paid_at__extract_year
+        , subq_1.booking__paid_at__extract_quarter
+        , subq_1.booking__paid_at__extract_month
+        , subq_1.booking__paid_at__extract_day
+        , subq_1.booking__paid_at__extract_dow
+        , subq_1.booking__paid_at__extract_doy
+        , subq_1.metric_time__day
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.metric_time__extract_year
+        , subq_1.metric_time__extract_quarter
+        , subq_1.metric_time__extract_month
+        , subq_1.metric_time__extract_day
+        , subq_1.metric_time__extract_dow
+        , subq_1.metric_time__extract_doy
+        , subq_1.listing
+        , subq_1.guest
+        , subq_1.host
+        , subq_1.booking__listing
+        , subq_1.booking__guest
+        , subq_1.booking__host
+        , subq_1.is_instant
+        , subq_1.booking__is_instant
+        , subq_1.bookings
+        , subq_1.instant_bookings
+        , subq_1.booking_value
+        , subq_1.max_booking_value
+        , subq_1.min_booking_value
+        , subq_1.bookers
+        , subq_1.average_booking_value
+        , subq_1.referred_bookings
+        , subq_1.median_booking_value
+        , subq_1.booking_value_p99
+        , subq_1.discrete_booking_value_p99
+        , subq_1.approximate_continuous_booking_value_p99
+        , subq_1.approximate_discrete_booking_value_p99
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_2.ds__day
-          , subq_2.ds__week
-          , subq_2.ds__month
-          , subq_2.ds__quarter
-          , subq_2.ds__year
-          , subq_2.ds__extract_year
-          , subq_2.ds__extract_quarter
-          , subq_2.ds__extract_month
-          , subq_2.ds__extract_day
-          , subq_2.ds__extract_dow
-          , subq_2.ds__extract_doy
-          , subq_2.ds_partitioned__day
-          , subq_2.ds_partitioned__week
-          , subq_2.ds_partitioned__month
-          , subq_2.ds_partitioned__quarter
-          , subq_2.ds_partitioned__year
-          , subq_2.ds_partitioned__extract_year
-          , subq_2.ds_partitioned__extract_quarter
-          , subq_2.ds_partitioned__extract_month
-          , subq_2.ds_partitioned__extract_day
-          , subq_2.ds_partitioned__extract_dow
-          , subq_2.ds_partitioned__extract_doy
-          , subq_2.paid_at__day
-          , subq_2.paid_at__week
-          , subq_2.paid_at__month
-          , subq_2.paid_at__quarter
-          , subq_2.paid_at__year
-          , subq_2.paid_at__extract_year
-          , subq_2.paid_at__extract_quarter
-          , subq_2.paid_at__extract_month
-          , subq_2.paid_at__extract_day
-          , subq_2.paid_at__extract_dow
-          , subq_2.paid_at__extract_doy
-          , subq_2.booking__ds__day
-          , subq_2.booking__ds__week
-          , subq_2.booking__ds__month
-          , subq_2.booking__ds__quarter
-          , subq_2.booking__ds__year
-          , subq_2.booking__ds__extract_year
-          , subq_2.booking__ds__extract_quarter
-          , subq_2.booking__ds__extract_month
-          , subq_2.booking__ds__extract_day
-          , subq_2.booking__ds__extract_dow
-          , subq_2.booking__ds__extract_doy
-          , subq_2.booking__ds_partitioned__day
-          , subq_2.booking__ds_partitioned__week
-          , subq_2.booking__ds_partitioned__month
-          , subq_2.booking__ds_partitioned__quarter
-          , subq_2.booking__ds_partitioned__year
-          , subq_2.booking__ds_partitioned__extract_year
-          , subq_2.booking__ds_partitioned__extract_quarter
-          , subq_2.booking__ds_partitioned__extract_month
-          , subq_2.booking__ds_partitioned__extract_day
-          , subq_2.booking__ds_partitioned__extract_dow
-          , subq_2.booking__ds_partitioned__extract_doy
-          , subq_2.booking__paid_at__day
-          , subq_2.booking__paid_at__week
-          , subq_2.booking__paid_at__month
-          , subq_2.booking__paid_at__quarter
-          , subq_2.booking__paid_at__year
-          , subq_2.booking__paid_at__extract_year
-          , subq_2.booking__paid_at__extract_quarter
-          , subq_2.booking__paid_at__extract_month
-          , subq_2.booking__paid_at__extract_day
-          , subq_2.booking__paid_at__extract_dow
-          , subq_2.booking__paid_at__extract_doy
-          , subq_2.ds__day AS metric_time__day
-          , subq_2.ds__week AS metric_time__week
-          , subq_2.ds__month AS metric_time__month
-          , subq_2.ds__quarter AS metric_time__quarter
-          , subq_2.ds__year AS metric_time__year
-          , subq_2.ds__extract_year AS metric_time__extract_year
-          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_2.ds__extract_month AS metric_time__extract_month
-          , subq_2.ds__extract_day AS metric_time__extract_day
-          , subq_2.ds__extract_dow AS metric_time__extract_dow
-          , subq_2.ds__extract_doy AS metric_time__extract_doy
-          , subq_2.listing
-          , subq_2.guest
-          , subq_2.host
-          , subq_2.booking__listing
-          , subq_2.booking__guest
-          , subq_2.booking__host
-          , subq_2.is_instant
-          , subq_2.booking__is_instant
-          , subq_2.bookings
-          , subq_2.instant_bookings
-          , subq_2.booking_value
-          , subq_2.max_booking_value
-          , subq_2.min_booking_value
-          , subq_2.bookers
-          , subq_2.average_booking_value
-          , subq_2.referred_bookings
-          , subq_2.median_booking_value
-          , subq_2.booking_value_p99
-          , subq_2.discrete_booking_value_p99
-          , subq_2.approximate_continuous_booking_value_p99
-          , subq_2.approximate_discrete_booking_value_p99
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.ds_partitioned__day
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.ds_partitioned__extract_year
+          , subq_0.ds_partitioned__extract_quarter
+          , subq_0.ds_partitioned__extract_month
+          , subq_0.ds_partitioned__extract_day
+          , subq_0.ds_partitioned__extract_dow
+          , subq_0.ds_partitioned__extract_doy
+          , subq_0.paid_at__day
+          , subq_0.paid_at__week
+          , subq_0.paid_at__month
+          , subq_0.paid_at__quarter
+          , subq_0.paid_at__year
+          , subq_0.paid_at__extract_year
+          , subq_0.paid_at__extract_quarter
+          , subq_0.paid_at__extract_month
+          , subq_0.paid_at__extract_day
+          , subq_0.paid_at__extract_dow
+          , subq_0.paid_at__extract_doy
+          , subq_0.booking__ds__day
+          , subq_0.booking__ds__week
+          , subq_0.booking__ds__month
+          , subq_0.booking__ds__quarter
+          , subq_0.booking__ds__year
+          , subq_0.booking__ds__extract_year
+          , subq_0.booking__ds__extract_quarter
+          , subq_0.booking__ds__extract_month
+          , subq_0.booking__ds__extract_day
+          , subq_0.booking__ds__extract_dow
+          , subq_0.booking__ds__extract_doy
+          , subq_0.booking__ds_partitioned__day
+          , subq_0.booking__ds_partitioned__week
+          , subq_0.booking__ds_partitioned__month
+          , subq_0.booking__ds_partitioned__quarter
+          , subq_0.booking__ds_partitioned__year
+          , subq_0.booking__ds_partitioned__extract_year
+          , subq_0.booking__ds_partitioned__extract_quarter
+          , subq_0.booking__ds_partitioned__extract_month
+          , subq_0.booking__ds_partitioned__extract_day
+          , subq_0.booking__ds_partitioned__extract_dow
+          , subq_0.booking__ds_partitioned__extract_doy
+          , subq_0.booking__paid_at__day
+          , subq_0.booking__paid_at__week
+          , subq_0.booking__paid_at__month
+          , subq_0.booking__paid_at__quarter
+          , subq_0.booking__paid_at__year
+          , subq_0.booking__paid_at__extract_year
+          , subq_0.booking__paid_at__extract_quarter
+          , subq_0.booking__paid_at__extract_month
+          , subq_0.booking__paid_at__extract_day
+          , subq_0.booking__paid_at__extract_dow
+          , subq_0.booking__paid_at__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.booking__listing
+          , subq_0.booking__guest
+          , subq_0.booking__host
+          , subq_0.is_instant
+          , subq_0.booking__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
+          , subq_0.referred_bookings
+          , subq_0.median_booking_value
+          , subq_0.booking_value_p99
+          , subq_0.discrete_booking_value_p99
+          , subq_0.approximate_continuous_booking_value_p99
+          , subq_0.approximate_discrete_booking_value_p99
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
           SELECT
@@ -303,9 +303,9 @@ FROM (
             , bookings_source_src_28000.guest_id AS booking__guest
             , bookings_source_src_28000.host_id AS booking__host
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_2
-      ) subq_3
-      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_4
-  ) subq_5
-) subq_6
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_2
+  ) subq_3
+) subq_4

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_13
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings AS bookings
+    subq_7.metric_time__day AS metric_time__day
+    , subq_6.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-  ) subq_9
+      subq_8.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_8
+  ) subq_7
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -329,17 +329,17 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day
+  ) subq_6
   ON
-    subq_9.metric_time__day = subq_8.metric_time__day
-) subq_11
+    subq_7.metric_time__day = subq_6.metric_time__day
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_22.ds AS metric_time__day
-    , subq_20.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_22
+    subq_18.ds AS metric_time__day
+    , subq_16.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_18
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_11
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_16
   ON
-    subq_22.ds = subq_20.metric_time__day
-) subq_23
+    subq_18.ds = subq_16.metric_time__day
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , subq_11.booking__is_instant
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , subq_9.booking__is_instant
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_10.metric_time__day
-    , subq_10.booking__is_instant
-    , subq_10.bookings
+    subq_8.metric_time__day
+    , subq_8.booking__is_instant
+    , subq_8.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_8.metric_time__day AS metric_time__day
-      , subq_7.booking__is_instant AS booking__is_instant
-      , subq_7.bookings AS bookings
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking__is_instant AS booking__is_instant
+      , subq_5.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_9.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_9
-    ) subq_8
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-        , SUM(subq_6.bookings) AS bookings
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+        , SUM(subq_4.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -333,19 +333,19 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
+      ) subq_4
       GROUP BY
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-    ) subq_7
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+    ) subq_5
     ON
-      subq_8.metric_time__day = subq_7.metric_time__day
-  ) subq_10
+      subq_6.metric_time__day = subq_5.metric_time__day
+  ) subq_8
   WHERE booking__is_instant
-) subq_11
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.ds AS metric_time__day
-      , subq_19.booking__is_instant AS booking__is_instant
-      , subq_19.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_21
+      subq_17.ds AS metric_time__day
+      , subq_15.booking__is_instant AS booking__is_instant
+      , subq_15.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_15
+        ) subq_11
         WHERE booking__is_instant
-      ) subq_17
+      ) subq_13
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_19
+    ) subq_15
     ON
-      subq_21.ds = subq_19.metric_time__day
-  ) subq_22
+      subq_17.ds = subq_15.metric_time__day
+  ) subq_18
   WHERE booking__is_instant
-) subq_23
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_9.metric_time__day
-    , subq_9.bookings
+    subq_7.metric_time__day
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_7.metric_time__day AS metric_time__day
-      , subq_6.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_8.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_8
-      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_7
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+      WHERE subq_6.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.bookings) AS bookings
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.bookings
+          subq_2.metric_time__day
+          , subq_2.bookings
         FROM (
           -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.max_booking_value
-            , subq_3.min_booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
-            , subq_3.referred_bookings
-            , subq_3.median_booking_value
-            , subq_3.booking_value_p99
-            , subq_3.discrete_booking_value_p99
-            , subq_3.approximate_continuous_booking_value_p99
-            , subq_3.approximate_discrete_booking_value_p99
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.ds_partitioned__day
+            , subq_1.ds_partitioned__week
+            , subq_1.ds_partitioned__month
+            , subq_1.ds_partitioned__quarter
+            , subq_1.ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy
+            , subq_1.paid_at__day
+            , subq_1.paid_at__week
+            , subq_1.paid_at__month
+            , subq_1.paid_at__quarter
+            , subq_1.paid_at__year
+            , subq_1.paid_at__extract_year
+            , subq_1.paid_at__extract_quarter
+            , subq_1.paid_at__extract_month
+            , subq_1.paid_at__extract_day
+            , subq_1.paid_at__extract_dow
+            , subq_1.paid_at__extract_doy
+            , subq_1.booking__ds__day
+            , subq_1.booking__ds__week
+            , subq_1.booking__ds__month
+            , subq_1.booking__ds__quarter
+            , subq_1.booking__ds__year
+            , subq_1.booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month
+            , subq_1.booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day
+            , subq_1.booking__paid_at__week
+            , subq_1.booking__paid_at__month
+            , subq_1.booking__paid_at__quarter
+            , subq_1.booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.listing
+            , subq_1.guest
+            , subq_1.host
+            , subq_1.booking__listing
+            , subq_1.booking__guest
+            , subq_1.booking__host
+            , subq_1.is_instant
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+            , subq_1.instant_bookings
+            , subq_1.booking_value
+            , subq_1.max_booking_value
+            , subq_1.min_booking_value
+            , subq_1.bookers
+            , subq_1.average_booking_value
+            , subq_1.referred_bookings
+            , subq_1.median_booking_value
+            , subq_1.booking_value_p99
+            , subq_1.discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.ds_partitioned__day
-              , subq_2.ds_partitioned__week
-              , subq_2.ds_partitioned__month
-              , subq_2.ds_partitioned__quarter
-              , subq_2.ds_partitioned__year
-              , subq_2.ds_partitioned__extract_year
-              , subq_2.ds_partitioned__extract_quarter
-              , subq_2.ds_partitioned__extract_month
-              , subq_2.ds_partitioned__extract_day
-              , subq_2.ds_partitioned__extract_dow
-              , subq_2.ds_partitioned__extract_doy
-              , subq_2.paid_at__day
-              , subq_2.paid_at__week
-              , subq_2.paid_at__month
-              , subq_2.paid_at__quarter
-              , subq_2.paid_at__year
-              , subq_2.paid_at__extract_year
-              , subq_2.paid_at__extract_quarter
-              , subq_2.paid_at__extract_month
-              , subq_2.paid_at__extract_day
-              , subq_2.paid_at__extract_dow
-              , subq_2.paid_at__extract_doy
-              , subq_2.booking__ds__day
-              , subq_2.booking__ds__week
-              , subq_2.booking__ds__month
-              , subq_2.booking__ds__quarter
-              , subq_2.booking__ds__year
-              , subq_2.booking__ds__extract_year
-              , subq_2.booking__ds__extract_quarter
-              , subq_2.booking__ds__extract_month
-              , subq_2.booking__ds__extract_day
-              , subq_2.booking__ds__extract_dow
-              , subq_2.booking__ds__extract_doy
-              , subq_2.booking__ds_partitioned__day
-              , subq_2.booking__ds_partitioned__week
-              , subq_2.booking__ds_partitioned__month
-              , subq_2.booking__ds_partitioned__quarter
-              , subq_2.booking__ds_partitioned__year
-              , subq_2.booking__ds_partitioned__extract_year
-              , subq_2.booking__ds_partitioned__extract_quarter
-              , subq_2.booking__ds_partitioned__extract_month
-              , subq_2.booking__ds_partitioned__extract_day
-              , subq_2.booking__ds_partitioned__extract_dow
-              , subq_2.booking__ds_partitioned__extract_doy
-              , subq_2.booking__paid_at__day
-              , subq_2.booking__paid_at__week
-              , subq_2.booking__paid_at__month
-              , subq_2.booking__paid_at__quarter
-              , subq_2.booking__paid_at__year
-              , subq_2.booking__paid_at__extract_year
-              , subq_2.booking__paid_at__extract_quarter
-              , subq_2.booking__paid_at__extract_month
-              , subq_2.booking__paid_at__extract_day
-              , subq_2.booking__paid_at__extract_dow
-              , subq_2.booking__paid_at__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.listing
-              , subq_2.guest
-              , subq_2.host
-              , subq_2.booking__listing
-              , subq_2.booking__guest
-              , subq_2.booking__host
-              , subq_2.is_instant
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-              , subq_2.instant_bookings
-              , subq_2.booking_value
-              , subq_2.max_booking_value
-              , subq_2.min_booking_value
-              , subq_2.bookers
-              , subq_2.average_booking_value
-              , subq_2.referred_bookings
-              , subq_2.median_booking_value
-              , subq_2.booking_value_p99
-              , subq_2.discrete_booking_value_p99
-              , subq_2.approximate_continuous_booking_value_p99
-              , subq_2.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
               -- Read Elements From Semantic Model 'bookings_source'
               SELECT
@@ -323,16 +323,16 @@ FROM (
                 , bookings_source_src_28000.guest_id AS booking__guest
                 , bookings_source_src_28000.host_id AS booking__host
               FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-        ) subq_4
-      ) subq_5
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_2
+      ) subq_3
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
+        subq_3.metric_time__day
+    ) subq_4
     ON
-      subq_7.metric_time__day = subq_6.metric_time__day
-  ) subq_9
-  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_10
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE subq_7.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_18.metric_time__day AS metric_time__day
-    , subq_17.bookings AS bookings
+    subq_14.metric_time__day AS metric_time__day
+    , subq_13.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_19
+    FROM ***************************.mf_time_spine subq_15
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_16
+    ) subq_12
     GROUP BY
       metric_time__day
-  ) subq_17
+  ) subq_13
   ON
-    subq_18.metric_time__day = subq_17.metric_time__day
-  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_21
+    subq_14.metric_time__day = subq_13.metric_time__day
+  WHERE subq_14.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,216 +1,216 @@
 -- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+  COALESCE(subq_4.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_5.bookings) AS bookings
+    SUM(subq_3.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings',]
     SELECT
-      subq_4.bookings
+      subq_2.bookings
     FROM (
       -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
       SELECT
-        subq_3.ds__day
-        , subq_3.ds__week
-        , subq_3.ds__month
-        , subq_3.ds__quarter
-        , subq_3.ds__year
-        , subq_3.ds__extract_year
-        , subq_3.ds__extract_quarter
-        , subq_3.ds__extract_month
-        , subq_3.ds__extract_day
-        , subq_3.ds__extract_dow
-        , subq_3.ds__extract_doy
-        , subq_3.ds_partitioned__day
-        , subq_3.ds_partitioned__week
-        , subq_3.ds_partitioned__month
-        , subq_3.ds_partitioned__quarter
-        , subq_3.ds_partitioned__year
-        , subq_3.ds_partitioned__extract_year
-        , subq_3.ds_partitioned__extract_quarter
-        , subq_3.ds_partitioned__extract_month
-        , subq_3.ds_partitioned__extract_day
-        , subq_3.ds_partitioned__extract_dow
-        , subq_3.ds_partitioned__extract_doy
-        , subq_3.paid_at__day
-        , subq_3.paid_at__week
-        , subq_3.paid_at__month
-        , subq_3.paid_at__quarter
-        , subq_3.paid_at__year
-        , subq_3.paid_at__extract_year
-        , subq_3.paid_at__extract_quarter
-        , subq_3.paid_at__extract_month
-        , subq_3.paid_at__extract_day
-        , subq_3.paid_at__extract_dow
-        , subq_3.paid_at__extract_doy
-        , subq_3.booking__ds__day
-        , subq_3.booking__ds__week
-        , subq_3.booking__ds__month
-        , subq_3.booking__ds__quarter
-        , subq_3.booking__ds__year
-        , subq_3.booking__ds__extract_year
-        , subq_3.booking__ds__extract_quarter
-        , subq_3.booking__ds__extract_month
-        , subq_3.booking__ds__extract_day
-        , subq_3.booking__ds__extract_dow
-        , subq_3.booking__ds__extract_doy
-        , subq_3.booking__ds_partitioned__day
-        , subq_3.booking__ds_partitioned__week
-        , subq_3.booking__ds_partitioned__month
-        , subq_3.booking__ds_partitioned__quarter
-        , subq_3.booking__ds_partitioned__year
-        , subq_3.booking__ds_partitioned__extract_year
-        , subq_3.booking__ds_partitioned__extract_quarter
-        , subq_3.booking__ds_partitioned__extract_month
-        , subq_3.booking__ds_partitioned__extract_day
-        , subq_3.booking__ds_partitioned__extract_dow
-        , subq_3.booking__ds_partitioned__extract_doy
-        , subq_3.booking__paid_at__day
-        , subq_3.booking__paid_at__week
-        , subq_3.booking__paid_at__month
-        , subq_3.booking__paid_at__quarter
-        , subq_3.booking__paid_at__year
-        , subq_3.booking__paid_at__extract_year
-        , subq_3.booking__paid_at__extract_quarter
-        , subq_3.booking__paid_at__extract_month
-        , subq_3.booking__paid_at__extract_day
-        , subq_3.booking__paid_at__extract_dow
-        , subq_3.booking__paid_at__extract_doy
-        , subq_3.metric_time__day
-        , subq_3.metric_time__week
-        , subq_3.metric_time__month
-        , subq_3.metric_time__quarter
-        , subq_3.metric_time__year
-        , subq_3.metric_time__extract_year
-        , subq_3.metric_time__extract_quarter
-        , subq_3.metric_time__extract_month
-        , subq_3.metric_time__extract_day
-        , subq_3.metric_time__extract_dow
-        , subq_3.metric_time__extract_doy
-        , subq_3.listing
-        , subq_3.guest
-        , subq_3.host
-        , subq_3.booking__listing
-        , subq_3.booking__guest
-        , subq_3.booking__host
-        , subq_3.is_instant
-        , subq_3.booking__is_instant
-        , subq_3.bookings
-        , subq_3.instant_bookings
-        , subq_3.booking_value
-        , subq_3.max_booking_value
-        , subq_3.min_booking_value
-        , subq_3.bookers
-        , subq_3.average_booking_value
-        , subq_3.referred_bookings
-        , subq_3.median_booking_value
-        , subq_3.booking_value_p99
-        , subq_3.discrete_booking_value_p99
-        , subq_3.approximate_continuous_booking_value_p99
-        , subq_3.approximate_discrete_booking_value_p99
+        subq_1.ds__day
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.ds__extract_year
+        , subq_1.ds__extract_quarter
+        , subq_1.ds__extract_month
+        , subq_1.ds__extract_day
+        , subq_1.ds__extract_dow
+        , subq_1.ds__extract_doy
+        , subq_1.ds_partitioned__day
+        , subq_1.ds_partitioned__week
+        , subq_1.ds_partitioned__month
+        , subq_1.ds_partitioned__quarter
+        , subq_1.ds_partitioned__year
+        , subq_1.ds_partitioned__extract_year
+        , subq_1.ds_partitioned__extract_quarter
+        , subq_1.ds_partitioned__extract_month
+        , subq_1.ds_partitioned__extract_day
+        , subq_1.ds_partitioned__extract_dow
+        , subq_1.ds_partitioned__extract_doy
+        , subq_1.paid_at__day
+        , subq_1.paid_at__week
+        , subq_1.paid_at__month
+        , subq_1.paid_at__quarter
+        , subq_1.paid_at__year
+        , subq_1.paid_at__extract_year
+        , subq_1.paid_at__extract_quarter
+        , subq_1.paid_at__extract_month
+        , subq_1.paid_at__extract_day
+        , subq_1.paid_at__extract_dow
+        , subq_1.paid_at__extract_doy
+        , subq_1.booking__ds__day
+        , subq_1.booking__ds__week
+        , subq_1.booking__ds__month
+        , subq_1.booking__ds__quarter
+        , subq_1.booking__ds__year
+        , subq_1.booking__ds__extract_year
+        , subq_1.booking__ds__extract_quarter
+        , subq_1.booking__ds__extract_month
+        , subq_1.booking__ds__extract_day
+        , subq_1.booking__ds__extract_dow
+        , subq_1.booking__ds__extract_doy
+        , subq_1.booking__ds_partitioned__day
+        , subq_1.booking__ds_partitioned__week
+        , subq_1.booking__ds_partitioned__month
+        , subq_1.booking__ds_partitioned__quarter
+        , subq_1.booking__ds_partitioned__year
+        , subq_1.booking__ds_partitioned__extract_year
+        , subq_1.booking__ds_partitioned__extract_quarter
+        , subq_1.booking__ds_partitioned__extract_month
+        , subq_1.booking__ds_partitioned__extract_day
+        , subq_1.booking__ds_partitioned__extract_dow
+        , subq_1.booking__ds_partitioned__extract_doy
+        , subq_1.booking__paid_at__day
+        , subq_1.booking__paid_at__week
+        , subq_1.booking__paid_at__month
+        , subq_1.booking__paid_at__quarter
+        , subq_1.booking__paid_at__year
+        , subq_1.booking__paid_at__extract_year
+        , subq_1.booking__paid_at__extract_quarter
+        , subq_1.booking__paid_at__extract_month
+        , subq_1.booking__paid_at__extract_day
+        , subq_1.booking__paid_at__extract_dow
+        , subq_1.booking__paid_at__extract_doy
+        , subq_1.metric_time__day
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.metric_time__extract_year
+        , subq_1.metric_time__extract_quarter
+        , subq_1.metric_time__extract_month
+        , subq_1.metric_time__extract_day
+        , subq_1.metric_time__extract_dow
+        , subq_1.metric_time__extract_doy
+        , subq_1.listing
+        , subq_1.guest
+        , subq_1.host
+        , subq_1.booking__listing
+        , subq_1.booking__guest
+        , subq_1.booking__host
+        , subq_1.is_instant
+        , subq_1.booking__is_instant
+        , subq_1.bookings
+        , subq_1.instant_bookings
+        , subq_1.booking_value
+        , subq_1.max_booking_value
+        , subq_1.min_booking_value
+        , subq_1.bookers
+        , subq_1.average_booking_value
+        , subq_1.referred_bookings
+        , subq_1.median_booking_value
+        , subq_1.booking_value_p99
+        , subq_1.discrete_booking_value_p99
+        , subq_1.approximate_continuous_booking_value_p99
+        , subq_1.approximate_discrete_booking_value_p99
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_2.ds__day
-          , subq_2.ds__week
-          , subq_2.ds__month
-          , subq_2.ds__quarter
-          , subq_2.ds__year
-          , subq_2.ds__extract_year
-          , subq_2.ds__extract_quarter
-          , subq_2.ds__extract_month
-          , subq_2.ds__extract_day
-          , subq_2.ds__extract_dow
-          , subq_2.ds__extract_doy
-          , subq_2.ds_partitioned__day
-          , subq_2.ds_partitioned__week
-          , subq_2.ds_partitioned__month
-          , subq_2.ds_partitioned__quarter
-          , subq_2.ds_partitioned__year
-          , subq_2.ds_partitioned__extract_year
-          , subq_2.ds_partitioned__extract_quarter
-          , subq_2.ds_partitioned__extract_month
-          , subq_2.ds_partitioned__extract_day
-          , subq_2.ds_partitioned__extract_dow
-          , subq_2.ds_partitioned__extract_doy
-          , subq_2.paid_at__day
-          , subq_2.paid_at__week
-          , subq_2.paid_at__month
-          , subq_2.paid_at__quarter
-          , subq_2.paid_at__year
-          , subq_2.paid_at__extract_year
-          , subq_2.paid_at__extract_quarter
-          , subq_2.paid_at__extract_month
-          , subq_2.paid_at__extract_day
-          , subq_2.paid_at__extract_dow
-          , subq_2.paid_at__extract_doy
-          , subq_2.booking__ds__day
-          , subq_2.booking__ds__week
-          , subq_2.booking__ds__month
-          , subq_2.booking__ds__quarter
-          , subq_2.booking__ds__year
-          , subq_2.booking__ds__extract_year
-          , subq_2.booking__ds__extract_quarter
-          , subq_2.booking__ds__extract_month
-          , subq_2.booking__ds__extract_day
-          , subq_2.booking__ds__extract_dow
-          , subq_2.booking__ds__extract_doy
-          , subq_2.booking__ds_partitioned__day
-          , subq_2.booking__ds_partitioned__week
-          , subq_2.booking__ds_partitioned__month
-          , subq_2.booking__ds_partitioned__quarter
-          , subq_2.booking__ds_partitioned__year
-          , subq_2.booking__ds_partitioned__extract_year
-          , subq_2.booking__ds_partitioned__extract_quarter
-          , subq_2.booking__ds_partitioned__extract_month
-          , subq_2.booking__ds_partitioned__extract_day
-          , subq_2.booking__ds_partitioned__extract_dow
-          , subq_2.booking__ds_partitioned__extract_doy
-          , subq_2.booking__paid_at__day
-          , subq_2.booking__paid_at__week
-          , subq_2.booking__paid_at__month
-          , subq_2.booking__paid_at__quarter
-          , subq_2.booking__paid_at__year
-          , subq_2.booking__paid_at__extract_year
-          , subq_2.booking__paid_at__extract_quarter
-          , subq_2.booking__paid_at__extract_month
-          , subq_2.booking__paid_at__extract_day
-          , subq_2.booking__paid_at__extract_dow
-          , subq_2.booking__paid_at__extract_doy
-          , subq_2.ds__day AS metric_time__day
-          , subq_2.ds__week AS metric_time__week
-          , subq_2.ds__month AS metric_time__month
-          , subq_2.ds__quarter AS metric_time__quarter
-          , subq_2.ds__year AS metric_time__year
-          , subq_2.ds__extract_year AS metric_time__extract_year
-          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_2.ds__extract_month AS metric_time__extract_month
-          , subq_2.ds__extract_day AS metric_time__extract_day
-          , subq_2.ds__extract_dow AS metric_time__extract_dow
-          , subq_2.ds__extract_doy AS metric_time__extract_doy
-          , subq_2.listing
-          , subq_2.guest
-          , subq_2.host
-          , subq_2.booking__listing
-          , subq_2.booking__guest
-          , subq_2.booking__host
-          , subq_2.is_instant
-          , subq_2.booking__is_instant
-          , subq_2.bookings
-          , subq_2.instant_bookings
-          , subq_2.booking_value
-          , subq_2.max_booking_value
-          , subq_2.min_booking_value
-          , subq_2.bookers
-          , subq_2.average_booking_value
-          , subq_2.referred_bookings
-          , subq_2.median_booking_value
-          , subq_2.booking_value_p99
-          , subq_2.discrete_booking_value_p99
-          , subq_2.approximate_continuous_booking_value_p99
-          , subq_2.approximate_discrete_booking_value_p99
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.ds_partitioned__day
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.ds_partitioned__extract_year
+          , subq_0.ds_partitioned__extract_quarter
+          , subq_0.ds_partitioned__extract_month
+          , subq_0.ds_partitioned__extract_day
+          , subq_0.ds_partitioned__extract_dow
+          , subq_0.ds_partitioned__extract_doy
+          , subq_0.paid_at__day
+          , subq_0.paid_at__week
+          , subq_0.paid_at__month
+          , subq_0.paid_at__quarter
+          , subq_0.paid_at__year
+          , subq_0.paid_at__extract_year
+          , subq_0.paid_at__extract_quarter
+          , subq_0.paid_at__extract_month
+          , subq_0.paid_at__extract_day
+          , subq_0.paid_at__extract_dow
+          , subq_0.paid_at__extract_doy
+          , subq_0.booking__ds__day
+          , subq_0.booking__ds__week
+          , subq_0.booking__ds__month
+          , subq_0.booking__ds__quarter
+          , subq_0.booking__ds__year
+          , subq_0.booking__ds__extract_year
+          , subq_0.booking__ds__extract_quarter
+          , subq_0.booking__ds__extract_month
+          , subq_0.booking__ds__extract_day
+          , subq_0.booking__ds__extract_dow
+          , subq_0.booking__ds__extract_doy
+          , subq_0.booking__ds_partitioned__day
+          , subq_0.booking__ds_partitioned__week
+          , subq_0.booking__ds_partitioned__month
+          , subq_0.booking__ds_partitioned__quarter
+          , subq_0.booking__ds_partitioned__year
+          , subq_0.booking__ds_partitioned__extract_year
+          , subq_0.booking__ds_partitioned__extract_quarter
+          , subq_0.booking__ds_partitioned__extract_month
+          , subq_0.booking__ds_partitioned__extract_day
+          , subq_0.booking__ds_partitioned__extract_dow
+          , subq_0.booking__ds_partitioned__extract_doy
+          , subq_0.booking__paid_at__day
+          , subq_0.booking__paid_at__week
+          , subq_0.booking__paid_at__month
+          , subq_0.booking__paid_at__quarter
+          , subq_0.booking__paid_at__year
+          , subq_0.booking__paid_at__extract_year
+          , subq_0.booking__paid_at__extract_quarter
+          , subq_0.booking__paid_at__extract_month
+          , subq_0.booking__paid_at__extract_day
+          , subq_0.booking__paid_at__extract_dow
+          , subq_0.booking__paid_at__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.booking__listing
+          , subq_0.booking__guest
+          , subq_0.booking__host
+          , subq_0.is_instant
+          , subq_0.booking__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
+          , subq_0.referred_bookings
+          , subq_0.median_booking_value
+          , subq_0.booking_value_p99
+          , subq_0.discrete_booking_value_p99
+          , subq_0.approximate_continuous_booking_value_p99
+          , subq_0.approximate_discrete_booking_value_p99
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
           SELECT
@@ -303,9 +303,9 @@ FROM (
             , bookings_source_src_28000.guest_id AS booking__guest
             , bookings_source_src_28000.host_id AS booking__host
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_2
-      ) subq_3
-      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_4
-  ) subq_5
-) subq_6
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_2
+  ) subq_3
+) subq_4

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_13
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings AS bookings
+    subq_7.metric_time__day AS metric_time__day
+    , subq_6.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-  ) subq_9
+      subq_8.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_8
+  ) subq_7
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -329,17 +329,17 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day
+  ) subq_6
   ON
-    subq_9.metric_time__day = subq_8.metric_time__day
-) subq_11
+    subq_7.metric_time__day = subq_6.metric_time__day
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_22.ds AS metric_time__day
-    , subq_20.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_22
+    subq_18.ds AS metric_time__day
+    , subq_16.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_18
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_11
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_16
   ON
-    subq_22.ds = subq_20.metric_time__day
-) subq_23
+    subq_18.ds = subq_16.metric_time__day
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , subq_11.booking__is_instant
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , subq_9.booking__is_instant
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_10.metric_time__day
-    , subq_10.booking__is_instant
-    , subq_10.bookings
+    subq_8.metric_time__day
+    , subq_8.booking__is_instant
+    , subq_8.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_8.metric_time__day AS metric_time__day
-      , subq_7.booking__is_instant AS booking__is_instant
-      , subq_7.bookings AS bookings
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking__is_instant AS booking__is_instant
+      , subq_5.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_9.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_9
-    ) subq_8
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-        , SUM(subq_6.bookings) AS bookings
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+        , SUM(subq_4.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -333,19 +333,19 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
+      ) subq_4
       GROUP BY
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-    ) subq_7
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+    ) subq_5
     ON
-      subq_8.metric_time__day = subq_7.metric_time__day
-  ) subq_10
+      subq_6.metric_time__day = subq_5.metric_time__day
+  ) subq_8
   WHERE booking__is_instant
-) subq_11
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.ds AS metric_time__day
-      , subq_19.booking__is_instant AS booking__is_instant
-      , subq_19.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_21
+      subq_17.ds AS metric_time__day
+      , subq_15.booking__is_instant AS booking__is_instant
+      , subq_15.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_15
+        ) subq_11
         WHERE booking__is_instant
-      ) subq_17
+      ) subq_13
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_19
+    ) subq_15
     ON
-      subq_21.ds = subq_19.metric_time__day
-  ) subq_22
+      subq_17.ds = subq_15.metric_time__day
+  ) subq_18
   WHERE booking__is_instant
-) subq_23
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_9.metric_time__day
-    , subq_9.bookings
+    subq_7.metric_time__day
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_7.metric_time__day AS metric_time__day
-      , subq_6.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_8.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_8
-      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_7
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+      WHERE subq_6.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.bookings) AS bookings
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.bookings
+          subq_2.metric_time__day
+          , subq_2.bookings
         FROM (
           -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.max_booking_value
-            , subq_3.min_booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
-            , subq_3.referred_bookings
-            , subq_3.median_booking_value
-            , subq_3.booking_value_p99
-            , subq_3.discrete_booking_value_p99
-            , subq_3.approximate_continuous_booking_value_p99
-            , subq_3.approximate_discrete_booking_value_p99
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.ds_partitioned__day
+            , subq_1.ds_partitioned__week
+            , subq_1.ds_partitioned__month
+            , subq_1.ds_partitioned__quarter
+            , subq_1.ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy
+            , subq_1.paid_at__day
+            , subq_1.paid_at__week
+            , subq_1.paid_at__month
+            , subq_1.paid_at__quarter
+            , subq_1.paid_at__year
+            , subq_1.paid_at__extract_year
+            , subq_1.paid_at__extract_quarter
+            , subq_1.paid_at__extract_month
+            , subq_1.paid_at__extract_day
+            , subq_1.paid_at__extract_dow
+            , subq_1.paid_at__extract_doy
+            , subq_1.booking__ds__day
+            , subq_1.booking__ds__week
+            , subq_1.booking__ds__month
+            , subq_1.booking__ds__quarter
+            , subq_1.booking__ds__year
+            , subq_1.booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month
+            , subq_1.booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day
+            , subq_1.booking__paid_at__week
+            , subq_1.booking__paid_at__month
+            , subq_1.booking__paid_at__quarter
+            , subq_1.booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.listing
+            , subq_1.guest
+            , subq_1.host
+            , subq_1.booking__listing
+            , subq_1.booking__guest
+            , subq_1.booking__host
+            , subq_1.is_instant
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+            , subq_1.instant_bookings
+            , subq_1.booking_value
+            , subq_1.max_booking_value
+            , subq_1.min_booking_value
+            , subq_1.bookers
+            , subq_1.average_booking_value
+            , subq_1.referred_bookings
+            , subq_1.median_booking_value
+            , subq_1.booking_value_p99
+            , subq_1.discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.ds_partitioned__day
-              , subq_2.ds_partitioned__week
-              , subq_2.ds_partitioned__month
-              , subq_2.ds_partitioned__quarter
-              , subq_2.ds_partitioned__year
-              , subq_2.ds_partitioned__extract_year
-              , subq_2.ds_partitioned__extract_quarter
-              , subq_2.ds_partitioned__extract_month
-              , subq_2.ds_partitioned__extract_day
-              , subq_2.ds_partitioned__extract_dow
-              , subq_2.ds_partitioned__extract_doy
-              , subq_2.paid_at__day
-              , subq_2.paid_at__week
-              , subq_2.paid_at__month
-              , subq_2.paid_at__quarter
-              , subq_2.paid_at__year
-              , subq_2.paid_at__extract_year
-              , subq_2.paid_at__extract_quarter
-              , subq_2.paid_at__extract_month
-              , subq_2.paid_at__extract_day
-              , subq_2.paid_at__extract_dow
-              , subq_2.paid_at__extract_doy
-              , subq_2.booking__ds__day
-              , subq_2.booking__ds__week
-              , subq_2.booking__ds__month
-              , subq_2.booking__ds__quarter
-              , subq_2.booking__ds__year
-              , subq_2.booking__ds__extract_year
-              , subq_2.booking__ds__extract_quarter
-              , subq_2.booking__ds__extract_month
-              , subq_2.booking__ds__extract_day
-              , subq_2.booking__ds__extract_dow
-              , subq_2.booking__ds__extract_doy
-              , subq_2.booking__ds_partitioned__day
-              , subq_2.booking__ds_partitioned__week
-              , subq_2.booking__ds_partitioned__month
-              , subq_2.booking__ds_partitioned__quarter
-              , subq_2.booking__ds_partitioned__year
-              , subq_2.booking__ds_partitioned__extract_year
-              , subq_2.booking__ds_partitioned__extract_quarter
-              , subq_2.booking__ds_partitioned__extract_month
-              , subq_2.booking__ds_partitioned__extract_day
-              , subq_2.booking__ds_partitioned__extract_dow
-              , subq_2.booking__ds_partitioned__extract_doy
-              , subq_2.booking__paid_at__day
-              , subq_2.booking__paid_at__week
-              , subq_2.booking__paid_at__month
-              , subq_2.booking__paid_at__quarter
-              , subq_2.booking__paid_at__year
-              , subq_2.booking__paid_at__extract_year
-              , subq_2.booking__paid_at__extract_quarter
-              , subq_2.booking__paid_at__extract_month
-              , subq_2.booking__paid_at__extract_day
-              , subq_2.booking__paid_at__extract_dow
-              , subq_2.booking__paid_at__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.listing
-              , subq_2.guest
-              , subq_2.host
-              , subq_2.booking__listing
-              , subq_2.booking__guest
-              , subq_2.booking__host
-              , subq_2.is_instant
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-              , subq_2.instant_bookings
-              , subq_2.booking_value
-              , subq_2.max_booking_value
-              , subq_2.min_booking_value
-              , subq_2.bookers
-              , subq_2.average_booking_value
-              , subq_2.referred_bookings
-              , subq_2.median_booking_value
-              , subq_2.booking_value_p99
-              , subq_2.discrete_booking_value_p99
-              , subq_2.approximate_continuous_booking_value_p99
-              , subq_2.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
               -- Read Elements From Semantic Model 'bookings_source'
               SELECT
@@ -323,16 +323,16 @@ FROM (
                 , bookings_source_src_28000.guest_id AS booking__guest
                 , bookings_source_src_28000.host_id AS booking__host
               FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-        ) subq_4
-      ) subq_5
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_2
+      ) subq_3
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
+        subq_3.metric_time__day
+    ) subq_4
     ON
-      subq_7.metric_time__day = subq_6.metric_time__day
-  ) subq_9
-  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_10
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE subq_7.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_18.metric_time__day AS metric_time__day
-    , subq_17.bookings AS bookings
+    subq_14.metric_time__day AS metric_time__day
+    , subq_13.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_19
+    FROM ***************************.mf_time_spine subq_15
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_16
+    ) subq_12
     GROUP BY
       metric_time__day
-  ) subq_17
+  ) subq_13
   ON
-    subq_18.metric_time__day = subq_17.metric_time__day
-  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_21
+    subq_14.metric_time__day = subq_13.metric_time__day
+  WHERE subq_14.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,216 +1,216 @@
 -- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+  COALESCE(subq_4.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_5.bookings) AS bookings
+    SUM(subq_3.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings',]
     SELECT
-      subq_4.bookings
+      subq_2.bookings
     FROM (
       -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
       SELECT
-        subq_3.ds__day
-        , subq_3.ds__week
-        , subq_3.ds__month
-        , subq_3.ds__quarter
-        , subq_3.ds__year
-        , subq_3.ds__extract_year
-        , subq_3.ds__extract_quarter
-        , subq_3.ds__extract_month
-        , subq_3.ds__extract_day
-        , subq_3.ds__extract_dow
-        , subq_3.ds__extract_doy
-        , subq_3.ds_partitioned__day
-        , subq_3.ds_partitioned__week
-        , subq_3.ds_partitioned__month
-        , subq_3.ds_partitioned__quarter
-        , subq_3.ds_partitioned__year
-        , subq_3.ds_partitioned__extract_year
-        , subq_3.ds_partitioned__extract_quarter
-        , subq_3.ds_partitioned__extract_month
-        , subq_3.ds_partitioned__extract_day
-        , subq_3.ds_partitioned__extract_dow
-        , subq_3.ds_partitioned__extract_doy
-        , subq_3.paid_at__day
-        , subq_3.paid_at__week
-        , subq_3.paid_at__month
-        , subq_3.paid_at__quarter
-        , subq_3.paid_at__year
-        , subq_3.paid_at__extract_year
-        , subq_3.paid_at__extract_quarter
-        , subq_3.paid_at__extract_month
-        , subq_3.paid_at__extract_day
-        , subq_3.paid_at__extract_dow
-        , subq_3.paid_at__extract_doy
-        , subq_3.booking__ds__day
-        , subq_3.booking__ds__week
-        , subq_3.booking__ds__month
-        , subq_3.booking__ds__quarter
-        , subq_3.booking__ds__year
-        , subq_3.booking__ds__extract_year
-        , subq_3.booking__ds__extract_quarter
-        , subq_3.booking__ds__extract_month
-        , subq_3.booking__ds__extract_day
-        , subq_3.booking__ds__extract_dow
-        , subq_3.booking__ds__extract_doy
-        , subq_3.booking__ds_partitioned__day
-        , subq_3.booking__ds_partitioned__week
-        , subq_3.booking__ds_partitioned__month
-        , subq_3.booking__ds_partitioned__quarter
-        , subq_3.booking__ds_partitioned__year
-        , subq_3.booking__ds_partitioned__extract_year
-        , subq_3.booking__ds_partitioned__extract_quarter
-        , subq_3.booking__ds_partitioned__extract_month
-        , subq_3.booking__ds_partitioned__extract_day
-        , subq_3.booking__ds_partitioned__extract_dow
-        , subq_3.booking__ds_partitioned__extract_doy
-        , subq_3.booking__paid_at__day
-        , subq_3.booking__paid_at__week
-        , subq_3.booking__paid_at__month
-        , subq_3.booking__paid_at__quarter
-        , subq_3.booking__paid_at__year
-        , subq_3.booking__paid_at__extract_year
-        , subq_3.booking__paid_at__extract_quarter
-        , subq_3.booking__paid_at__extract_month
-        , subq_3.booking__paid_at__extract_day
-        , subq_3.booking__paid_at__extract_dow
-        , subq_3.booking__paid_at__extract_doy
-        , subq_3.metric_time__day
-        , subq_3.metric_time__week
-        , subq_3.metric_time__month
-        , subq_3.metric_time__quarter
-        , subq_3.metric_time__year
-        , subq_3.metric_time__extract_year
-        , subq_3.metric_time__extract_quarter
-        , subq_3.metric_time__extract_month
-        , subq_3.metric_time__extract_day
-        , subq_3.metric_time__extract_dow
-        , subq_3.metric_time__extract_doy
-        , subq_3.listing
-        , subq_3.guest
-        , subq_3.host
-        , subq_3.booking__listing
-        , subq_3.booking__guest
-        , subq_3.booking__host
-        , subq_3.is_instant
-        , subq_3.booking__is_instant
-        , subq_3.bookings
-        , subq_3.instant_bookings
-        , subq_3.booking_value
-        , subq_3.max_booking_value
-        , subq_3.min_booking_value
-        , subq_3.bookers
-        , subq_3.average_booking_value
-        , subq_3.referred_bookings
-        , subq_3.median_booking_value
-        , subq_3.booking_value_p99
-        , subq_3.discrete_booking_value_p99
-        , subq_3.approximate_continuous_booking_value_p99
-        , subq_3.approximate_discrete_booking_value_p99
+        subq_1.ds__day
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.ds__extract_year
+        , subq_1.ds__extract_quarter
+        , subq_1.ds__extract_month
+        , subq_1.ds__extract_day
+        , subq_1.ds__extract_dow
+        , subq_1.ds__extract_doy
+        , subq_1.ds_partitioned__day
+        , subq_1.ds_partitioned__week
+        , subq_1.ds_partitioned__month
+        , subq_1.ds_partitioned__quarter
+        , subq_1.ds_partitioned__year
+        , subq_1.ds_partitioned__extract_year
+        , subq_1.ds_partitioned__extract_quarter
+        , subq_1.ds_partitioned__extract_month
+        , subq_1.ds_partitioned__extract_day
+        , subq_1.ds_partitioned__extract_dow
+        , subq_1.ds_partitioned__extract_doy
+        , subq_1.paid_at__day
+        , subq_1.paid_at__week
+        , subq_1.paid_at__month
+        , subq_1.paid_at__quarter
+        , subq_1.paid_at__year
+        , subq_1.paid_at__extract_year
+        , subq_1.paid_at__extract_quarter
+        , subq_1.paid_at__extract_month
+        , subq_1.paid_at__extract_day
+        , subq_1.paid_at__extract_dow
+        , subq_1.paid_at__extract_doy
+        , subq_1.booking__ds__day
+        , subq_1.booking__ds__week
+        , subq_1.booking__ds__month
+        , subq_1.booking__ds__quarter
+        , subq_1.booking__ds__year
+        , subq_1.booking__ds__extract_year
+        , subq_1.booking__ds__extract_quarter
+        , subq_1.booking__ds__extract_month
+        , subq_1.booking__ds__extract_day
+        , subq_1.booking__ds__extract_dow
+        , subq_1.booking__ds__extract_doy
+        , subq_1.booking__ds_partitioned__day
+        , subq_1.booking__ds_partitioned__week
+        , subq_1.booking__ds_partitioned__month
+        , subq_1.booking__ds_partitioned__quarter
+        , subq_1.booking__ds_partitioned__year
+        , subq_1.booking__ds_partitioned__extract_year
+        , subq_1.booking__ds_partitioned__extract_quarter
+        , subq_1.booking__ds_partitioned__extract_month
+        , subq_1.booking__ds_partitioned__extract_day
+        , subq_1.booking__ds_partitioned__extract_dow
+        , subq_1.booking__ds_partitioned__extract_doy
+        , subq_1.booking__paid_at__day
+        , subq_1.booking__paid_at__week
+        , subq_1.booking__paid_at__month
+        , subq_1.booking__paid_at__quarter
+        , subq_1.booking__paid_at__year
+        , subq_1.booking__paid_at__extract_year
+        , subq_1.booking__paid_at__extract_quarter
+        , subq_1.booking__paid_at__extract_month
+        , subq_1.booking__paid_at__extract_day
+        , subq_1.booking__paid_at__extract_dow
+        , subq_1.booking__paid_at__extract_doy
+        , subq_1.metric_time__day
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.metric_time__extract_year
+        , subq_1.metric_time__extract_quarter
+        , subq_1.metric_time__extract_month
+        , subq_1.metric_time__extract_day
+        , subq_1.metric_time__extract_dow
+        , subq_1.metric_time__extract_doy
+        , subq_1.listing
+        , subq_1.guest
+        , subq_1.host
+        , subq_1.booking__listing
+        , subq_1.booking__guest
+        , subq_1.booking__host
+        , subq_1.is_instant
+        , subq_1.booking__is_instant
+        , subq_1.bookings
+        , subq_1.instant_bookings
+        , subq_1.booking_value
+        , subq_1.max_booking_value
+        , subq_1.min_booking_value
+        , subq_1.bookers
+        , subq_1.average_booking_value
+        , subq_1.referred_bookings
+        , subq_1.median_booking_value
+        , subq_1.booking_value_p99
+        , subq_1.discrete_booking_value_p99
+        , subq_1.approximate_continuous_booking_value_p99
+        , subq_1.approximate_discrete_booking_value_p99
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_2.ds__day
-          , subq_2.ds__week
-          , subq_2.ds__month
-          , subq_2.ds__quarter
-          , subq_2.ds__year
-          , subq_2.ds__extract_year
-          , subq_2.ds__extract_quarter
-          , subq_2.ds__extract_month
-          , subq_2.ds__extract_day
-          , subq_2.ds__extract_dow
-          , subq_2.ds__extract_doy
-          , subq_2.ds_partitioned__day
-          , subq_2.ds_partitioned__week
-          , subq_2.ds_partitioned__month
-          , subq_2.ds_partitioned__quarter
-          , subq_2.ds_partitioned__year
-          , subq_2.ds_partitioned__extract_year
-          , subq_2.ds_partitioned__extract_quarter
-          , subq_2.ds_partitioned__extract_month
-          , subq_2.ds_partitioned__extract_day
-          , subq_2.ds_partitioned__extract_dow
-          , subq_2.ds_partitioned__extract_doy
-          , subq_2.paid_at__day
-          , subq_2.paid_at__week
-          , subq_2.paid_at__month
-          , subq_2.paid_at__quarter
-          , subq_2.paid_at__year
-          , subq_2.paid_at__extract_year
-          , subq_2.paid_at__extract_quarter
-          , subq_2.paid_at__extract_month
-          , subq_2.paid_at__extract_day
-          , subq_2.paid_at__extract_dow
-          , subq_2.paid_at__extract_doy
-          , subq_2.booking__ds__day
-          , subq_2.booking__ds__week
-          , subq_2.booking__ds__month
-          , subq_2.booking__ds__quarter
-          , subq_2.booking__ds__year
-          , subq_2.booking__ds__extract_year
-          , subq_2.booking__ds__extract_quarter
-          , subq_2.booking__ds__extract_month
-          , subq_2.booking__ds__extract_day
-          , subq_2.booking__ds__extract_dow
-          , subq_2.booking__ds__extract_doy
-          , subq_2.booking__ds_partitioned__day
-          , subq_2.booking__ds_partitioned__week
-          , subq_2.booking__ds_partitioned__month
-          , subq_2.booking__ds_partitioned__quarter
-          , subq_2.booking__ds_partitioned__year
-          , subq_2.booking__ds_partitioned__extract_year
-          , subq_2.booking__ds_partitioned__extract_quarter
-          , subq_2.booking__ds_partitioned__extract_month
-          , subq_2.booking__ds_partitioned__extract_day
-          , subq_2.booking__ds_partitioned__extract_dow
-          , subq_2.booking__ds_partitioned__extract_doy
-          , subq_2.booking__paid_at__day
-          , subq_2.booking__paid_at__week
-          , subq_2.booking__paid_at__month
-          , subq_2.booking__paid_at__quarter
-          , subq_2.booking__paid_at__year
-          , subq_2.booking__paid_at__extract_year
-          , subq_2.booking__paid_at__extract_quarter
-          , subq_2.booking__paid_at__extract_month
-          , subq_2.booking__paid_at__extract_day
-          , subq_2.booking__paid_at__extract_dow
-          , subq_2.booking__paid_at__extract_doy
-          , subq_2.ds__day AS metric_time__day
-          , subq_2.ds__week AS metric_time__week
-          , subq_2.ds__month AS metric_time__month
-          , subq_2.ds__quarter AS metric_time__quarter
-          , subq_2.ds__year AS metric_time__year
-          , subq_2.ds__extract_year AS metric_time__extract_year
-          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_2.ds__extract_month AS metric_time__extract_month
-          , subq_2.ds__extract_day AS metric_time__extract_day
-          , subq_2.ds__extract_dow AS metric_time__extract_dow
-          , subq_2.ds__extract_doy AS metric_time__extract_doy
-          , subq_2.listing
-          , subq_2.guest
-          , subq_2.host
-          , subq_2.booking__listing
-          , subq_2.booking__guest
-          , subq_2.booking__host
-          , subq_2.is_instant
-          , subq_2.booking__is_instant
-          , subq_2.bookings
-          , subq_2.instant_bookings
-          , subq_2.booking_value
-          , subq_2.max_booking_value
-          , subq_2.min_booking_value
-          , subq_2.bookers
-          , subq_2.average_booking_value
-          , subq_2.referred_bookings
-          , subq_2.median_booking_value
-          , subq_2.booking_value_p99
-          , subq_2.discrete_booking_value_p99
-          , subq_2.approximate_continuous_booking_value_p99
-          , subq_2.approximate_discrete_booking_value_p99
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.ds_partitioned__day
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.ds_partitioned__extract_year
+          , subq_0.ds_partitioned__extract_quarter
+          , subq_0.ds_partitioned__extract_month
+          , subq_0.ds_partitioned__extract_day
+          , subq_0.ds_partitioned__extract_dow
+          , subq_0.ds_partitioned__extract_doy
+          , subq_0.paid_at__day
+          , subq_0.paid_at__week
+          , subq_0.paid_at__month
+          , subq_0.paid_at__quarter
+          , subq_0.paid_at__year
+          , subq_0.paid_at__extract_year
+          , subq_0.paid_at__extract_quarter
+          , subq_0.paid_at__extract_month
+          , subq_0.paid_at__extract_day
+          , subq_0.paid_at__extract_dow
+          , subq_0.paid_at__extract_doy
+          , subq_0.booking__ds__day
+          , subq_0.booking__ds__week
+          , subq_0.booking__ds__month
+          , subq_0.booking__ds__quarter
+          , subq_0.booking__ds__year
+          , subq_0.booking__ds__extract_year
+          , subq_0.booking__ds__extract_quarter
+          , subq_0.booking__ds__extract_month
+          , subq_0.booking__ds__extract_day
+          , subq_0.booking__ds__extract_dow
+          , subq_0.booking__ds__extract_doy
+          , subq_0.booking__ds_partitioned__day
+          , subq_0.booking__ds_partitioned__week
+          , subq_0.booking__ds_partitioned__month
+          , subq_0.booking__ds_partitioned__quarter
+          , subq_0.booking__ds_partitioned__year
+          , subq_0.booking__ds_partitioned__extract_year
+          , subq_0.booking__ds_partitioned__extract_quarter
+          , subq_0.booking__ds_partitioned__extract_month
+          , subq_0.booking__ds_partitioned__extract_day
+          , subq_0.booking__ds_partitioned__extract_dow
+          , subq_0.booking__ds_partitioned__extract_doy
+          , subq_0.booking__paid_at__day
+          , subq_0.booking__paid_at__week
+          , subq_0.booking__paid_at__month
+          , subq_0.booking__paid_at__quarter
+          , subq_0.booking__paid_at__year
+          , subq_0.booking__paid_at__extract_year
+          , subq_0.booking__paid_at__extract_quarter
+          , subq_0.booking__paid_at__extract_month
+          , subq_0.booking__paid_at__extract_day
+          , subq_0.booking__paid_at__extract_dow
+          , subq_0.booking__paid_at__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.booking__listing
+          , subq_0.booking__guest
+          , subq_0.booking__host
+          , subq_0.is_instant
+          , subq_0.booking__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
+          , subq_0.referred_bookings
+          , subq_0.median_booking_value
+          , subq_0.booking_value_p99
+          , subq_0.discrete_booking_value_p99
+          , subq_0.approximate_continuous_booking_value_p99
+          , subq_0.approximate_discrete_booking_value_p99
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
           SELECT
@@ -303,9 +303,9 @@ FROM (
             , bookings_source_src_28000.guest_id AS booking__guest
             , bookings_source_src_28000.host_id AS booking__host
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_2
-      ) subq_3
-      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_4
-  ) subq_5
-) subq_6
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_2
+  ) subq_3
+) subq_4

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_13
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings AS bookings
+    subq_7.metric_time__day AS metric_time__day
+    , subq_6.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-  ) subq_9
+      subq_8.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_8
+  ) subq_7
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -329,17 +329,17 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day
+  ) subq_6
   ON
-    subq_9.metric_time__day = subq_8.metric_time__day
-) subq_11
+    subq_7.metric_time__day = subq_6.metric_time__day
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_22.ds AS metric_time__day
-    , subq_20.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_22
+    subq_18.ds AS metric_time__day
+    , subq_16.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_18
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_11
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_16
   ON
-    subq_22.ds = subq_20.metric_time__day
-) subq_23
+    subq_18.ds = subq_16.metric_time__day
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , subq_11.booking__is_instant
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , subq_9.booking__is_instant
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_10.metric_time__day
-    , subq_10.booking__is_instant
-    , subq_10.bookings
+    subq_8.metric_time__day
+    , subq_8.booking__is_instant
+    , subq_8.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_8.metric_time__day AS metric_time__day
-      , subq_7.booking__is_instant AS booking__is_instant
-      , subq_7.bookings AS bookings
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking__is_instant AS booking__is_instant
+      , subq_5.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_9.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_9
-    ) subq_8
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-        , SUM(subq_6.bookings) AS bookings
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+        , SUM(subq_4.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -333,19 +333,19 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
+      ) subq_4
       GROUP BY
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-    ) subq_7
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+    ) subq_5
     ON
-      subq_8.metric_time__day = subq_7.metric_time__day
-  ) subq_10
+      subq_6.metric_time__day = subq_5.metric_time__day
+  ) subq_8
   WHERE booking__is_instant
-) subq_11
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.ds AS metric_time__day
-      , subq_19.booking__is_instant AS booking__is_instant
-      , subq_19.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_21
+      subq_17.ds AS metric_time__day
+      , subq_15.booking__is_instant AS booking__is_instant
+      , subq_15.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_15
+        ) subq_11
         WHERE booking__is_instant
-      ) subq_17
+      ) subq_13
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_19
+    ) subq_15
     ON
-      subq_21.ds = subq_19.metric_time__day
-  ) subq_22
+      subq_17.ds = subq_15.metric_time__day
+  ) subq_18
   WHERE booking__is_instant
-) subq_23
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_9.metric_time__day
-    , subq_9.bookings
+    subq_7.metric_time__day
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_7.metric_time__day AS metric_time__day
-      , subq_6.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_8.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_8
-      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_7
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+      WHERE subq_6.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.bookings) AS bookings
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.bookings
+          subq_2.metric_time__day
+          , subq_2.bookings
         FROM (
           -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.max_booking_value
-            , subq_3.min_booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
-            , subq_3.referred_bookings
-            , subq_3.median_booking_value
-            , subq_3.booking_value_p99
-            , subq_3.discrete_booking_value_p99
-            , subq_3.approximate_continuous_booking_value_p99
-            , subq_3.approximate_discrete_booking_value_p99
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.ds_partitioned__day
+            , subq_1.ds_partitioned__week
+            , subq_1.ds_partitioned__month
+            , subq_1.ds_partitioned__quarter
+            , subq_1.ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy
+            , subq_1.paid_at__day
+            , subq_1.paid_at__week
+            , subq_1.paid_at__month
+            , subq_1.paid_at__quarter
+            , subq_1.paid_at__year
+            , subq_1.paid_at__extract_year
+            , subq_1.paid_at__extract_quarter
+            , subq_1.paid_at__extract_month
+            , subq_1.paid_at__extract_day
+            , subq_1.paid_at__extract_dow
+            , subq_1.paid_at__extract_doy
+            , subq_1.booking__ds__day
+            , subq_1.booking__ds__week
+            , subq_1.booking__ds__month
+            , subq_1.booking__ds__quarter
+            , subq_1.booking__ds__year
+            , subq_1.booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month
+            , subq_1.booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day
+            , subq_1.booking__paid_at__week
+            , subq_1.booking__paid_at__month
+            , subq_1.booking__paid_at__quarter
+            , subq_1.booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.listing
+            , subq_1.guest
+            , subq_1.host
+            , subq_1.booking__listing
+            , subq_1.booking__guest
+            , subq_1.booking__host
+            , subq_1.is_instant
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+            , subq_1.instant_bookings
+            , subq_1.booking_value
+            , subq_1.max_booking_value
+            , subq_1.min_booking_value
+            , subq_1.bookers
+            , subq_1.average_booking_value
+            , subq_1.referred_bookings
+            , subq_1.median_booking_value
+            , subq_1.booking_value_p99
+            , subq_1.discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.ds_partitioned__day
-              , subq_2.ds_partitioned__week
-              , subq_2.ds_partitioned__month
-              , subq_2.ds_partitioned__quarter
-              , subq_2.ds_partitioned__year
-              , subq_2.ds_partitioned__extract_year
-              , subq_2.ds_partitioned__extract_quarter
-              , subq_2.ds_partitioned__extract_month
-              , subq_2.ds_partitioned__extract_day
-              , subq_2.ds_partitioned__extract_dow
-              , subq_2.ds_partitioned__extract_doy
-              , subq_2.paid_at__day
-              , subq_2.paid_at__week
-              , subq_2.paid_at__month
-              , subq_2.paid_at__quarter
-              , subq_2.paid_at__year
-              , subq_2.paid_at__extract_year
-              , subq_2.paid_at__extract_quarter
-              , subq_2.paid_at__extract_month
-              , subq_2.paid_at__extract_day
-              , subq_2.paid_at__extract_dow
-              , subq_2.paid_at__extract_doy
-              , subq_2.booking__ds__day
-              , subq_2.booking__ds__week
-              , subq_2.booking__ds__month
-              , subq_2.booking__ds__quarter
-              , subq_2.booking__ds__year
-              , subq_2.booking__ds__extract_year
-              , subq_2.booking__ds__extract_quarter
-              , subq_2.booking__ds__extract_month
-              , subq_2.booking__ds__extract_day
-              , subq_2.booking__ds__extract_dow
-              , subq_2.booking__ds__extract_doy
-              , subq_2.booking__ds_partitioned__day
-              , subq_2.booking__ds_partitioned__week
-              , subq_2.booking__ds_partitioned__month
-              , subq_2.booking__ds_partitioned__quarter
-              , subq_2.booking__ds_partitioned__year
-              , subq_2.booking__ds_partitioned__extract_year
-              , subq_2.booking__ds_partitioned__extract_quarter
-              , subq_2.booking__ds_partitioned__extract_month
-              , subq_2.booking__ds_partitioned__extract_day
-              , subq_2.booking__ds_partitioned__extract_dow
-              , subq_2.booking__ds_partitioned__extract_doy
-              , subq_2.booking__paid_at__day
-              , subq_2.booking__paid_at__week
-              , subq_2.booking__paid_at__month
-              , subq_2.booking__paid_at__quarter
-              , subq_2.booking__paid_at__year
-              , subq_2.booking__paid_at__extract_year
-              , subq_2.booking__paid_at__extract_quarter
-              , subq_2.booking__paid_at__extract_month
-              , subq_2.booking__paid_at__extract_day
-              , subq_2.booking__paid_at__extract_dow
-              , subq_2.booking__paid_at__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.listing
-              , subq_2.guest
-              , subq_2.host
-              , subq_2.booking__listing
-              , subq_2.booking__guest
-              , subq_2.booking__host
-              , subq_2.is_instant
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-              , subq_2.instant_bookings
-              , subq_2.booking_value
-              , subq_2.max_booking_value
-              , subq_2.min_booking_value
-              , subq_2.bookers
-              , subq_2.average_booking_value
-              , subq_2.referred_bookings
-              , subq_2.median_booking_value
-              , subq_2.booking_value_p99
-              , subq_2.discrete_booking_value_p99
-              , subq_2.approximate_continuous_booking_value_p99
-              , subq_2.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
               -- Read Elements From Semantic Model 'bookings_source'
               SELECT
@@ -323,16 +323,16 @@ FROM (
                 , bookings_source_src_28000.guest_id AS booking__guest
                 , bookings_source_src_28000.host_id AS booking__host
               FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-        ) subq_4
-      ) subq_5
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_2
+      ) subq_3
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
+        subq_3.metric_time__day
+    ) subq_4
     ON
-      subq_7.metric_time__day = subq_6.metric_time__day
-  ) subq_9
-  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_10
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE subq_7.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_18.metric_time__day AS metric_time__day
-    , subq_17.bookings AS bookings
+    subq_14.metric_time__day AS metric_time__day
+    , subq_13.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_19
+    FROM ***************************.mf_time_spine subq_15
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_16
+    ) subq_12
     GROUP BY
       metric_time__day
-  ) subq_17
+  ) subq_13
   ON
-    subq_18.metric_time__day = subq_17.metric_time__day
-  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_21
+    subq_14.metric_time__day = subq_13.metric_time__day
+  WHERE subq_14.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,216 +1,216 @@
 -- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+  COALESCE(subq_4.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_5.bookings) AS bookings
+    SUM(subq_3.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings',]
     SELECT
-      subq_4.bookings
+      subq_2.bookings
     FROM (
       -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
       SELECT
-        subq_3.ds__day
-        , subq_3.ds__week
-        , subq_3.ds__month
-        , subq_3.ds__quarter
-        , subq_3.ds__year
-        , subq_3.ds__extract_year
-        , subq_3.ds__extract_quarter
-        , subq_3.ds__extract_month
-        , subq_3.ds__extract_day
-        , subq_3.ds__extract_dow
-        , subq_3.ds__extract_doy
-        , subq_3.ds_partitioned__day
-        , subq_3.ds_partitioned__week
-        , subq_3.ds_partitioned__month
-        , subq_3.ds_partitioned__quarter
-        , subq_3.ds_partitioned__year
-        , subq_3.ds_partitioned__extract_year
-        , subq_3.ds_partitioned__extract_quarter
-        , subq_3.ds_partitioned__extract_month
-        , subq_3.ds_partitioned__extract_day
-        , subq_3.ds_partitioned__extract_dow
-        , subq_3.ds_partitioned__extract_doy
-        , subq_3.paid_at__day
-        , subq_3.paid_at__week
-        , subq_3.paid_at__month
-        , subq_3.paid_at__quarter
-        , subq_3.paid_at__year
-        , subq_3.paid_at__extract_year
-        , subq_3.paid_at__extract_quarter
-        , subq_3.paid_at__extract_month
-        , subq_3.paid_at__extract_day
-        , subq_3.paid_at__extract_dow
-        , subq_3.paid_at__extract_doy
-        , subq_3.booking__ds__day
-        , subq_3.booking__ds__week
-        , subq_3.booking__ds__month
-        , subq_3.booking__ds__quarter
-        , subq_3.booking__ds__year
-        , subq_3.booking__ds__extract_year
-        , subq_3.booking__ds__extract_quarter
-        , subq_3.booking__ds__extract_month
-        , subq_3.booking__ds__extract_day
-        , subq_3.booking__ds__extract_dow
-        , subq_3.booking__ds__extract_doy
-        , subq_3.booking__ds_partitioned__day
-        , subq_3.booking__ds_partitioned__week
-        , subq_3.booking__ds_partitioned__month
-        , subq_3.booking__ds_partitioned__quarter
-        , subq_3.booking__ds_partitioned__year
-        , subq_3.booking__ds_partitioned__extract_year
-        , subq_3.booking__ds_partitioned__extract_quarter
-        , subq_3.booking__ds_partitioned__extract_month
-        , subq_3.booking__ds_partitioned__extract_day
-        , subq_3.booking__ds_partitioned__extract_dow
-        , subq_3.booking__ds_partitioned__extract_doy
-        , subq_3.booking__paid_at__day
-        , subq_3.booking__paid_at__week
-        , subq_3.booking__paid_at__month
-        , subq_3.booking__paid_at__quarter
-        , subq_3.booking__paid_at__year
-        , subq_3.booking__paid_at__extract_year
-        , subq_3.booking__paid_at__extract_quarter
-        , subq_3.booking__paid_at__extract_month
-        , subq_3.booking__paid_at__extract_day
-        , subq_3.booking__paid_at__extract_dow
-        , subq_3.booking__paid_at__extract_doy
-        , subq_3.metric_time__day
-        , subq_3.metric_time__week
-        , subq_3.metric_time__month
-        , subq_3.metric_time__quarter
-        , subq_3.metric_time__year
-        , subq_3.metric_time__extract_year
-        , subq_3.metric_time__extract_quarter
-        , subq_3.metric_time__extract_month
-        , subq_3.metric_time__extract_day
-        , subq_3.metric_time__extract_dow
-        , subq_3.metric_time__extract_doy
-        , subq_3.listing
-        , subq_3.guest
-        , subq_3.host
-        , subq_3.booking__listing
-        , subq_3.booking__guest
-        , subq_3.booking__host
-        , subq_3.is_instant
-        , subq_3.booking__is_instant
-        , subq_3.bookings
-        , subq_3.instant_bookings
-        , subq_3.booking_value
-        , subq_3.max_booking_value
-        , subq_3.min_booking_value
-        , subq_3.bookers
-        , subq_3.average_booking_value
-        , subq_3.referred_bookings
-        , subq_3.median_booking_value
-        , subq_3.booking_value_p99
-        , subq_3.discrete_booking_value_p99
-        , subq_3.approximate_continuous_booking_value_p99
-        , subq_3.approximate_discrete_booking_value_p99
+        subq_1.ds__day
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.ds__extract_year
+        , subq_1.ds__extract_quarter
+        , subq_1.ds__extract_month
+        , subq_1.ds__extract_day
+        , subq_1.ds__extract_dow
+        , subq_1.ds__extract_doy
+        , subq_1.ds_partitioned__day
+        , subq_1.ds_partitioned__week
+        , subq_1.ds_partitioned__month
+        , subq_1.ds_partitioned__quarter
+        , subq_1.ds_partitioned__year
+        , subq_1.ds_partitioned__extract_year
+        , subq_1.ds_partitioned__extract_quarter
+        , subq_1.ds_partitioned__extract_month
+        , subq_1.ds_partitioned__extract_day
+        , subq_1.ds_partitioned__extract_dow
+        , subq_1.ds_partitioned__extract_doy
+        , subq_1.paid_at__day
+        , subq_1.paid_at__week
+        , subq_1.paid_at__month
+        , subq_1.paid_at__quarter
+        , subq_1.paid_at__year
+        , subq_1.paid_at__extract_year
+        , subq_1.paid_at__extract_quarter
+        , subq_1.paid_at__extract_month
+        , subq_1.paid_at__extract_day
+        , subq_1.paid_at__extract_dow
+        , subq_1.paid_at__extract_doy
+        , subq_1.booking__ds__day
+        , subq_1.booking__ds__week
+        , subq_1.booking__ds__month
+        , subq_1.booking__ds__quarter
+        , subq_1.booking__ds__year
+        , subq_1.booking__ds__extract_year
+        , subq_1.booking__ds__extract_quarter
+        , subq_1.booking__ds__extract_month
+        , subq_1.booking__ds__extract_day
+        , subq_1.booking__ds__extract_dow
+        , subq_1.booking__ds__extract_doy
+        , subq_1.booking__ds_partitioned__day
+        , subq_1.booking__ds_partitioned__week
+        , subq_1.booking__ds_partitioned__month
+        , subq_1.booking__ds_partitioned__quarter
+        , subq_1.booking__ds_partitioned__year
+        , subq_1.booking__ds_partitioned__extract_year
+        , subq_1.booking__ds_partitioned__extract_quarter
+        , subq_1.booking__ds_partitioned__extract_month
+        , subq_1.booking__ds_partitioned__extract_day
+        , subq_1.booking__ds_partitioned__extract_dow
+        , subq_1.booking__ds_partitioned__extract_doy
+        , subq_1.booking__paid_at__day
+        , subq_1.booking__paid_at__week
+        , subq_1.booking__paid_at__month
+        , subq_1.booking__paid_at__quarter
+        , subq_1.booking__paid_at__year
+        , subq_1.booking__paid_at__extract_year
+        , subq_1.booking__paid_at__extract_quarter
+        , subq_1.booking__paid_at__extract_month
+        , subq_1.booking__paid_at__extract_day
+        , subq_1.booking__paid_at__extract_dow
+        , subq_1.booking__paid_at__extract_doy
+        , subq_1.metric_time__day
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.metric_time__extract_year
+        , subq_1.metric_time__extract_quarter
+        , subq_1.metric_time__extract_month
+        , subq_1.metric_time__extract_day
+        , subq_1.metric_time__extract_dow
+        , subq_1.metric_time__extract_doy
+        , subq_1.listing
+        , subq_1.guest
+        , subq_1.host
+        , subq_1.booking__listing
+        , subq_1.booking__guest
+        , subq_1.booking__host
+        , subq_1.is_instant
+        , subq_1.booking__is_instant
+        , subq_1.bookings
+        , subq_1.instant_bookings
+        , subq_1.booking_value
+        , subq_1.max_booking_value
+        , subq_1.min_booking_value
+        , subq_1.bookers
+        , subq_1.average_booking_value
+        , subq_1.referred_bookings
+        , subq_1.median_booking_value
+        , subq_1.booking_value_p99
+        , subq_1.discrete_booking_value_p99
+        , subq_1.approximate_continuous_booking_value_p99
+        , subq_1.approximate_discrete_booking_value_p99
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_2.ds__day
-          , subq_2.ds__week
-          , subq_2.ds__month
-          , subq_2.ds__quarter
-          , subq_2.ds__year
-          , subq_2.ds__extract_year
-          , subq_2.ds__extract_quarter
-          , subq_2.ds__extract_month
-          , subq_2.ds__extract_day
-          , subq_2.ds__extract_dow
-          , subq_2.ds__extract_doy
-          , subq_2.ds_partitioned__day
-          , subq_2.ds_partitioned__week
-          , subq_2.ds_partitioned__month
-          , subq_2.ds_partitioned__quarter
-          , subq_2.ds_partitioned__year
-          , subq_2.ds_partitioned__extract_year
-          , subq_2.ds_partitioned__extract_quarter
-          , subq_2.ds_partitioned__extract_month
-          , subq_2.ds_partitioned__extract_day
-          , subq_2.ds_partitioned__extract_dow
-          , subq_2.ds_partitioned__extract_doy
-          , subq_2.paid_at__day
-          , subq_2.paid_at__week
-          , subq_2.paid_at__month
-          , subq_2.paid_at__quarter
-          , subq_2.paid_at__year
-          , subq_2.paid_at__extract_year
-          , subq_2.paid_at__extract_quarter
-          , subq_2.paid_at__extract_month
-          , subq_2.paid_at__extract_day
-          , subq_2.paid_at__extract_dow
-          , subq_2.paid_at__extract_doy
-          , subq_2.booking__ds__day
-          , subq_2.booking__ds__week
-          , subq_2.booking__ds__month
-          , subq_2.booking__ds__quarter
-          , subq_2.booking__ds__year
-          , subq_2.booking__ds__extract_year
-          , subq_2.booking__ds__extract_quarter
-          , subq_2.booking__ds__extract_month
-          , subq_2.booking__ds__extract_day
-          , subq_2.booking__ds__extract_dow
-          , subq_2.booking__ds__extract_doy
-          , subq_2.booking__ds_partitioned__day
-          , subq_2.booking__ds_partitioned__week
-          , subq_2.booking__ds_partitioned__month
-          , subq_2.booking__ds_partitioned__quarter
-          , subq_2.booking__ds_partitioned__year
-          , subq_2.booking__ds_partitioned__extract_year
-          , subq_2.booking__ds_partitioned__extract_quarter
-          , subq_2.booking__ds_partitioned__extract_month
-          , subq_2.booking__ds_partitioned__extract_day
-          , subq_2.booking__ds_partitioned__extract_dow
-          , subq_2.booking__ds_partitioned__extract_doy
-          , subq_2.booking__paid_at__day
-          , subq_2.booking__paid_at__week
-          , subq_2.booking__paid_at__month
-          , subq_2.booking__paid_at__quarter
-          , subq_2.booking__paid_at__year
-          , subq_2.booking__paid_at__extract_year
-          , subq_2.booking__paid_at__extract_quarter
-          , subq_2.booking__paid_at__extract_month
-          , subq_2.booking__paid_at__extract_day
-          , subq_2.booking__paid_at__extract_dow
-          , subq_2.booking__paid_at__extract_doy
-          , subq_2.ds__day AS metric_time__day
-          , subq_2.ds__week AS metric_time__week
-          , subq_2.ds__month AS metric_time__month
-          , subq_2.ds__quarter AS metric_time__quarter
-          , subq_2.ds__year AS metric_time__year
-          , subq_2.ds__extract_year AS metric_time__extract_year
-          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_2.ds__extract_month AS metric_time__extract_month
-          , subq_2.ds__extract_day AS metric_time__extract_day
-          , subq_2.ds__extract_dow AS metric_time__extract_dow
-          , subq_2.ds__extract_doy AS metric_time__extract_doy
-          , subq_2.listing
-          , subq_2.guest
-          , subq_2.host
-          , subq_2.booking__listing
-          , subq_2.booking__guest
-          , subq_2.booking__host
-          , subq_2.is_instant
-          , subq_2.booking__is_instant
-          , subq_2.bookings
-          , subq_2.instant_bookings
-          , subq_2.booking_value
-          , subq_2.max_booking_value
-          , subq_2.min_booking_value
-          , subq_2.bookers
-          , subq_2.average_booking_value
-          , subq_2.referred_bookings
-          , subq_2.median_booking_value
-          , subq_2.booking_value_p99
-          , subq_2.discrete_booking_value_p99
-          , subq_2.approximate_continuous_booking_value_p99
-          , subq_2.approximate_discrete_booking_value_p99
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.ds_partitioned__day
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.ds_partitioned__extract_year
+          , subq_0.ds_partitioned__extract_quarter
+          , subq_0.ds_partitioned__extract_month
+          , subq_0.ds_partitioned__extract_day
+          , subq_0.ds_partitioned__extract_dow
+          , subq_0.ds_partitioned__extract_doy
+          , subq_0.paid_at__day
+          , subq_0.paid_at__week
+          , subq_0.paid_at__month
+          , subq_0.paid_at__quarter
+          , subq_0.paid_at__year
+          , subq_0.paid_at__extract_year
+          , subq_0.paid_at__extract_quarter
+          , subq_0.paid_at__extract_month
+          , subq_0.paid_at__extract_day
+          , subq_0.paid_at__extract_dow
+          , subq_0.paid_at__extract_doy
+          , subq_0.booking__ds__day
+          , subq_0.booking__ds__week
+          , subq_0.booking__ds__month
+          , subq_0.booking__ds__quarter
+          , subq_0.booking__ds__year
+          , subq_0.booking__ds__extract_year
+          , subq_0.booking__ds__extract_quarter
+          , subq_0.booking__ds__extract_month
+          , subq_0.booking__ds__extract_day
+          , subq_0.booking__ds__extract_dow
+          , subq_0.booking__ds__extract_doy
+          , subq_0.booking__ds_partitioned__day
+          , subq_0.booking__ds_partitioned__week
+          , subq_0.booking__ds_partitioned__month
+          , subq_0.booking__ds_partitioned__quarter
+          , subq_0.booking__ds_partitioned__year
+          , subq_0.booking__ds_partitioned__extract_year
+          , subq_0.booking__ds_partitioned__extract_quarter
+          , subq_0.booking__ds_partitioned__extract_month
+          , subq_0.booking__ds_partitioned__extract_day
+          , subq_0.booking__ds_partitioned__extract_dow
+          , subq_0.booking__ds_partitioned__extract_doy
+          , subq_0.booking__paid_at__day
+          , subq_0.booking__paid_at__week
+          , subq_0.booking__paid_at__month
+          , subq_0.booking__paid_at__quarter
+          , subq_0.booking__paid_at__year
+          , subq_0.booking__paid_at__extract_year
+          , subq_0.booking__paid_at__extract_quarter
+          , subq_0.booking__paid_at__extract_month
+          , subq_0.booking__paid_at__extract_day
+          , subq_0.booking__paid_at__extract_dow
+          , subq_0.booking__paid_at__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.booking__listing
+          , subq_0.booking__guest
+          , subq_0.booking__host
+          , subq_0.is_instant
+          , subq_0.booking__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
+          , subq_0.referred_bookings
+          , subq_0.median_booking_value
+          , subq_0.booking_value_p99
+          , subq_0.discrete_booking_value_p99
+          , subq_0.approximate_continuous_booking_value_p99
+          , subq_0.approximate_discrete_booking_value_p99
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
           SELECT
@@ -303,9 +303,9 @@ FROM (
             , bookings_source_src_28000.guest_id AS booking__guest
             , bookings_source_src_28000.host_id AS booking__host
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_2
-      ) subq_3
-      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_4
-  ) subq_5
-) subq_6
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_2
+  ) subq_3
+) subq_4

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_13
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings AS bookings
+    subq_7.metric_time__day AS metric_time__day
+    , subq_6.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-  ) subq_9
+      subq_8.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_8
+  ) subq_7
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -329,17 +329,17 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day
+  ) subq_6
   ON
-    subq_9.metric_time__day = subq_8.metric_time__day
-) subq_11
+    subq_7.metric_time__day = subq_6.metric_time__day
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_22.ds AS metric_time__day
-    , subq_20.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_22
+    subq_18.ds AS metric_time__day
+    , subq_16.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_18
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_11
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_16
   ON
-    subq_22.ds = subq_20.metric_time__day
-) subq_23
+    subq_18.ds = subq_16.metric_time__day
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , subq_11.booking__is_instant
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , subq_9.booking__is_instant
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_10.metric_time__day
-    , subq_10.booking__is_instant
-    , subq_10.bookings
+    subq_8.metric_time__day
+    , subq_8.booking__is_instant
+    , subq_8.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_8.metric_time__day AS metric_time__day
-      , subq_7.booking__is_instant AS booking__is_instant
-      , subq_7.bookings AS bookings
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking__is_instant AS booking__is_instant
+      , subq_5.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_9.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_9
-    ) subq_8
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-        , SUM(subq_6.bookings) AS bookings
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+        , SUM(subq_4.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -333,19 +333,19 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
+      ) subq_4
       GROUP BY
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-    ) subq_7
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+    ) subq_5
     ON
-      subq_8.metric_time__day = subq_7.metric_time__day
-  ) subq_10
+      subq_6.metric_time__day = subq_5.metric_time__day
+  ) subq_8
   WHERE booking__is_instant
-) subq_11
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.ds AS metric_time__day
-      , subq_19.booking__is_instant AS booking__is_instant
-      , subq_19.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_21
+      subq_17.ds AS metric_time__day
+      , subq_15.booking__is_instant AS booking__is_instant
+      , subq_15.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_15
+        ) subq_11
         WHERE booking__is_instant
-      ) subq_17
+      ) subq_13
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_19
+    ) subq_15
     ON
-      subq_21.ds = subq_19.metric_time__day
-  ) subq_22
+      subq_17.ds = subq_15.metric_time__day
+  ) subq_18
   WHERE booking__is_instant
-) subq_23
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_9.metric_time__day
-    , subq_9.bookings
+    subq_7.metric_time__day
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_7.metric_time__day AS metric_time__day
-      , subq_6.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_8.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_8
-      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_7
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+      WHERE subq_6.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.bookings) AS bookings
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.bookings
+          subq_2.metric_time__day
+          , subq_2.bookings
         FROM (
           -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.max_booking_value
-            , subq_3.min_booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
-            , subq_3.referred_bookings
-            , subq_3.median_booking_value
-            , subq_3.booking_value_p99
-            , subq_3.discrete_booking_value_p99
-            , subq_3.approximate_continuous_booking_value_p99
-            , subq_3.approximate_discrete_booking_value_p99
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.ds_partitioned__day
+            , subq_1.ds_partitioned__week
+            , subq_1.ds_partitioned__month
+            , subq_1.ds_partitioned__quarter
+            , subq_1.ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy
+            , subq_1.paid_at__day
+            , subq_1.paid_at__week
+            , subq_1.paid_at__month
+            , subq_1.paid_at__quarter
+            , subq_1.paid_at__year
+            , subq_1.paid_at__extract_year
+            , subq_1.paid_at__extract_quarter
+            , subq_1.paid_at__extract_month
+            , subq_1.paid_at__extract_day
+            , subq_1.paid_at__extract_dow
+            , subq_1.paid_at__extract_doy
+            , subq_1.booking__ds__day
+            , subq_1.booking__ds__week
+            , subq_1.booking__ds__month
+            , subq_1.booking__ds__quarter
+            , subq_1.booking__ds__year
+            , subq_1.booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month
+            , subq_1.booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day
+            , subq_1.booking__paid_at__week
+            , subq_1.booking__paid_at__month
+            , subq_1.booking__paid_at__quarter
+            , subq_1.booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.listing
+            , subq_1.guest
+            , subq_1.host
+            , subq_1.booking__listing
+            , subq_1.booking__guest
+            , subq_1.booking__host
+            , subq_1.is_instant
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+            , subq_1.instant_bookings
+            , subq_1.booking_value
+            , subq_1.max_booking_value
+            , subq_1.min_booking_value
+            , subq_1.bookers
+            , subq_1.average_booking_value
+            , subq_1.referred_bookings
+            , subq_1.median_booking_value
+            , subq_1.booking_value_p99
+            , subq_1.discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.ds_partitioned__day
-              , subq_2.ds_partitioned__week
-              , subq_2.ds_partitioned__month
-              , subq_2.ds_partitioned__quarter
-              , subq_2.ds_partitioned__year
-              , subq_2.ds_partitioned__extract_year
-              , subq_2.ds_partitioned__extract_quarter
-              , subq_2.ds_partitioned__extract_month
-              , subq_2.ds_partitioned__extract_day
-              , subq_2.ds_partitioned__extract_dow
-              , subq_2.ds_partitioned__extract_doy
-              , subq_2.paid_at__day
-              , subq_2.paid_at__week
-              , subq_2.paid_at__month
-              , subq_2.paid_at__quarter
-              , subq_2.paid_at__year
-              , subq_2.paid_at__extract_year
-              , subq_2.paid_at__extract_quarter
-              , subq_2.paid_at__extract_month
-              , subq_2.paid_at__extract_day
-              , subq_2.paid_at__extract_dow
-              , subq_2.paid_at__extract_doy
-              , subq_2.booking__ds__day
-              , subq_2.booking__ds__week
-              , subq_2.booking__ds__month
-              , subq_2.booking__ds__quarter
-              , subq_2.booking__ds__year
-              , subq_2.booking__ds__extract_year
-              , subq_2.booking__ds__extract_quarter
-              , subq_2.booking__ds__extract_month
-              , subq_2.booking__ds__extract_day
-              , subq_2.booking__ds__extract_dow
-              , subq_2.booking__ds__extract_doy
-              , subq_2.booking__ds_partitioned__day
-              , subq_2.booking__ds_partitioned__week
-              , subq_2.booking__ds_partitioned__month
-              , subq_2.booking__ds_partitioned__quarter
-              , subq_2.booking__ds_partitioned__year
-              , subq_2.booking__ds_partitioned__extract_year
-              , subq_2.booking__ds_partitioned__extract_quarter
-              , subq_2.booking__ds_partitioned__extract_month
-              , subq_2.booking__ds_partitioned__extract_day
-              , subq_2.booking__ds_partitioned__extract_dow
-              , subq_2.booking__ds_partitioned__extract_doy
-              , subq_2.booking__paid_at__day
-              , subq_2.booking__paid_at__week
-              , subq_2.booking__paid_at__month
-              , subq_2.booking__paid_at__quarter
-              , subq_2.booking__paid_at__year
-              , subq_2.booking__paid_at__extract_year
-              , subq_2.booking__paid_at__extract_quarter
-              , subq_2.booking__paid_at__extract_month
-              , subq_2.booking__paid_at__extract_day
-              , subq_2.booking__paid_at__extract_dow
-              , subq_2.booking__paid_at__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.listing
-              , subq_2.guest
-              , subq_2.host
-              , subq_2.booking__listing
-              , subq_2.booking__guest
-              , subq_2.booking__host
-              , subq_2.is_instant
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-              , subq_2.instant_bookings
-              , subq_2.booking_value
-              , subq_2.max_booking_value
-              , subq_2.min_booking_value
-              , subq_2.bookers
-              , subq_2.average_booking_value
-              , subq_2.referred_bookings
-              , subq_2.median_booking_value
-              , subq_2.booking_value_p99
-              , subq_2.discrete_booking_value_p99
-              , subq_2.approximate_continuous_booking_value_p99
-              , subq_2.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
               -- Read Elements From Semantic Model 'bookings_source'
               SELECT
@@ -323,16 +323,16 @@ FROM (
                 , bookings_source_src_28000.guest_id AS booking__guest
                 , bookings_source_src_28000.host_id AS booking__host
               FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-        ) subq_4
-      ) subq_5
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_2
+      ) subq_3
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
+        subq_3.metric_time__day
+    ) subq_4
     ON
-      subq_7.metric_time__day = subq_6.metric_time__day
-  ) subq_9
-  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_10
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE subq_7.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_18.metric_time__day AS metric_time__day
-    , subq_17.bookings AS bookings
+    subq_14.metric_time__day AS metric_time__day
+    , subq_13.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_19
+    FROM ***************************.mf_time_spine subq_15
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_16
+    ) subq_12
     GROUP BY
       metric_time__day
-  ) subq_17
+  ) subq_13
   ON
-    subq_18.metric_time__day = subq_17.metric_time__day
-  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_21
+    subq_14.metric_time__day = subq_13.metric_time__day
+  WHERE subq_14.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,216 +1,216 @@
 -- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+  COALESCE(subq_4.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_5.bookings) AS bookings
+    SUM(subq_3.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings',]
     SELECT
-      subq_4.bookings
+      subq_2.bookings
     FROM (
       -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
       SELECT
-        subq_3.ds__day
-        , subq_3.ds__week
-        , subq_3.ds__month
-        , subq_3.ds__quarter
-        , subq_3.ds__year
-        , subq_3.ds__extract_year
-        , subq_3.ds__extract_quarter
-        , subq_3.ds__extract_month
-        , subq_3.ds__extract_day
-        , subq_3.ds__extract_dow
-        , subq_3.ds__extract_doy
-        , subq_3.ds_partitioned__day
-        , subq_3.ds_partitioned__week
-        , subq_3.ds_partitioned__month
-        , subq_3.ds_partitioned__quarter
-        , subq_3.ds_partitioned__year
-        , subq_3.ds_partitioned__extract_year
-        , subq_3.ds_partitioned__extract_quarter
-        , subq_3.ds_partitioned__extract_month
-        , subq_3.ds_partitioned__extract_day
-        , subq_3.ds_partitioned__extract_dow
-        , subq_3.ds_partitioned__extract_doy
-        , subq_3.paid_at__day
-        , subq_3.paid_at__week
-        , subq_3.paid_at__month
-        , subq_3.paid_at__quarter
-        , subq_3.paid_at__year
-        , subq_3.paid_at__extract_year
-        , subq_3.paid_at__extract_quarter
-        , subq_3.paid_at__extract_month
-        , subq_3.paid_at__extract_day
-        , subq_3.paid_at__extract_dow
-        , subq_3.paid_at__extract_doy
-        , subq_3.booking__ds__day
-        , subq_3.booking__ds__week
-        , subq_3.booking__ds__month
-        , subq_3.booking__ds__quarter
-        , subq_3.booking__ds__year
-        , subq_3.booking__ds__extract_year
-        , subq_3.booking__ds__extract_quarter
-        , subq_3.booking__ds__extract_month
-        , subq_3.booking__ds__extract_day
-        , subq_3.booking__ds__extract_dow
-        , subq_3.booking__ds__extract_doy
-        , subq_3.booking__ds_partitioned__day
-        , subq_3.booking__ds_partitioned__week
-        , subq_3.booking__ds_partitioned__month
-        , subq_3.booking__ds_partitioned__quarter
-        , subq_3.booking__ds_partitioned__year
-        , subq_3.booking__ds_partitioned__extract_year
-        , subq_3.booking__ds_partitioned__extract_quarter
-        , subq_3.booking__ds_partitioned__extract_month
-        , subq_3.booking__ds_partitioned__extract_day
-        , subq_3.booking__ds_partitioned__extract_dow
-        , subq_3.booking__ds_partitioned__extract_doy
-        , subq_3.booking__paid_at__day
-        , subq_3.booking__paid_at__week
-        , subq_3.booking__paid_at__month
-        , subq_3.booking__paid_at__quarter
-        , subq_3.booking__paid_at__year
-        , subq_3.booking__paid_at__extract_year
-        , subq_3.booking__paid_at__extract_quarter
-        , subq_3.booking__paid_at__extract_month
-        , subq_3.booking__paid_at__extract_day
-        , subq_3.booking__paid_at__extract_dow
-        , subq_3.booking__paid_at__extract_doy
-        , subq_3.metric_time__day
-        , subq_3.metric_time__week
-        , subq_3.metric_time__month
-        , subq_3.metric_time__quarter
-        , subq_3.metric_time__year
-        , subq_3.metric_time__extract_year
-        , subq_3.metric_time__extract_quarter
-        , subq_3.metric_time__extract_month
-        , subq_3.metric_time__extract_day
-        , subq_3.metric_time__extract_dow
-        , subq_3.metric_time__extract_doy
-        , subq_3.listing
-        , subq_3.guest
-        , subq_3.host
-        , subq_3.booking__listing
-        , subq_3.booking__guest
-        , subq_3.booking__host
-        , subq_3.is_instant
-        , subq_3.booking__is_instant
-        , subq_3.bookings
-        , subq_3.instant_bookings
-        , subq_3.booking_value
-        , subq_3.max_booking_value
-        , subq_3.min_booking_value
-        , subq_3.bookers
-        , subq_3.average_booking_value
-        , subq_3.referred_bookings
-        , subq_3.median_booking_value
-        , subq_3.booking_value_p99
-        , subq_3.discrete_booking_value_p99
-        , subq_3.approximate_continuous_booking_value_p99
-        , subq_3.approximate_discrete_booking_value_p99
+        subq_1.ds__day
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.ds__extract_year
+        , subq_1.ds__extract_quarter
+        , subq_1.ds__extract_month
+        , subq_1.ds__extract_day
+        , subq_1.ds__extract_dow
+        , subq_1.ds__extract_doy
+        , subq_1.ds_partitioned__day
+        , subq_1.ds_partitioned__week
+        , subq_1.ds_partitioned__month
+        , subq_1.ds_partitioned__quarter
+        , subq_1.ds_partitioned__year
+        , subq_1.ds_partitioned__extract_year
+        , subq_1.ds_partitioned__extract_quarter
+        , subq_1.ds_partitioned__extract_month
+        , subq_1.ds_partitioned__extract_day
+        , subq_1.ds_partitioned__extract_dow
+        , subq_1.ds_partitioned__extract_doy
+        , subq_1.paid_at__day
+        , subq_1.paid_at__week
+        , subq_1.paid_at__month
+        , subq_1.paid_at__quarter
+        , subq_1.paid_at__year
+        , subq_1.paid_at__extract_year
+        , subq_1.paid_at__extract_quarter
+        , subq_1.paid_at__extract_month
+        , subq_1.paid_at__extract_day
+        , subq_1.paid_at__extract_dow
+        , subq_1.paid_at__extract_doy
+        , subq_1.booking__ds__day
+        , subq_1.booking__ds__week
+        , subq_1.booking__ds__month
+        , subq_1.booking__ds__quarter
+        , subq_1.booking__ds__year
+        , subq_1.booking__ds__extract_year
+        , subq_1.booking__ds__extract_quarter
+        , subq_1.booking__ds__extract_month
+        , subq_1.booking__ds__extract_day
+        , subq_1.booking__ds__extract_dow
+        , subq_1.booking__ds__extract_doy
+        , subq_1.booking__ds_partitioned__day
+        , subq_1.booking__ds_partitioned__week
+        , subq_1.booking__ds_partitioned__month
+        , subq_1.booking__ds_partitioned__quarter
+        , subq_1.booking__ds_partitioned__year
+        , subq_1.booking__ds_partitioned__extract_year
+        , subq_1.booking__ds_partitioned__extract_quarter
+        , subq_1.booking__ds_partitioned__extract_month
+        , subq_1.booking__ds_partitioned__extract_day
+        , subq_1.booking__ds_partitioned__extract_dow
+        , subq_1.booking__ds_partitioned__extract_doy
+        , subq_1.booking__paid_at__day
+        , subq_1.booking__paid_at__week
+        , subq_1.booking__paid_at__month
+        , subq_1.booking__paid_at__quarter
+        , subq_1.booking__paid_at__year
+        , subq_1.booking__paid_at__extract_year
+        , subq_1.booking__paid_at__extract_quarter
+        , subq_1.booking__paid_at__extract_month
+        , subq_1.booking__paid_at__extract_day
+        , subq_1.booking__paid_at__extract_dow
+        , subq_1.booking__paid_at__extract_doy
+        , subq_1.metric_time__day
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.metric_time__extract_year
+        , subq_1.metric_time__extract_quarter
+        , subq_1.metric_time__extract_month
+        , subq_1.metric_time__extract_day
+        , subq_1.metric_time__extract_dow
+        , subq_1.metric_time__extract_doy
+        , subq_1.listing
+        , subq_1.guest
+        , subq_1.host
+        , subq_1.booking__listing
+        , subq_1.booking__guest
+        , subq_1.booking__host
+        , subq_1.is_instant
+        , subq_1.booking__is_instant
+        , subq_1.bookings
+        , subq_1.instant_bookings
+        , subq_1.booking_value
+        , subq_1.max_booking_value
+        , subq_1.min_booking_value
+        , subq_1.bookers
+        , subq_1.average_booking_value
+        , subq_1.referred_bookings
+        , subq_1.median_booking_value
+        , subq_1.booking_value_p99
+        , subq_1.discrete_booking_value_p99
+        , subq_1.approximate_continuous_booking_value_p99
+        , subq_1.approximate_discrete_booking_value_p99
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_2.ds__day
-          , subq_2.ds__week
-          , subq_2.ds__month
-          , subq_2.ds__quarter
-          , subq_2.ds__year
-          , subq_2.ds__extract_year
-          , subq_2.ds__extract_quarter
-          , subq_2.ds__extract_month
-          , subq_2.ds__extract_day
-          , subq_2.ds__extract_dow
-          , subq_2.ds__extract_doy
-          , subq_2.ds_partitioned__day
-          , subq_2.ds_partitioned__week
-          , subq_2.ds_partitioned__month
-          , subq_2.ds_partitioned__quarter
-          , subq_2.ds_partitioned__year
-          , subq_2.ds_partitioned__extract_year
-          , subq_2.ds_partitioned__extract_quarter
-          , subq_2.ds_partitioned__extract_month
-          , subq_2.ds_partitioned__extract_day
-          , subq_2.ds_partitioned__extract_dow
-          , subq_2.ds_partitioned__extract_doy
-          , subq_2.paid_at__day
-          , subq_2.paid_at__week
-          , subq_2.paid_at__month
-          , subq_2.paid_at__quarter
-          , subq_2.paid_at__year
-          , subq_2.paid_at__extract_year
-          , subq_2.paid_at__extract_quarter
-          , subq_2.paid_at__extract_month
-          , subq_2.paid_at__extract_day
-          , subq_2.paid_at__extract_dow
-          , subq_2.paid_at__extract_doy
-          , subq_2.booking__ds__day
-          , subq_2.booking__ds__week
-          , subq_2.booking__ds__month
-          , subq_2.booking__ds__quarter
-          , subq_2.booking__ds__year
-          , subq_2.booking__ds__extract_year
-          , subq_2.booking__ds__extract_quarter
-          , subq_2.booking__ds__extract_month
-          , subq_2.booking__ds__extract_day
-          , subq_2.booking__ds__extract_dow
-          , subq_2.booking__ds__extract_doy
-          , subq_2.booking__ds_partitioned__day
-          , subq_2.booking__ds_partitioned__week
-          , subq_2.booking__ds_partitioned__month
-          , subq_2.booking__ds_partitioned__quarter
-          , subq_2.booking__ds_partitioned__year
-          , subq_2.booking__ds_partitioned__extract_year
-          , subq_2.booking__ds_partitioned__extract_quarter
-          , subq_2.booking__ds_partitioned__extract_month
-          , subq_2.booking__ds_partitioned__extract_day
-          , subq_2.booking__ds_partitioned__extract_dow
-          , subq_2.booking__ds_partitioned__extract_doy
-          , subq_2.booking__paid_at__day
-          , subq_2.booking__paid_at__week
-          , subq_2.booking__paid_at__month
-          , subq_2.booking__paid_at__quarter
-          , subq_2.booking__paid_at__year
-          , subq_2.booking__paid_at__extract_year
-          , subq_2.booking__paid_at__extract_quarter
-          , subq_2.booking__paid_at__extract_month
-          , subq_2.booking__paid_at__extract_day
-          , subq_2.booking__paid_at__extract_dow
-          , subq_2.booking__paid_at__extract_doy
-          , subq_2.ds__day AS metric_time__day
-          , subq_2.ds__week AS metric_time__week
-          , subq_2.ds__month AS metric_time__month
-          , subq_2.ds__quarter AS metric_time__quarter
-          , subq_2.ds__year AS metric_time__year
-          , subq_2.ds__extract_year AS metric_time__extract_year
-          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_2.ds__extract_month AS metric_time__extract_month
-          , subq_2.ds__extract_day AS metric_time__extract_day
-          , subq_2.ds__extract_dow AS metric_time__extract_dow
-          , subq_2.ds__extract_doy AS metric_time__extract_doy
-          , subq_2.listing
-          , subq_2.guest
-          , subq_2.host
-          , subq_2.booking__listing
-          , subq_2.booking__guest
-          , subq_2.booking__host
-          , subq_2.is_instant
-          , subq_2.booking__is_instant
-          , subq_2.bookings
-          , subq_2.instant_bookings
-          , subq_2.booking_value
-          , subq_2.max_booking_value
-          , subq_2.min_booking_value
-          , subq_2.bookers
-          , subq_2.average_booking_value
-          , subq_2.referred_bookings
-          , subq_2.median_booking_value
-          , subq_2.booking_value_p99
-          , subq_2.discrete_booking_value_p99
-          , subq_2.approximate_continuous_booking_value_p99
-          , subq_2.approximate_discrete_booking_value_p99
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.ds_partitioned__day
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.ds_partitioned__extract_year
+          , subq_0.ds_partitioned__extract_quarter
+          , subq_0.ds_partitioned__extract_month
+          , subq_0.ds_partitioned__extract_day
+          , subq_0.ds_partitioned__extract_dow
+          , subq_0.ds_partitioned__extract_doy
+          , subq_0.paid_at__day
+          , subq_0.paid_at__week
+          , subq_0.paid_at__month
+          , subq_0.paid_at__quarter
+          , subq_0.paid_at__year
+          , subq_0.paid_at__extract_year
+          , subq_0.paid_at__extract_quarter
+          , subq_0.paid_at__extract_month
+          , subq_0.paid_at__extract_day
+          , subq_0.paid_at__extract_dow
+          , subq_0.paid_at__extract_doy
+          , subq_0.booking__ds__day
+          , subq_0.booking__ds__week
+          , subq_0.booking__ds__month
+          , subq_0.booking__ds__quarter
+          , subq_0.booking__ds__year
+          , subq_0.booking__ds__extract_year
+          , subq_0.booking__ds__extract_quarter
+          , subq_0.booking__ds__extract_month
+          , subq_0.booking__ds__extract_day
+          , subq_0.booking__ds__extract_dow
+          , subq_0.booking__ds__extract_doy
+          , subq_0.booking__ds_partitioned__day
+          , subq_0.booking__ds_partitioned__week
+          , subq_0.booking__ds_partitioned__month
+          , subq_0.booking__ds_partitioned__quarter
+          , subq_0.booking__ds_partitioned__year
+          , subq_0.booking__ds_partitioned__extract_year
+          , subq_0.booking__ds_partitioned__extract_quarter
+          , subq_0.booking__ds_partitioned__extract_month
+          , subq_0.booking__ds_partitioned__extract_day
+          , subq_0.booking__ds_partitioned__extract_dow
+          , subq_0.booking__ds_partitioned__extract_doy
+          , subq_0.booking__paid_at__day
+          , subq_0.booking__paid_at__week
+          , subq_0.booking__paid_at__month
+          , subq_0.booking__paid_at__quarter
+          , subq_0.booking__paid_at__year
+          , subq_0.booking__paid_at__extract_year
+          , subq_0.booking__paid_at__extract_quarter
+          , subq_0.booking__paid_at__extract_month
+          , subq_0.booking__paid_at__extract_day
+          , subq_0.booking__paid_at__extract_dow
+          , subq_0.booking__paid_at__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.booking__listing
+          , subq_0.booking__guest
+          , subq_0.booking__host
+          , subq_0.is_instant
+          , subq_0.booking__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
+          , subq_0.referred_bookings
+          , subq_0.median_booking_value
+          , subq_0.booking_value_p99
+          , subq_0.discrete_booking_value_p99
+          , subq_0.approximate_continuous_booking_value_p99
+          , subq_0.approximate_discrete_booking_value_p99
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
           SELECT
@@ -303,9 +303,9 @@ FROM (
             , bookings_source_src_28000.guest_id AS booking__guest
             , bookings_source_src_28000.host_id AS booking__host
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_2
-      ) subq_3
-      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_4
-  ) subq_5
-) subq_6
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_2
+  ) subq_3
+) subq_4

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_13
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings AS bookings
+    subq_7.metric_time__day AS metric_time__day
+    , subq_6.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-  ) subq_9
+      subq_8.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_8
+  ) subq_7
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -329,17 +329,17 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day
+  ) subq_6
   ON
-    subq_9.metric_time__day = subq_8.metric_time__day
-) subq_11
+    subq_7.metric_time__day = subq_6.metric_time__day
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_22.ds AS metric_time__day
-    , subq_20.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_22
+    subq_18.ds AS metric_time__day
+    , subq_16.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_18
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_11
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_16
   ON
-    subq_22.ds = subq_20.metric_time__day
-) subq_23
+    subq_18.ds = subq_16.metric_time__day
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , subq_11.booking__is_instant
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , subq_9.booking__is_instant
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_10.metric_time__day
-    , subq_10.booking__is_instant
-    , subq_10.bookings
+    subq_8.metric_time__day
+    , subq_8.booking__is_instant
+    , subq_8.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_8.metric_time__day AS metric_time__day
-      , subq_7.booking__is_instant AS booking__is_instant
-      , subq_7.bookings AS bookings
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking__is_instant AS booking__is_instant
+      , subq_5.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_9.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_9
-    ) subq_8
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-        , SUM(subq_6.bookings) AS bookings
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+        , SUM(subq_4.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -333,19 +333,19 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
+      ) subq_4
       GROUP BY
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-    ) subq_7
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+    ) subq_5
     ON
-      subq_8.metric_time__day = subq_7.metric_time__day
-  ) subq_10
+      subq_6.metric_time__day = subq_5.metric_time__day
+  ) subq_8
   WHERE booking__is_instant
-) subq_11
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.ds AS metric_time__day
-      , subq_19.booking__is_instant AS booking__is_instant
-      , subq_19.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_21
+      subq_17.ds AS metric_time__day
+      , subq_15.booking__is_instant AS booking__is_instant
+      , subq_15.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_15
+        ) subq_11
         WHERE booking__is_instant
-      ) subq_17
+      ) subq_13
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_19
+    ) subq_15
     ON
-      subq_21.ds = subq_19.metric_time__day
-  ) subq_22
+      subq_17.ds = subq_15.metric_time__day
+  ) subq_18
   WHERE booking__is_instant
-) subq_23
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,236 +1,236 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__day
-  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_9.metric_time__day
-    , subq_9.bookings
+    subq_7.metric_time__day
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_7.metric_time__day AS metric_time__day
-      , subq_6.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_8.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_8
-      WHERE subq_8.ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-    ) subq_7
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+      WHERE subq_6.ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.bookings) AS bookings
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.bookings
+          subq_2.metric_time__day
+          , subq_2.bookings
         FROM (
           -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
           SELECT
-            subq_3.ds__day
-            , subq_3.ds__week
-            , subq_3.ds__month
-            , subq_3.ds__quarter
-            , subq_3.ds__year
-            , subq_3.ds__extract_year
-            , subq_3.ds__extract_quarter
-            , subq_3.ds__extract_month
-            , subq_3.ds__extract_day
-            , subq_3.ds__extract_dow
-            , subq_3.ds__extract_doy
-            , subq_3.ds_partitioned__day
-            , subq_3.ds_partitioned__week
-            , subq_3.ds_partitioned__month
-            , subq_3.ds_partitioned__quarter
-            , subq_3.ds_partitioned__year
-            , subq_3.ds_partitioned__extract_year
-            , subq_3.ds_partitioned__extract_quarter
-            , subq_3.ds_partitioned__extract_month
-            , subq_3.ds_partitioned__extract_day
-            , subq_3.ds_partitioned__extract_dow
-            , subq_3.ds_partitioned__extract_doy
-            , subq_3.paid_at__day
-            , subq_3.paid_at__week
-            , subq_3.paid_at__month
-            , subq_3.paid_at__quarter
-            , subq_3.paid_at__year
-            , subq_3.paid_at__extract_year
-            , subq_3.paid_at__extract_quarter
-            , subq_3.paid_at__extract_month
-            , subq_3.paid_at__extract_day
-            , subq_3.paid_at__extract_dow
-            , subq_3.paid_at__extract_doy
-            , subq_3.booking__ds__day
-            , subq_3.booking__ds__week
-            , subq_3.booking__ds__month
-            , subq_3.booking__ds__quarter
-            , subq_3.booking__ds__year
-            , subq_3.booking__ds__extract_year
-            , subq_3.booking__ds__extract_quarter
-            , subq_3.booking__ds__extract_month
-            , subq_3.booking__ds__extract_day
-            , subq_3.booking__ds__extract_dow
-            , subq_3.booking__ds__extract_doy
-            , subq_3.booking__ds_partitioned__day
-            , subq_3.booking__ds_partitioned__week
-            , subq_3.booking__ds_partitioned__month
-            , subq_3.booking__ds_partitioned__quarter
-            , subq_3.booking__ds_partitioned__year
-            , subq_3.booking__ds_partitioned__extract_year
-            , subq_3.booking__ds_partitioned__extract_quarter
-            , subq_3.booking__ds_partitioned__extract_month
-            , subq_3.booking__ds_partitioned__extract_day
-            , subq_3.booking__ds_partitioned__extract_dow
-            , subq_3.booking__ds_partitioned__extract_doy
-            , subq_3.booking__paid_at__day
-            , subq_3.booking__paid_at__week
-            , subq_3.booking__paid_at__month
-            , subq_3.booking__paid_at__quarter
-            , subq_3.booking__paid_at__year
-            , subq_3.booking__paid_at__extract_year
-            , subq_3.booking__paid_at__extract_quarter
-            , subq_3.booking__paid_at__extract_month
-            , subq_3.booking__paid_at__extract_day
-            , subq_3.booking__paid_at__extract_dow
-            , subq_3.booking__paid_at__extract_doy
-            , subq_3.metric_time__day
-            , subq_3.metric_time__week
-            , subq_3.metric_time__month
-            , subq_3.metric_time__quarter
-            , subq_3.metric_time__year
-            , subq_3.metric_time__extract_year
-            , subq_3.metric_time__extract_quarter
-            , subq_3.metric_time__extract_month
-            , subq_3.metric_time__extract_day
-            , subq_3.metric_time__extract_dow
-            , subq_3.metric_time__extract_doy
-            , subq_3.listing
-            , subq_3.guest
-            , subq_3.host
-            , subq_3.booking__listing
-            , subq_3.booking__guest
-            , subq_3.booking__host
-            , subq_3.is_instant
-            , subq_3.booking__is_instant
-            , subq_3.bookings
-            , subq_3.instant_bookings
-            , subq_3.booking_value
-            , subq_3.max_booking_value
-            , subq_3.min_booking_value
-            , subq_3.bookers
-            , subq_3.average_booking_value
-            , subq_3.referred_bookings
-            , subq_3.median_booking_value
-            , subq_3.booking_value_p99
-            , subq_3.discrete_booking_value_p99
-            , subq_3.approximate_continuous_booking_value_p99
-            , subq_3.approximate_discrete_booking_value_p99
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.ds_partitioned__day
+            , subq_1.ds_partitioned__week
+            , subq_1.ds_partitioned__month
+            , subq_1.ds_partitioned__quarter
+            , subq_1.ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy
+            , subq_1.paid_at__day
+            , subq_1.paid_at__week
+            , subq_1.paid_at__month
+            , subq_1.paid_at__quarter
+            , subq_1.paid_at__year
+            , subq_1.paid_at__extract_year
+            , subq_1.paid_at__extract_quarter
+            , subq_1.paid_at__extract_month
+            , subq_1.paid_at__extract_day
+            , subq_1.paid_at__extract_dow
+            , subq_1.paid_at__extract_doy
+            , subq_1.booking__ds__day
+            , subq_1.booking__ds__week
+            , subq_1.booking__ds__month
+            , subq_1.booking__ds__quarter
+            , subq_1.booking__ds__year
+            , subq_1.booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month
+            , subq_1.booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day
+            , subq_1.booking__paid_at__week
+            , subq_1.booking__paid_at__month
+            , subq_1.booking__paid_at__quarter
+            , subq_1.booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.listing
+            , subq_1.guest
+            , subq_1.host
+            , subq_1.booking__listing
+            , subq_1.booking__guest
+            , subq_1.booking__host
+            , subq_1.is_instant
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+            , subq_1.instant_bookings
+            , subq_1.booking_value
+            , subq_1.max_booking_value
+            , subq_1.min_booking_value
+            , subq_1.bookers
+            , subq_1.average_booking_value
+            , subq_1.referred_bookings
+            , subq_1.median_booking_value
+            , subq_1.booking_value_p99
+            , subq_1.discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_2.ds__day
-              , subq_2.ds__week
-              , subq_2.ds__month
-              , subq_2.ds__quarter
-              , subq_2.ds__year
-              , subq_2.ds__extract_year
-              , subq_2.ds__extract_quarter
-              , subq_2.ds__extract_month
-              , subq_2.ds__extract_day
-              , subq_2.ds__extract_dow
-              , subq_2.ds__extract_doy
-              , subq_2.ds_partitioned__day
-              , subq_2.ds_partitioned__week
-              , subq_2.ds_partitioned__month
-              , subq_2.ds_partitioned__quarter
-              , subq_2.ds_partitioned__year
-              , subq_2.ds_partitioned__extract_year
-              , subq_2.ds_partitioned__extract_quarter
-              , subq_2.ds_partitioned__extract_month
-              , subq_2.ds_partitioned__extract_day
-              , subq_2.ds_partitioned__extract_dow
-              , subq_2.ds_partitioned__extract_doy
-              , subq_2.paid_at__day
-              , subq_2.paid_at__week
-              , subq_2.paid_at__month
-              , subq_2.paid_at__quarter
-              , subq_2.paid_at__year
-              , subq_2.paid_at__extract_year
-              , subq_2.paid_at__extract_quarter
-              , subq_2.paid_at__extract_month
-              , subq_2.paid_at__extract_day
-              , subq_2.paid_at__extract_dow
-              , subq_2.paid_at__extract_doy
-              , subq_2.booking__ds__day
-              , subq_2.booking__ds__week
-              , subq_2.booking__ds__month
-              , subq_2.booking__ds__quarter
-              , subq_2.booking__ds__year
-              , subq_2.booking__ds__extract_year
-              , subq_2.booking__ds__extract_quarter
-              , subq_2.booking__ds__extract_month
-              , subq_2.booking__ds__extract_day
-              , subq_2.booking__ds__extract_dow
-              , subq_2.booking__ds__extract_doy
-              , subq_2.booking__ds_partitioned__day
-              , subq_2.booking__ds_partitioned__week
-              , subq_2.booking__ds_partitioned__month
-              , subq_2.booking__ds_partitioned__quarter
-              , subq_2.booking__ds_partitioned__year
-              , subq_2.booking__ds_partitioned__extract_year
-              , subq_2.booking__ds_partitioned__extract_quarter
-              , subq_2.booking__ds_partitioned__extract_month
-              , subq_2.booking__ds_partitioned__extract_day
-              , subq_2.booking__ds_partitioned__extract_dow
-              , subq_2.booking__ds_partitioned__extract_doy
-              , subq_2.booking__paid_at__day
-              , subq_2.booking__paid_at__week
-              , subq_2.booking__paid_at__month
-              , subq_2.booking__paid_at__quarter
-              , subq_2.booking__paid_at__year
-              , subq_2.booking__paid_at__extract_year
-              , subq_2.booking__paid_at__extract_quarter
-              , subq_2.booking__paid_at__extract_month
-              , subq_2.booking__paid_at__extract_day
-              , subq_2.booking__paid_at__extract_dow
-              , subq_2.booking__paid_at__extract_doy
-              , subq_2.ds__day AS metric_time__day
-              , subq_2.ds__week AS metric_time__week
-              , subq_2.ds__month AS metric_time__month
-              , subq_2.ds__quarter AS metric_time__quarter
-              , subq_2.ds__year AS metric_time__year
-              , subq_2.ds__extract_year AS metric_time__extract_year
-              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_2.ds__extract_month AS metric_time__extract_month
-              , subq_2.ds__extract_day AS metric_time__extract_day
-              , subq_2.ds__extract_dow AS metric_time__extract_dow
-              , subq_2.ds__extract_doy AS metric_time__extract_doy
-              , subq_2.listing
-              , subq_2.guest
-              , subq_2.host
-              , subq_2.booking__listing
-              , subq_2.booking__guest
-              , subq_2.booking__host
-              , subq_2.is_instant
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-              , subq_2.instant_bookings
-              , subq_2.booking_value
-              , subq_2.max_booking_value
-              , subq_2.min_booking_value
-              , subq_2.bookers
-              , subq_2.average_booking_value
-              , subq_2.referred_bookings
-              , subq_2.median_booking_value
-              , subq_2.booking_value_p99
-              , subq_2.discrete_booking_value_p99
-              , subq_2.approximate_continuous_booking_value_p99
-              , subq_2.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
               -- Read Elements From Semantic Model 'bookings_source'
               SELECT
@@ -323,16 +323,16 @@ FROM (
                 , bookings_source_src_28000.guest_id AS booking__guest
                 , bookings_source_src_28000.host_id AS booking__host
               FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_2
-          ) subq_3
-          WHERE subq_3.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-        ) subq_4
-      ) subq_5
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+        ) subq_2
+      ) subq_3
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
+        subq_3.metric_time__day
+    ) subq_4
     ON
-      subq_7.metric_time__day = subq_6.metric_time__day
-  ) subq_9
-  WHERE subq_9.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-) subq_10
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE subq_7.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_18.metric_time__day AS metric_time__day
-    , subq_17.bookings AS bookings
+    subq_14.metric_time__day AS metric_time__day
+    , subq_13.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_19
+    FROM ***************************.mf_time_spine subq_15
     WHERE ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-  ) subq_18
+  ) subq_14
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-    ) subq_16
+    ) subq_12
     GROUP BY
       metric_time__day
-  ) subq_17
+  ) subq_13
   ON
-    subq_18.metric_time__day = subq_17.metric_time__day
-  WHERE subq_18.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-) subq_21
+    subq_14.metric_time__day = subq_13.metric_time__day
+  WHERE subq_14.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,216 +1,216 @@
 -- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+  COALESCE(subq_4.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_5.bookings) AS bookings
+    SUM(subq_3.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings',]
     SELECT
-      subq_4.bookings
+      subq_2.bookings
     FROM (
       -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
       SELECT
-        subq_3.ds__day
-        , subq_3.ds__week
-        , subq_3.ds__month
-        , subq_3.ds__quarter
-        , subq_3.ds__year
-        , subq_3.ds__extract_year
-        , subq_3.ds__extract_quarter
-        , subq_3.ds__extract_month
-        , subq_3.ds__extract_day
-        , subq_3.ds__extract_dow
-        , subq_3.ds__extract_doy
-        , subq_3.ds_partitioned__day
-        , subq_3.ds_partitioned__week
-        , subq_3.ds_partitioned__month
-        , subq_3.ds_partitioned__quarter
-        , subq_3.ds_partitioned__year
-        , subq_3.ds_partitioned__extract_year
-        , subq_3.ds_partitioned__extract_quarter
-        , subq_3.ds_partitioned__extract_month
-        , subq_3.ds_partitioned__extract_day
-        , subq_3.ds_partitioned__extract_dow
-        , subq_3.ds_partitioned__extract_doy
-        , subq_3.paid_at__day
-        , subq_3.paid_at__week
-        , subq_3.paid_at__month
-        , subq_3.paid_at__quarter
-        , subq_3.paid_at__year
-        , subq_3.paid_at__extract_year
-        , subq_3.paid_at__extract_quarter
-        , subq_3.paid_at__extract_month
-        , subq_3.paid_at__extract_day
-        , subq_3.paid_at__extract_dow
-        , subq_3.paid_at__extract_doy
-        , subq_3.booking__ds__day
-        , subq_3.booking__ds__week
-        , subq_3.booking__ds__month
-        , subq_3.booking__ds__quarter
-        , subq_3.booking__ds__year
-        , subq_3.booking__ds__extract_year
-        , subq_3.booking__ds__extract_quarter
-        , subq_3.booking__ds__extract_month
-        , subq_3.booking__ds__extract_day
-        , subq_3.booking__ds__extract_dow
-        , subq_3.booking__ds__extract_doy
-        , subq_3.booking__ds_partitioned__day
-        , subq_3.booking__ds_partitioned__week
-        , subq_3.booking__ds_partitioned__month
-        , subq_3.booking__ds_partitioned__quarter
-        , subq_3.booking__ds_partitioned__year
-        , subq_3.booking__ds_partitioned__extract_year
-        , subq_3.booking__ds_partitioned__extract_quarter
-        , subq_3.booking__ds_partitioned__extract_month
-        , subq_3.booking__ds_partitioned__extract_day
-        , subq_3.booking__ds_partitioned__extract_dow
-        , subq_3.booking__ds_partitioned__extract_doy
-        , subq_3.booking__paid_at__day
-        , subq_3.booking__paid_at__week
-        , subq_3.booking__paid_at__month
-        , subq_3.booking__paid_at__quarter
-        , subq_3.booking__paid_at__year
-        , subq_3.booking__paid_at__extract_year
-        , subq_3.booking__paid_at__extract_quarter
-        , subq_3.booking__paid_at__extract_month
-        , subq_3.booking__paid_at__extract_day
-        , subq_3.booking__paid_at__extract_dow
-        , subq_3.booking__paid_at__extract_doy
-        , subq_3.metric_time__day
-        , subq_3.metric_time__week
-        , subq_3.metric_time__month
-        , subq_3.metric_time__quarter
-        , subq_3.metric_time__year
-        , subq_3.metric_time__extract_year
-        , subq_3.metric_time__extract_quarter
-        , subq_3.metric_time__extract_month
-        , subq_3.metric_time__extract_day
-        , subq_3.metric_time__extract_dow
-        , subq_3.metric_time__extract_doy
-        , subq_3.listing
-        , subq_3.guest
-        , subq_3.host
-        , subq_3.booking__listing
-        , subq_3.booking__guest
-        , subq_3.booking__host
-        , subq_3.is_instant
-        , subq_3.booking__is_instant
-        , subq_3.bookings
-        , subq_3.instant_bookings
-        , subq_3.booking_value
-        , subq_3.max_booking_value
-        , subq_3.min_booking_value
-        , subq_3.bookers
-        , subq_3.average_booking_value
-        , subq_3.referred_bookings
-        , subq_3.median_booking_value
-        , subq_3.booking_value_p99
-        , subq_3.discrete_booking_value_p99
-        , subq_3.approximate_continuous_booking_value_p99
-        , subq_3.approximate_discrete_booking_value_p99
+        subq_1.ds__day
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.ds__extract_year
+        , subq_1.ds__extract_quarter
+        , subq_1.ds__extract_month
+        , subq_1.ds__extract_day
+        , subq_1.ds__extract_dow
+        , subq_1.ds__extract_doy
+        , subq_1.ds_partitioned__day
+        , subq_1.ds_partitioned__week
+        , subq_1.ds_partitioned__month
+        , subq_1.ds_partitioned__quarter
+        , subq_1.ds_partitioned__year
+        , subq_1.ds_partitioned__extract_year
+        , subq_1.ds_partitioned__extract_quarter
+        , subq_1.ds_partitioned__extract_month
+        , subq_1.ds_partitioned__extract_day
+        , subq_1.ds_partitioned__extract_dow
+        , subq_1.ds_partitioned__extract_doy
+        , subq_1.paid_at__day
+        , subq_1.paid_at__week
+        , subq_1.paid_at__month
+        , subq_1.paid_at__quarter
+        , subq_1.paid_at__year
+        , subq_1.paid_at__extract_year
+        , subq_1.paid_at__extract_quarter
+        , subq_1.paid_at__extract_month
+        , subq_1.paid_at__extract_day
+        , subq_1.paid_at__extract_dow
+        , subq_1.paid_at__extract_doy
+        , subq_1.booking__ds__day
+        , subq_1.booking__ds__week
+        , subq_1.booking__ds__month
+        , subq_1.booking__ds__quarter
+        , subq_1.booking__ds__year
+        , subq_1.booking__ds__extract_year
+        , subq_1.booking__ds__extract_quarter
+        , subq_1.booking__ds__extract_month
+        , subq_1.booking__ds__extract_day
+        , subq_1.booking__ds__extract_dow
+        , subq_1.booking__ds__extract_doy
+        , subq_1.booking__ds_partitioned__day
+        , subq_1.booking__ds_partitioned__week
+        , subq_1.booking__ds_partitioned__month
+        , subq_1.booking__ds_partitioned__quarter
+        , subq_1.booking__ds_partitioned__year
+        , subq_1.booking__ds_partitioned__extract_year
+        , subq_1.booking__ds_partitioned__extract_quarter
+        , subq_1.booking__ds_partitioned__extract_month
+        , subq_1.booking__ds_partitioned__extract_day
+        , subq_1.booking__ds_partitioned__extract_dow
+        , subq_1.booking__ds_partitioned__extract_doy
+        , subq_1.booking__paid_at__day
+        , subq_1.booking__paid_at__week
+        , subq_1.booking__paid_at__month
+        , subq_1.booking__paid_at__quarter
+        , subq_1.booking__paid_at__year
+        , subq_1.booking__paid_at__extract_year
+        , subq_1.booking__paid_at__extract_quarter
+        , subq_1.booking__paid_at__extract_month
+        , subq_1.booking__paid_at__extract_day
+        , subq_1.booking__paid_at__extract_dow
+        , subq_1.booking__paid_at__extract_doy
+        , subq_1.metric_time__day
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.metric_time__extract_year
+        , subq_1.metric_time__extract_quarter
+        , subq_1.metric_time__extract_month
+        , subq_1.metric_time__extract_day
+        , subq_1.metric_time__extract_dow
+        , subq_1.metric_time__extract_doy
+        , subq_1.listing
+        , subq_1.guest
+        , subq_1.host
+        , subq_1.booking__listing
+        , subq_1.booking__guest
+        , subq_1.booking__host
+        , subq_1.is_instant
+        , subq_1.booking__is_instant
+        , subq_1.bookings
+        , subq_1.instant_bookings
+        , subq_1.booking_value
+        , subq_1.max_booking_value
+        , subq_1.min_booking_value
+        , subq_1.bookers
+        , subq_1.average_booking_value
+        , subq_1.referred_bookings
+        , subq_1.median_booking_value
+        , subq_1.booking_value_p99
+        , subq_1.discrete_booking_value_p99
+        , subq_1.approximate_continuous_booking_value_p99
+        , subq_1.approximate_discrete_booking_value_p99
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_2.ds__day
-          , subq_2.ds__week
-          , subq_2.ds__month
-          , subq_2.ds__quarter
-          , subq_2.ds__year
-          , subq_2.ds__extract_year
-          , subq_2.ds__extract_quarter
-          , subq_2.ds__extract_month
-          , subq_2.ds__extract_day
-          , subq_2.ds__extract_dow
-          , subq_2.ds__extract_doy
-          , subq_2.ds_partitioned__day
-          , subq_2.ds_partitioned__week
-          , subq_2.ds_partitioned__month
-          , subq_2.ds_partitioned__quarter
-          , subq_2.ds_partitioned__year
-          , subq_2.ds_partitioned__extract_year
-          , subq_2.ds_partitioned__extract_quarter
-          , subq_2.ds_partitioned__extract_month
-          , subq_2.ds_partitioned__extract_day
-          , subq_2.ds_partitioned__extract_dow
-          , subq_2.ds_partitioned__extract_doy
-          , subq_2.paid_at__day
-          , subq_2.paid_at__week
-          , subq_2.paid_at__month
-          , subq_2.paid_at__quarter
-          , subq_2.paid_at__year
-          , subq_2.paid_at__extract_year
-          , subq_2.paid_at__extract_quarter
-          , subq_2.paid_at__extract_month
-          , subq_2.paid_at__extract_day
-          , subq_2.paid_at__extract_dow
-          , subq_2.paid_at__extract_doy
-          , subq_2.booking__ds__day
-          , subq_2.booking__ds__week
-          , subq_2.booking__ds__month
-          , subq_2.booking__ds__quarter
-          , subq_2.booking__ds__year
-          , subq_2.booking__ds__extract_year
-          , subq_2.booking__ds__extract_quarter
-          , subq_2.booking__ds__extract_month
-          , subq_2.booking__ds__extract_day
-          , subq_2.booking__ds__extract_dow
-          , subq_2.booking__ds__extract_doy
-          , subq_2.booking__ds_partitioned__day
-          , subq_2.booking__ds_partitioned__week
-          , subq_2.booking__ds_partitioned__month
-          , subq_2.booking__ds_partitioned__quarter
-          , subq_2.booking__ds_partitioned__year
-          , subq_2.booking__ds_partitioned__extract_year
-          , subq_2.booking__ds_partitioned__extract_quarter
-          , subq_2.booking__ds_partitioned__extract_month
-          , subq_2.booking__ds_partitioned__extract_day
-          , subq_2.booking__ds_partitioned__extract_dow
-          , subq_2.booking__ds_partitioned__extract_doy
-          , subq_2.booking__paid_at__day
-          , subq_2.booking__paid_at__week
-          , subq_2.booking__paid_at__month
-          , subq_2.booking__paid_at__quarter
-          , subq_2.booking__paid_at__year
-          , subq_2.booking__paid_at__extract_year
-          , subq_2.booking__paid_at__extract_quarter
-          , subq_2.booking__paid_at__extract_month
-          , subq_2.booking__paid_at__extract_day
-          , subq_2.booking__paid_at__extract_dow
-          , subq_2.booking__paid_at__extract_doy
-          , subq_2.ds__day AS metric_time__day
-          , subq_2.ds__week AS metric_time__week
-          , subq_2.ds__month AS metric_time__month
-          , subq_2.ds__quarter AS metric_time__quarter
-          , subq_2.ds__year AS metric_time__year
-          , subq_2.ds__extract_year AS metric_time__extract_year
-          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_2.ds__extract_month AS metric_time__extract_month
-          , subq_2.ds__extract_day AS metric_time__extract_day
-          , subq_2.ds__extract_dow AS metric_time__extract_dow
-          , subq_2.ds__extract_doy AS metric_time__extract_doy
-          , subq_2.listing
-          , subq_2.guest
-          , subq_2.host
-          , subq_2.booking__listing
-          , subq_2.booking__guest
-          , subq_2.booking__host
-          , subq_2.is_instant
-          , subq_2.booking__is_instant
-          , subq_2.bookings
-          , subq_2.instant_bookings
-          , subq_2.booking_value
-          , subq_2.max_booking_value
-          , subq_2.min_booking_value
-          , subq_2.bookers
-          , subq_2.average_booking_value
-          , subq_2.referred_bookings
-          , subq_2.median_booking_value
-          , subq_2.booking_value_p99
-          , subq_2.discrete_booking_value_p99
-          , subq_2.approximate_continuous_booking_value_p99
-          , subq_2.approximate_discrete_booking_value_p99
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.ds_partitioned__day
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.ds_partitioned__extract_year
+          , subq_0.ds_partitioned__extract_quarter
+          , subq_0.ds_partitioned__extract_month
+          , subq_0.ds_partitioned__extract_day
+          , subq_0.ds_partitioned__extract_dow
+          , subq_0.ds_partitioned__extract_doy
+          , subq_0.paid_at__day
+          , subq_0.paid_at__week
+          , subq_0.paid_at__month
+          , subq_0.paid_at__quarter
+          , subq_0.paid_at__year
+          , subq_0.paid_at__extract_year
+          , subq_0.paid_at__extract_quarter
+          , subq_0.paid_at__extract_month
+          , subq_0.paid_at__extract_day
+          , subq_0.paid_at__extract_dow
+          , subq_0.paid_at__extract_doy
+          , subq_0.booking__ds__day
+          , subq_0.booking__ds__week
+          , subq_0.booking__ds__month
+          , subq_0.booking__ds__quarter
+          , subq_0.booking__ds__year
+          , subq_0.booking__ds__extract_year
+          , subq_0.booking__ds__extract_quarter
+          , subq_0.booking__ds__extract_month
+          , subq_0.booking__ds__extract_day
+          , subq_0.booking__ds__extract_dow
+          , subq_0.booking__ds__extract_doy
+          , subq_0.booking__ds_partitioned__day
+          , subq_0.booking__ds_partitioned__week
+          , subq_0.booking__ds_partitioned__month
+          , subq_0.booking__ds_partitioned__quarter
+          , subq_0.booking__ds_partitioned__year
+          , subq_0.booking__ds_partitioned__extract_year
+          , subq_0.booking__ds_partitioned__extract_quarter
+          , subq_0.booking__ds_partitioned__extract_month
+          , subq_0.booking__ds_partitioned__extract_day
+          , subq_0.booking__ds_partitioned__extract_dow
+          , subq_0.booking__ds_partitioned__extract_doy
+          , subq_0.booking__paid_at__day
+          , subq_0.booking__paid_at__week
+          , subq_0.booking__paid_at__month
+          , subq_0.booking__paid_at__quarter
+          , subq_0.booking__paid_at__year
+          , subq_0.booking__paid_at__extract_year
+          , subq_0.booking__paid_at__extract_quarter
+          , subq_0.booking__paid_at__extract_month
+          , subq_0.booking__paid_at__extract_day
+          , subq_0.booking__paid_at__extract_dow
+          , subq_0.booking__paid_at__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.booking__listing
+          , subq_0.booking__guest
+          , subq_0.booking__host
+          , subq_0.is_instant
+          , subq_0.booking__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
+          , subq_0.referred_bookings
+          , subq_0.median_booking_value
+          , subq_0.booking_value_p99
+          , subq_0.discrete_booking_value_p99
+          , subq_0.approximate_continuous_booking_value_p99
+          , subq_0.approximate_discrete_booking_value_p99
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
           SELECT
@@ -303,9 +303,9 @@ FROM (
             , bookings_source_src_28000.guest_id AS booking__guest
             , bookings_source_src_28000.host_id AS booking__host
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_2
-      ) subq_3
-      WHERE subq_3.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-    ) subq_4
-  ) subq_5
-) subq_6
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+    ) subq_2
+  ) subq_3
+) subq_4

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-) subq_13
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,242 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings AS bookings
+    subq_7.metric_time__day AS metric_time__day
+    , subq_6.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-  ) subq_9
+      subq_8.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_8
+  ) subq_7
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_7.metric_time__day
-      , SUM(subq_7.bookings) AS bookings
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_4.metric_time__day
+        , subq_4.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -329,17 +329,17 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
-    ) subq_7
+      ) subq_4
+    ) subq_5
     GROUP BY
-      subq_7.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day
+  ) subq_6
   ON
-    subq_9.metric_time__day = subq_8.metric_time__day
-) subq_11
+    subq_7.metric_time__day = subq_6.metric_time__day
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_22.ds AS metric_time__day
-    , subq_20.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_22
+    subq_18.ds AS metric_time__day
+    , subq_16.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_18
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_11
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_16
   ON
-    subq_22.ds = subq_20.metric_time__day
-) subq_23
+    subq_18.ds = subq_16.metric_time__day
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,246 +1,246 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
-  , subq_11.booking__is_instant
-  , COALESCE(subq_11.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_9.metric_time__day
+  , subq_9.booking__is_instant
+  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_10.metric_time__day
-    , subq_10.booking__is_instant
-    , subq_10.bookings
+    subq_8.metric_time__day
+    , subq_8.booking__is_instant
+    , subq_8.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_8.metric_time__day AS metric_time__day
-      , subq_7.booking__is_instant AS booking__is_instant
-      , subq_7.bookings AS bookings
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking__is_instant AS booking__is_instant
+      , subq_5.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_9.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_9
-    ) subq_8
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-        , SUM(subq_6.bookings) AS bookings
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+        , SUM(subq_4.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_5.metric_time__day
-          , subq_5.booking__is_instant
-          , subq_5.bookings
+          subq_3.metric_time__day
+          , subq_3.booking__is_instant
+          , subq_3.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.booking__is_instant
-            , subq_4.bookings
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_3.ds__day
-              , subq_3.ds__week
-              , subq_3.ds__month
-              , subq_3.ds__quarter
-              , subq_3.ds__year
-              , subq_3.ds__extract_year
-              , subq_3.ds__extract_quarter
-              , subq_3.ds__extract_month
-              , subq_3.ds__extract_day
-              , subq_3.ds__extract_dow
-              , subq_3.ds__extract_doy
-              , subq_3.ds_partitioned__day
-              , subq_3.ds_partitioned__week
-              , subq_3.ds_partitioned__month
-              , subq_3.ds_partitioned__quarter
-              , subq_3.ds_partitioned__year
-              , subq_3.ds_partitioned__extract_year
-              , subq_3.ds_partitioned__extract_quarter
-              , subq_3.ds_partitioned__extract_month
-              , subq_3.ds_partitioned__extract_day
-              , subq_3.ds_partitioned__extract_dow
-              , subq_3.ds_partitioned__extract_doy
-              , subq_3.paid_at__day
-              , subq_3.paid_at__week
-              , subq_3.paid_at__month
-              , subq_3.paid_at__quarter
-              , subq_3.paid_at__year
-              , subq_3.paid_at__extract_year
-              , subq_3.paid_at__extract_quarter
-              , subq_3.paid_at__extract_month
-              , subq_3.paid_at__extract_day
-              , subq_3.paid_at__extract_dow
-              , subq_3.paid_at__extract_doy
-              , subq_3.booking__ds__day
-              , subq_3.booking__ds__week
-              , subq_3.booking__ds__month
-              , subq_3.booking__ds__quarter
-              , subq_3.booking__ds__year
-              , subq_3.booking__ds__extract_year
-              , subq_3.booking__ds__extract_quarter
-              , subq_3.booking__ds__extract_month
-              , subq_3.booking__ds__extract_day
-              , subq_3.booking__ds__extract_dow
-              , subq_3.booking__ds__extract_doy
-              , subq_3.booking__ds_partitioned__day
-              , subq_3.booking__ds_partitioned__week
-              , subq_3.booking__ds_partitioned__month
-              , subq_3.booking__ds_partitioned__quarter
-              , subq_3.booking__ds_partitioned__year
-              , subq_3.booking__ds_partitioned__extract_year
-              , subq_3.booking__ds_partitioned__extract_quarter
-              , subq_3.booking__ds_partitioned__extract_month
-              , subq_3.booking__ds_partitioned__extract_day
-              , subq_3.booking__ds_partitioned__extract_dow
-              , subq_3.booking__ds_partitioned__extract_doy
-              , subq_3.booking__paid_at__day
-              , subq_3.booking__paid_at__week
-              , subq_3.booking__paid_at__month
-              , subq_3.booking__paid_at__quarter
-              , subq_3.booking__paid_at__year
-              , subq_3.booking__paid_at__extract_year
-              , subq_3.booking__paid_at__extract_quarter
-              , subq_3.booking__paid_at__extract_month
-              , subq_3.booking__paid_at__extract_day
-              , subq_3.booking__paid_at__extract_dow
-              , subq_3.booking__paid_at__extract_doy
-              , subq_3.metric_time__day
-              , subq_3.metric_time__week
-              , subq_3.metric_time__month
-              , subq_3.metric_time__quarter
-              , subq_3.metric_time__year
-              , subq_3.metric_time__extract_year
-              , subq_3.metric_time__extract_quarter
-              , subq_3.metric_time__extract_month
-              , subq_3.metric_time__extract_day
-              , subq_3.metric_time__extract_dow
-              , subq_3.metric_time__extract_doy
-              , subq_3.listing
-              , subq_3.guest
-              , subq_3.host
-              , subq_3.booking__listing
-              , subq_3.booking__guest
-              , subq_3.booking__host
-              , subq_3.is_instant
-              , subq_3.booking__is_instant
-              , subq_3.bookings
-              , subq_3.instant_bookings
-              , subq_3.booking_value
-              , subq_3.max_booking_value
-              , subq_3.min_booking_value
-              , subq_3.bookers
-              , subq_3.average_booking_value
-              , subq_3.referred_bookings
-              , subq_3.median_booking_value
-              , subq_3.booking_value_p99
-              , subq_3.discrete_booking_value_p99
-              , subq_3.approximate_continuous_booking_value_p99
-              , subq_3.approximate_discrete_booking_value_p99
+              subq_1.ds__day
+              , subq_1.ds__week
+              , subq_1.ds__month
+              , subq_1.ds__quarter
+              , subq_1.ds__year
+              , subq_1.ds__extract_year
+              , subq_1.ds__extract_quarter
+              , subq_1.ds__extract_month
+              , subq_1.ds__extract_day
+              , subq_1.ds__extract_dow
+              , subq_1.ds__extract_doy
+              , subq_1.ds_partitioned__day
+              , subq_1.ds_partitioned__week
+              , subq_1.ds_partitioned__month
+              , subq_1.ds_partitioned__quarter
+              , subq_1.ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy
+              , subq_1.paid_at__day
+              , subq_1.paid_at__week
+              , subq_1.paid_at__month
+              , subq_1.paid_at__quarter
+              , subq_1.paid_at__year
+              , subq_1.paid_at__extract_year
+              , subq_1.paid_at__extract_quarter
+              , subq_1.paid_at__extract_month
+              , subq_1.paid_at__extract_day
+              , subq_1.paid_at__extract_dow
+              , subq_1.paid_at__extract_doy
+              , subq_1.booking__ds__day
+              , subq_1.booking__ds__week
+              , subq_1.booking__ds__month
+              , subq_1.booking__ds__quarter
+              , subq_1.booking__ds__year
+              , subq_1.booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month
+              , subq_1.booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day
+              , subq_1.booking__paid_at__week
+              , subq_1.booking__paid_at__month
+              , subq_1.booking__paid_at__quarter
+              , subq_1.booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy
+              , subq_1.metric_time__day
+              , subq_1.metric_time__week
+              , subq_1.metric_time__month
+              , subq_1.metric_time__quarter
+              , subq_1.metric_time__year
+              , subq_1.metric_time__extract_year
+              , subq_1.metric_time__extract_quarter
+              , subq_1.metric_time__extract_month
+              , subq_1.metric_time__extract_day
+              , subq_1.metric_time__extract_dow
+              , subq_1.metric_time__extract_doy
+              , subq_1.listing
+              , subq_1.guest
+              , subq_1.host
+              , subq_1.booking__listing
+              , subq_1.booking__guest
+              , subq_1.booking__host
+              , subq_1.is_instant
+              , subq_1.booking__is_instant
+              , subq_1.bookings
+              , subq_1.instant_bookings
+              , subq_1.booking_value
+              , subq_1.max_booking_value
+              , subq_1.min_booking_value
+              , subq_1.bookers
+              , subq_1.average_booking_value
+              , subq_1.referred_bookings
+              , subq_1.median_booking_value
+              , subq_1.booking_value_p99
+              , subq_1.discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_2.ds__day
-                , subq_2.ds__week
-                , subq_2.ds__month
-                , subq_2.ds__quarter
-                , subq_2.ds__year
-                , subq_2.ds__extract_year
-                , subq_2.ds__extract_quarter
-                , subq_2.ds__extract_month
-                , subq_2.ds__extract_day
-                , subq_2.ds__extract_dow
-                , subq_2.ds__extract_doy
-                , subq_2.ds_partitioned__day
-                , subq_2.ds_partitioned__week
-                , subq_2.ds_partitioned__month
-                , subq_2.ds_partitioned__quarter
-                , subq_2.ds_partitioned__year
-                , subq_2.ds_partitioned__extract_year
-                , subq_2.ds_partitioned__extract_quarter
-                , subq_2.ds_partitioned__extract_month
-                , subq_2.ds_partitioned__extract_day
-                , subq_2.ds_partitioned__extract_dow
-                , subq_2.ds_partitioned__extract_doy
-                , subq_2.paid_at__day
-                , subq_2.paid_at__week
-                , subq_2.paid_at__month
-                , subq_2.paid_at__quarter
-                , subq_2.paid_at__year
-                , subq_2.paid_at__extract_year
-                , subq_2.paid_at__extract_quarter
-                , subq_2.paid_at__extract_month
-                , subq_2.paid_at__extract_day
-                , subq_2.paid_at__extract_dow
-                , subq_2.paid_at__extract_doy
-                , subq_2.booking__ds__day
-                , subq_2.booking__ds__week
-                , subq_2.booking__ds__month
-                , subq_2.booking__ds__quarter
-                , subq_2.booking__ds__year
-                , subq_2.booking__ds__extract_year
-                , subq_2.booking__ds__extract_quarter
-                , subq_2.booking__ds__extract_month
-                , subq_2.booking__ds__extract_day
-                , subq_2.booking__ds__extract_dow
-                , subq_2.booking__ds__extract_doy
-                , subq_2.booking__ds_partitioned__day
-                , subq_2.booking__ds_partitioned__week
-                , subq_2.booking__ds_partitioned__month
-                , subq_2.booking__ds_partitioned__quarter
-                , subq_2.booking__ds_partitioned__year
-                , subq_2.booking__ds_partitioned__extract_year
-                , subq_2.booking__ds_partitioned__extract_quarter
-                , subq_2.booking__ds_partitioned__extract_month
-                , subq_2.booking__ds_partitioned__extract_day
-                , subq_2.booking__ds_partitioned__extract_dow
-                , subq_2.booking__ds_partitioned__extract_doy
-                , subq_2.booking__paid_at__day
-                , subq_2.booking__paid_at__week
-                , subq_2.booking__paid_at__month
-                , subq_2.booking__paid_at__quarter
-                , subq_2.booking__paid_at__year
-                , subq_2.booking__paid_at__extract_year
-                , subq_2.booking__paid_at__extract_quarter
-                , subq_2.booking__paid_at__extract_month
-                , subq_2.booking__paid_at__extract_day
-                , subq_2.booking__paid_at__extract_dow
-                , subq_2.booking__paid_at__extract_doy
-                , subq_2.ds__day AS metric_time__day
-                , subq_2.ds__week AS metric_time__week
-                , subq_2.ds__month AS metric_time__month
-                , subq_2.ds__quarter AS metric_time__quarter
-                , subq_2.ds__year AS metric_time__year
-                , subq_2.ds__extract_year AS metric_time__extract_year
-                , subq_2.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_2.ds__extract_month AS metric_time__extract_month
-                , subq_2.ds__extract_day AS metric_time__extract_day
-                , subq_2.ds__extract_dow AS metric_time__extract_dow
-                , subq_2.ds__extract_doy AS metric_time__extract_doy
-                , subq_2.listing
-                , subq_2.guest
-                , subq_2.host
-                , subq_2.booking__listing
-                , subq_2.booking__guest
-                , subq_2.booking__host
-                , subq_2.is_instant
-                , subq_2.booking__is_instant
-                , subq_2.bookings
-                , subq_2.instant_bookings
-                , subq_2.booking_value
-                , subq_2.max_booking_value
-                , subq_2.min_booking_value
-                , subq_2.bookers
-                , subq_2.average_booking_value
-                , subq_2.referred_bookings
-                , subq_2.median_booking_value
-                , subq_2.booking_value_p99
-                , subq_2.discrete_booking_value_p99
-                , subq_2.approximate_continuous_booking_value_p99
-                , subq_2.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
                 -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
@@ -333,19 +333,19 @@ FROM (
                   , bookings_source_src_28000.guest_id AS booking__guest
                   , bookings_source_src_28000.host_id AS booking__host
                 FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_2
-            ) subq_3
+              ) subq_0
+            ) subq_1
             WHERE booking__is_instant
-          ) subq_4
-        ) subq_5
+          ) subq_2
+        ) subq_3
         WHERE booking__is_instant
-      ) subq_6
+      ) subq_4
       GROUP BY
-        subq_6.metric_time__day
-        , subq_6.booking__is_instant
-    ) subq_7
+        subq_4.metric_time__day
+        , subq_4.booking__is_instant
+    ) subq_5
     ON
-      subq_8.metric_time__day = subq_7.metric_time__day
-  ) subq_10
+      subq_6.metric_time__day = subq_5.metric_time__day
+  ) subq_8
   WHERE booking__is_instant
-) subq_11
+) subq_9

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_21.ds AS metric_time__day
-      , subq_19.booking__is_instant AS booking__is_instant
-      , subq_19.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_21
+      subq_17.ds AS metric_time__day
+      , subq_15.booking__is_instant AS booking__is_instant
+      , subq_15.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_17
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_15
+        ) subq_11
         WHERE booking__is_instant
-      ) subq_17
+      ) subq_13
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_19
+    ) subq_15
     ON
-      subq_21.ds = subq_19.metric_time__day
-  ) subq_22
+      subq_17.ds = subq_15.metric_time__day
+  ) subq_18
   WHERE booking__is_instant
-) subq_23
+) subq_19


### PR DESCRIPTION
Move node dataset resolver subquery ids into a separate namespace

The DataflowPlanNodeOutputDataSetResolver class extends the
DataflowToSqlQueryPlanConverter class. As a result, both classes
effectively do a full conversion from a DataflowPlan to a SqlQueryPlan,
complete with SqlQueryPlan node_id generation. These shared the
same ID prefix, which meant any call that might trigger an additional
invocation of the node dataset resolver subclass could cause shifts
in the subquery IDs in our SqlQueryPlan outputs even if the invocation
had no material impact on the query in question.

In order to reduce snapshot thrash and make our subquery IDs easier to
reason about on read-through of the generated SQL, this change splits
the node dataset resolver ID prefix into a dedicated value.

Update engine snapshots