### PR TITLE
`DataflowPlan` for cumulative metrics queried with non-default granularity

### DIFF
--- a/.changes/unreleased/Features-20240613-172315.yaml
+++ b/.changes/unreleased/Features-20240613-172315.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Build dataflow plan for cumulative metrics queried with non-default granularity.
+time: 2024-06-13T17:23:15.095339-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1281"

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -9,6 +9,7 @@ from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.protocols.metric import Metric, MetricInputMeasure, MetricType
 from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
+from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from metricflow_semantics.errors.error_classes import DuplicateMetricError, MetricNotFoundError, NonExistentMeasureError
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
@@ -186,3 +187,26 @@ class MetricLookup:
             entity_links=agg_time_dimension_entity_links,
         )
         return valid_agg_time_dimension_specs
+
+    def get_min_queryable_time_granularity(self, metric_reference: MetricReference) -> TimeGranularity:
+        """The minimum grain that can be queried with this metric.
+
+        Maps to the largest granularity defined for any of the metric's agg_time_dimensions.
+        """
+        agg_time_dimension_specs = self._get_agg_time_dimension_specs_for_metric(metric_reference)
+        assert (
+            agg_time_dimension_specs
+        ), f"No agg_time_dimension found for metric {metric_reference}. Something has been misconfigured."
+
+        minimum_queryable_granularity = self._semantic_model_lookup.get_defined_time_granularity(
+            agg_time_dimension_specs[0].reference
+        )
+        if len(agg_time_dimension_specs) > 1:
+            for agg_time_dimension_spec in agg_time_dimension_specs[1:]:
+                defined_time_granularity = self._semantic_model_lookup.get_defined_time_granularity(
+                    agg_time_dimension_spec.reference
+                )
+                if defined_time_granularity.to_int() > minimum_queryable_granularity.to_int():
+                    minimum_queryable_granularity = defined_time_granularity
+
+        return minimum_queryable_granularity

--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
@@ -18,14 +18,14 @@ from dbt_semantic_interfaces.references import (
     SemanticModelReference,
     TimeDimensionReference,
 )
-from dbt_semantic_interfaces.type_enums import DimensionType, EntityType
-from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
+from dbt_semantic_interfaces.type_enums import AggregationType, DimensionType, EntityType, TimeGranularity
 
 from metricflow_semantics.errors.error_classes import InvalidSemanticModelError
 from metricflow_semantics.mf_logging.pretty_print import mf_pformat
 from metricflow_semantics.model.semantics.element_group import ElementGrouper
 from metricflow_semantics.model.spec_converters import MeasureConverter
 from metricflow_semantics.specs.spec_classes import (
+    DEFAULT_TIME_GRANULARITY,
     DimensionSpec,
     EntitySpec,
     LinkableInstanceSpec,
@@ -85,10 +85,13 @@ class SemanticModelLookup:
 
     def get_dimension(self, dimension_reference: DimensionReference) -> Dimension:
         """Retrieves a full dimension object by name."""
+        # If the reference passed is a TimeDimensionReference, convert to DimensionReference.
+        dimension_reference = DimensionReference(dimension_reference.element_name)
+
         semantic_models = self._dimension_index.get(dimension_reference)
         if not semantic_models:
             raise ValueError(
-                f"Could not find dimension with name ({dimension_reference.element_name}) in configured semantic models"
+                f"Could not find dimension with name '{dimension_reference.element_name}' in configured semantic models"
             )
 
         dimension = SemanticModelLookup.get_dimension_from_semantic_model(
@@ -366,3 +369,13 @@ class SemanticModelLookup:
             time_dimension_reference=agg_time_dimension,
             entity_links=(entity_link,),
         )
+
+    def get_defined_time_granularity(self, time_dimension_reference: TimeDimensionReference) -> TimeGranularity:
+        """Time granularity from the time dimension's YAML definition. If not set, defaults to DAY."""
+        time_dimension = self.get_dimension(time_dimension_reference)
+
+        defined_time_granularity = DEFAULT_TIME_GRANULARITY
+        if time_dimension.type_params and time_dimension.type_params.time_granularity:
+            defined_time_granularity = time_dimension.type_params.time_granularity
+
+        return defined_time_granularity


### PR DESCRIPTION
When querying cumulative metrics without default granularity, build a dataflow plan that includes `WindowReaggregationNode`.

E2E tests coming soon for this feature!