### PR TITLE
Remove granularity restriction for cumulative metrics

### DIFF
--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
@@ -46,7 +46,6 @@ from metricflow_semantics.query.issues.issues_base import (
     MetricFlowQueryResolutionIssueSet,
 )
 from metricflow_semantics.query.suggestion_generator import QueryItemSuggestionGenerator
-from metricflow_semantics.specs.patterns.base_time_grain import BaseTimeGrainPattern
 from metricflow_semantics.specs.patterns.none_date_part import NoneDatePartPattern
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
 
@@ -171,19 +170,8 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
             elif metric.type is MetricType.RATIO or metric.type is MetricType.DERIVED:
                 assert False, f"A measure should have a simple or cumulative metric as a child, but got {metric.type}"
             elif metric.type is MetricType.CUMULATIVE:
-                # To handle the restriction that cumulative metrics can only be queried at the base grain, it's
-                # easiest to handle that by applying the pattern to remove non-base grain time dimension specs at the
-                # measure node and generate the issue here if there's nothing that matches. Generating the issue here
-                # allows for creation of a more specific issue (i.e. include the measure) vs. generating the issue
-                # at a higher level. This can be more cleanly handled once we add additional context to the
-                # LinkableInstanceSpec.
                 patterns_to_apply = (
-                    # From comment in ValidLinkableSpecResolver:
-                    #   It's possible to aggregate measures to coarser time granularities
-                    #   (except with cumulative metrics).
-                    BaseTimeGrainPattern(only_apply_for_metric_time=True),
-                    # From comment in previous query parser:
-                    #   Cannot extract date part for cumulative metrics.
+                    # Date part doesn't make clear sense with cumulative metrics, so we don't allow it.
                     NoneDatePartPattern(),
                 )
             else:

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
@@ -177,9 +177,8 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
             else:
                 assert_values_exhausted(metric.type)
 
-            matching_items = items_available_for_measure.filter_by_spec_patterns(
-                patterns_to_apply + self._source_spec_patterns
-            )
+            patterns_to_apply += self._source_spec_patterns
+            matching_items = items_available_for_measure.filter_by_spec_patterns(patterns_to_apply)
 
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_available_group_by_items.py/LinkableSpecSet/test_available_group_by_items__accumulate_last_2_months_metric__set0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_available_group_by_items.py/LinkableSpecSet/test_available_group_by_items__accumulate_last_2_months_metric__set0.txt
@@ -1,5 +1,7 @@
 [
   "TimeDimension('metric_time', 'month')",
+  "TimeDimension('metric_time', 'quarter')",
+  "TimeDimension('metric_time', 'year')",
   "TimeDimension('monthly_measure_entity__creation_time', 'month')",
   "TimeDimension('monthly_measure_entity__creation_time', 'quarter')",
   "TimeDimension('monthly_measure_entity__creation_time', 'year')",


### PR DESCRIPTION
Remove the `BaseTimeGrainPattern` filter that was in place for cumulative metrics. This restricted users from querying cumulative metrics with `metric_time` using non-default granularities, which will be supported shortly.
Only thing left in the stack after this is tests!